### PR TITLE
Fix missing datetime import in proxy

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 import json
 from contextlib import asynccontextmanager
+from datetime import datetime
 
 import httpx
 from dotenv import load_dotenv
@@ -210,7 +211,6 @@ async def list_models(http_request: Request):
 # --- Main execution for running with Uvicorn directly (optional) ---
 if __name__ == "__main__":
     import uvicorn
-    from datetime import datetime # For the command-only response timestamp
     
     if not OPENROUTER_API_KEY:
         print("CRITICAL: OPENROUTER_API_KEY environment variable is not set.")


### PR DESCRIPTION
## Summary
- prevent runtime NameError by importing `datetime` at module level
- remove duplicate import in __main__ and ensure newline at EOF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400b73dff4833390a08015c27ad7c6