### PR TITLE
Add backend interface and OpenRouter support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "pytest",
+    "pytest-asyncio",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/backends/__init__.py
+++ b/src/backends/__init__.py
@@ -1,0 +1,4 @@
+from .base import LLMBackend
+from .openrouter import OpenRouterBackend
+
+__all__ = ["LLMBackend", "OpenRouterBackend"]

--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Dict, Optional, Union
+
+from models import ChatCompletionRequest
+
+
+class LLMBackend(ABC):
+    """Abstract interface for LLM backends."""
+
+    @abstractmethod
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        extra_headers: Optional[Dict[str, str]] = None,
+        stream: bool = False,
+    ) -> Union[Dict, AsyncIterator[bytes]]:
+        """Send a chat completion request.
+
+        Args:
+            request: Chat completion parameters including messages and model.
+            extra_headers: Additional HTTP headers to send with the request.
+            stream: If True, return an async iterator yielding byte chunks.
+        Returns:
+            JSON response from backend or async byte iterator when ``stream`` is
+            True.
+        """
+
+    @abstractmethod
+    async def list_models(
+        self, *, extra_headers: Optional[Dict[str, str]] = None
+    ) -> Dict:
+        """Return a JSON description of available models."""
+

--- a/src/backends/openrouter.py
+++ b/src/backends/openrouter.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import httpx
+from typing import AsyncIterator, Dict, Optional, Union, Any
+
+from models import ChatCompletionRequest
+from .base import LLMBackend
+
+
+class OpenRouterBackend(LLMBackend):
+    """LLM backend implementation for the OpenRouter API."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        api_key: str,
+        api_base_url: str,
+        app_site_url: str,
+        app_title: str,
+    ) -> None:
+        self.client = client
+        self.api_key = api_key
+        self.api_base_url = api_base_url.rstrip("/")
+        self.app_site_url = app_site_url
+        self.app_title = app_title
+
+    def _build_headers(self, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": self.app_site_url,
+            "X-Title": self.app_title,
+            "User-Agent": f"{self.app_title}/1.0 (Python httpx)",
+        }
+        if extra:
+            headers.update(extra)
+        return headers
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        extra_headers: Optional[Dict[str, str]] = None,
+        stream: bool = False,
+    ) -> Union[Dict[str, Any], AsyncIterator[bytes]]:
+        payload = request.dict(exclude_unset=True)
+        if request.extra_params:
+            payload.update(request.extra_params)
+        headers = self._build_headers(extra_headers)
+
+        if stream:
+            async def iterator() -> AsyncIterator[bytes]:
+                async with self.client.stream(
+                    "POST",
+                    f"{self.api_base_url}/chat/completions",
+                    json=payload,
+                    headers=headers,
+                ) as resp:
+                    resp.raise_for_status()
+                    async for chunk in resp.aiter_bytes():
+                        yield chunk
+
+            return iterator()
+
+        resp = await self.client.post(
+            f"{self.api_base_url}/chat/completions",
+            json=payload,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def list_models(
+        self, *, extra_headers: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        headers = self._build_headers(extra_headers)
+        resp = await self.client.get(f"{self.api_base_url}/models", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+

--- a/src/models.py
+++ b/src/models.py
@@ -38,6 +38,7 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = None
     logit_bias: Optional[Dict[str, float]] = None
     user: Optional[str] = None
+    extra_params: Optional[Dict[str, Any]] = None
     # Add other OpenAI parameters as needed, e.g., functions, tool_choice, tools
 
 # We don't strictly need to model the OpenAI response if we're just proxying JSON/SSE.

--- a/src/proxy_logic.py
+++ b/src/proxy_logic.py
@@ -102,7 +102,7 @@ def process_commands_in_messages(messages: List[ChatMessage]) -> Tuple[List[Chat
     if not messages:
         return messages, False
 
-    modified_messages = [msg.model_copy(deep=True) for msg in messages]
+    modified_messages = [msg.copy(deep=True) for msg in messages]
     any_command_processed_overall = False
 
     # Iterate backwards to find the last message suitable for command processing
@@ -132,7 +132,7 @@ def process_commands_in_messages(messages: List[ChatMessage]) -> Tuple[List[Chat
                     elif not commands_found : # if not command found and it was empty already preserve it
                         new_content_parts.append(MessageContentPartText(type="text", text=processed_text))
                 else:
-                    new_content_parts.append(part.model_copy(deep=True)) # Pass through non-text parts
+                    new_content_parts.append(part.copy(deep=True)) # Pass through non-text parts
 
             if part_level_command_found:
                 msg.content = new_content_parts

--- a/tests/test_openrouter_backend.py
+++ b/tests/test_openrouter_backend.py
@@ -1,0 +1,87 @@
+import pytest
+import httpx
+
+from backends.openrouter import OpenRouterBackend
+from models import ChatMessage, ChatCompletionRequest
+
+
+class MockStream(httpx.AsyncByteStream):
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_non_stream():
+    async def handler(request: httpx.Request):
+        import json
+
+        data = json.loads(request.content.decode())
+        assert data["model"] == "test-model"
+        return httpx.Response(200, json={"choices": []})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        backend = OpenRouterBackend(
+            client,
+            api_key="key",
+            api_base_url="https://example.com",
+            app_site_url="http://localhost",
+            app_title="Test",
+        )
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[ChatMessage(role="user", content="hi")],
+        )
+        resp = await backend.chat_completion(req)
+        assert resp == {"choices": []}
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_stream():
+    async def handler(request: httpx.Request):
+        stream = MockStream([b"a", b"b"])
+        return httpx.Response(200, stream=stream)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        backend = OpenRouterBackend(
+            client,
+            api_key="key",
+            api_base_url="https://example.com",
+            app_site_url="http://localhost",
+            app_title="Test",
+        )
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[ChatMessage(role="user", content="hi")],
+            stream=True,
+        )
+        iterator = await backend.chat_completion(req, stream=True)
+        chunks = [c async for c in iterator]
+        assert chunks == [b"a", b"b"]
+
+
+@pytest.mark.asyncio
+async def test_list_models():
+    async def handler(request: httpx.Request):
+        assert request.url.path == "/models"
+        return httpx.Response(200, json={"data": []})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        backend = OpenRouterBackend(
+            client,
+            api_key="key",
+            api_base_url="https://example.com",
+            app_site_url="http://localhost",
+            app_title="Test",
+        )
+        resp = await backend.list_models()
+        assert resp == {"data": []}


### PR DESCRIPTION
## Summary
- implement abstract `LLMBackend` interface
- add `OpenRouterBackend` with streaming and non-streaming chat completion
- extend chat request model with `extra_params`
- refactor command processing to use `copy`
- newline fixes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402c95ade883338f63c8ffbba74d66