### PR TITLE
Add backend abstraction and registry

### DIFF
--- a/src/backends/__init__.py
+++ b/src/backends/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+from .openrouter_backend import OpenRouterBackend
+from .registry import register_backend, get_backend, select_backend
+
+# Register default OpenRouter backend
+openrouter_backend = OpenRouterBackend(
+    api_key=os.getenv("OPENROUTER_API_KEY", ""),
+    base_url=os.getenv("OPENROUTER_API_BASE_URL", "https://openrouter.ai/api/v1"),
+)
+register_backend(openrouter_backend)
+
+__all__ = ["register_backend", "get_backend", "select_backend", "openrouter_backend"]

--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+import httpx
+
+from models import ChatCompletionRequest
+
+
+class Backend(ABC):
+    """Abstract base class for LLM backends."""
+
+    prefix: str
+
+    @abstractmethod
+    async def chat_completions(
+        self, request: ChatCompletionRequest, client: httpx.AsyncClient
+    ) -> Any:
+        """Handle a chat completion request."""
+
+    @abstractmethod
+    async def list_models(self, client: httpx.AsyncClient) -> Dict[str, Any]:
+        """Return a dictionary describing available models."""

--- a/src/backends/openrouter_backend.py
+++ b/src/backends/openrouter_backend.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, AsyncGenerator, Dict
+
+import httpx
+
+from models import ChatCompletionRequest
+from .base import Backend
+
+logger = logging.getLogger(__name__)
+
+
+class OpenRouterBackend(Backend):
+    """Backend implementation for the OpenRouter API."""
+
+    prefix = "openrouter"
+
+    def __init__(self, api_key: str, base_url: str):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise RuntimeError("OPENROUTER_API_KEY is not configured")
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def chat_completions(
+        self, request: ChatCompletionRequest, client: httpx.AsyncClient
+    ) -> Any:
+        payload = request.model_dump(exclude_unset=True)
+        payload["messages"] = [m.model_dump(exclude_unset=True) for m in request.messages]
+        if request.stream:
+            req = client.build_request(
+                "POST",
+                f"{self.base_url}/chat/completions",
+                json=payload,
+                headers=self._headers(),
+            )
+
+            async def gen() -> AsyncGenerator[bytes, None]:
+                async with client.stream(req) as response:
+                    response.raise_for_status()
+                    async for chunk in response.aiter_bytes():
+                        yield chunk
+            return gen()
+        else:
+            response = await client.post(
+                f"{self.base_url}/chat/completions",
+                json=payload,
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def list_models(self, client: httpx.AsyncClient) -> Dict[str, Any]:
+        response = await client.get(f"{self.base_url}/models", headers=self._headers())
+        response.raise_for_status()
+        return response.json()

--- a/src/backends/registry.py
+++ b/src/backends/registry.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from .base import Backend
+
+_backends: Dict[str, Backend] = {}
+
+def register_backend(backend: Backend) -> None:
+    _backends[backend.prefix] = backend
+
+def get_backend(prefix: str) -> Backend | None:
+    return _backends.get(prefix)
+
+def select_backend(model: str) -> Tuple[Backend, str]:
+    if ':' in model:
+        prefix, real_model = model.split(':', 1)
+        backend = get_backend(prefix)
+        if backend is not None:
+            return backend, real_model
+    # default backend is first registered
+    default_backend = next(iter(_backends.values()))
+    return default_backend, model

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import StreamingResponse
 
 from models import ChatCompletionRequest
 from proxy_logic import proxy_state, process_commands_in_messages
+from backends import select_backend, openrouter_backend
 
 # --- Configuration ---
 # Load environment variables from .env file
@@ -17,11 +18,11 @@ load_dotenv()
 
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 OPENROUTER_API_BASE_URL = os.getenv("OPENROUTER_API_BASE_URL", "https://openrouter.ai/api/v1")
-APP_SITE_URL = os.getenv("APP_SITE_URL", "http://localhost:8000") # Used for Referer header
-APP_X_TITLE = os.getenv("APP_X_TITLE", "InterceptorProxy")     # Used for X-Title header
+APP_SITE_URL = os.getenv("APP_SITE_URL", "http://localhost:8000")  # Used for Referer header
+APP_X_TITLE = os.getenv("APP_X_TITLE", "InterceptorProxy")  # Used for X-Title header
 PROXY_PORT = int(os.getenv("PROXY_PORT", "8000"))
 PROXY_HOST = os.getenv("PROXY_HOST", "0.0.0.0")
-OPENROUTER_TIMEOUT = int(os.getenv("OPENROUTER_TIMEOUT", "300")) # 5 minutes
+HTTP_TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "300"))
 
 # --- Logging Setup ---
 logging.basicConfig(
@@ -43,30 +44,13 @@ if not OPENROUTER_API_KEY:
 async def lifespan(app: FastAPI):
     # Startup: Initialize the HTTP client
     logger.info("Application startup: Initializing HTTPX client.")
-    app.state.httpx_client = httpx.AsyncClient(timeout=OPENROUTER_TIMEOUT)
-    if not OPENROUTER_API_KEY:
-        logger.warning("OPENROUTER_API_KEY is not configured. Requests to OpenRouter will likely fail.")
+    app.state.httpx_client = httpx.AsyncClient(timeout=HTTP_TIMEOUT)
     yield
     # Shutdown: Close the HTTP client
     logger.info("Application shutdown: Closing HTTPX client.")
     await app.state.httpx_client.aclose()
 
 app = FastAPI(lifespan=lifespan)
-
-# --- Helper Functions ---
-def get_openrouter_headers() -> dict:
-    if not OPENROUTER_API_KEY:
-        # This case should ideally be handled by not starting or raising prominently.
-        # If we reach here, it's a misconfiguration.
-        raise HTTPException(status_code=500, detail="Proxy server misconfiguration: OpenRouter API key not set.")
-
-    return {
-        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
-        "Content-Type": "application/json",
-        "HTTP-Referer": APP_SITE_URL,
-        "X-Title": APP_X_TITLE,
-        "User-Agent": f"{APP_X_TITLE}/1.0 (Python httpx)",
-    }
 
 # --- API Endpoints ---
 @app.get("/")
@@ -107,55 +91,21 @@ async def chat_completions(request_data: ChatCompletionRequest, http_request: Re
 
     effective_model = proxy_state.get_effective_model(request_data.model)
     
-    openrouter_payload = request_data.model_dump(exclude_unset=True)
-    openrouter_payload["model"] = effective_model
-    # Convert Pydantic message models back to dictionaries for the payload
-    openrouter_payload["messages"] = [msg.model_dump(exclude_unset=True) for msg in processed_messages]
+    backend, actual_model = select_backend(effective_model)
 
-    logger.info(f"Forwarding to OpenRouter. Effective model: {effective_model}. Stream: {request_data.stream}")
-    logger.debug(f"Payload for OpenRouter: {json.dumps(openrouter_payload, indent=2)}")
+    logger.info(
+        f"Forwarding request to backend '{backend.prefix}'. Model: {actual_model}. Stream: {request_data.stream}"
+    )
 
-    headers = get_openrouter_headers()
+    payload = request_data.model_copy()
+    payload.model = actual_model
+    payload.messages = processed_messages
 
     try:
+        result = await backend.chat_completions(payload, client)
         if request_data.stream:
-            logger.debug("Initiating stream request to OpenRouter.")
-            req = client.build_request("POST", f"{OPENROUTER_API_BASE_URL}/chat/completions",
-                                       json=openrouter_payload, headers=headers)
-            
-            async def stream_generator():
-                try:
-                    async with client.stream(req) as response:
-                        logger.debug(f"OpenRouter stream response status: {response.status_code}")
-                        response.raise_for_status() # Check for HTTP errors from OpenRouter
-                        async for chunk in response.aiter_bytes():
-                            # logger.debug(f"Stream chunk (bytes): {chunk[:100]}") # Log first 100 bytes
-                            yield chunk
-                        logger.debug("OpenRouter stream finished.")
-                except httpx.HTTPStatusError as e_stream:
-                    logger.error(f"HTTP error during OpenRouter stream: {e_stream.response.status_code} - {await e_stream.response.aread()}")
-                    # This error won't be caught by the outer try/except if it happens inside the generator
-                    # It's complex to propagate this back as an HTTPException directly from here.
-                    # The client will see a broken stream.
-                    # For robust error reporting in streams, one might stream an error message in SSE format.
-                    yield f"data: {json.dumps({'error': {'message': f'OpenRouter stream error: {e_stream.response.status_code}', 'type': 'openrouter_error', 'code': e_stream.response.status_code}})}\n\n".encode()
-                except Exception as e_gen:
-                    logger.error(f"Error in stream generator: {e_gen}", exc_info=True)
-                    yield f"data: {json.dumps({'error': {'message': f'Proxy stream generator error: {str(e_gen)}', 'type': 'proxy_error'}})}\n\n".encode()
-
-
-            return StreamingResponse(stream_generator(), media_type="text/event-stream")
-
-        else: # Non-streaming request
-            logger.debug("Initiating non-streaming request to OpenRouter.")
-            response = await client.post(f"{OPENROUTER_API_BASE_URL}/chat/completions",
-                                         json=openrouter_payload, headers=headers)
-            logger.debug(f"OpenRouter non-stream response status: {response.status_code}")
-            response.raise_for_status() # Raise HTTP errors
-            
-            response_json = response.json()
-            logger.debug(f"OpenRouter response JSON: {json.dumps(response_json, indent=2)}")
-            return response_json
+            return StreamingResponse(result, media_type="text/event-stream")
+        return result
 
     except httpx.HTTPStatusError as e:
         logger.error(f"HTTP error from OpenRouter: {e.response.status_code} - {e.response.text}", exc_info=True)
@@ -175,22 +125,12 @@ async def chat_completions(request_data: ChatCompletionRequest, http_request: Re
 async def list_models(http_request: Request):
     client: httpx.AsyncClient = http_request.app.state.httpx_client
     logger.info("Received request for /v1/models")
-    
-    headers = get_openrouter_headers()
-    
+
     try:
-        response = await client.get(f"{OPENROUTER_API_BASE_URL}/models", headers=headers)
-        logger.debug(f"OpenRouter /models response status: {response.status_code}")
-        response.raise_for_status()
-        
-        models_data = response.json()
-        logger.debug(f"Successfully fetched models from OpenRouter. Count: {len(models_data.get('data', []))}")
-        
-        # Optionally: Modify models_data here if needed.
-        # For example, to add info about the currently overridden model.
-        # if proxy_state.override_model:
-        #     models_data["proxy_override_active"] = proxy_state.override_model
-        
+        models_data = await openrouter_backend.list_models(client)
+        logger.debug(
+            f"Successfully fetched models from OpenRouter. Count: {len(models_data.get('data', []))}"
+        )
         return models_data
 
     except httpx.HTTPStatusError as e:
@@ -212,10 +152,5 @@ if __name__ == "__main__":
     import uvicorn
     from datetime import datetime # For the command-only response timestamp
     
-    if not OPENROUTER_API_KEY:
-        print("CRITICAL: OPENROUTER_API_KEY environment variable is not set.")
-        print("Please set it in a .env file or in your environment.")
-        # exit(1) # Or allow it to run but log warnings. FastAPI app.state.httpx_client will be problematic.
-
     logger.info(f"Starting Uvicorn server on {PROXY_HOST}:{PROXY_PORT}")
     uvicorn.run(app, host=PROXY_HOST, port=PROXY_PORT)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,22 @@
+import os
+from backends import select_backend, register_backend, openrouter_backend
+from backends.base import Backend
+
+class DummyBackend(Backend):
+    prefix = "dummy"
+    async def chat_completions(self, request, client):
+        return {"dummy": True}
+    async def list_models(self, client):
+        return {"data": []}
+
+def test_select_backend_defaults_to_registered():
+    backend, model = select_backend("gpt-3.5")
+    assert backend is openrouter_backend
+    assert model == "gpt-3.5"
+
+def test_select_backend_with_prefix():
+    dummy = DummyBackend()
+    register_backend(dummy)
+    backend, model = select_backend("dummy:model-x")
+    assert backend is dummy
+    assert model == "model-x"


### PR DESCRIPTION
## Summary
- add backend abstraction with registry system
- implement OpenRouter backend
- route requests in main through backend interface
- provide tests for backend selection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400b89e83483339e042cf6ce39e9de