### PR TITLE
Add basic command-processing tests

### DIFF
--- a/tests/test_proxy_logic.py
+++ b/tests/test_proxy_logic.py
@@ -1,0 +1,23 @@
+import pytest
+
+from proxy_logic import process_commands_in_messages, proxy_state
+from models import ChatMessage
+
+
+def teardown_function(function):
+    # Reset proxy state after each test
+    proxy_state.unset_override_model()
+
+
+def test_only_set_command_removes_message():
+    messages = [ChatMessage(role="user", content="!/set(model=foo)")]
+    processed, flag = process_commands_in_messages(messages)
+    assert processed == []
+    assert flag is True
+
+
+def test_normal_message_unchanged():
+    messages = [ChatMessage(role="user", content="Hello")]
+    processed, flag = process_commands_in_messages(messages)
+    assert processed == messages
+    assert flag is False


### PR DESCRIPTION
## Summary
- add `test_proxy_logic.py` with checks for processing commands in chat messages

## Testing
- `pytest -q` *(fails: 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68400e3de348833395255cbe5d791e96