### PR TITLE
Add Google Gemini backend and CLI

### DIFF
--- a/src/backends/__init__.py
+++ b/src/backends/__init__.py
@@ -1,4 +1,5 @@
 from .base import LLMBackend
 from .openrouter import OpenRouterBackend
+from .gemini import GeminiBackend
 
-__all__ = ["LLMBackend", "OpenRouterBackend"]
+__all__ = ["LLMBackend", "OpenRouterBackend", "GeminiBackend"]

--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import AsyncIterator, Dict, Optional, Union
 
-from models import ChatCompletionRequest
+from src.models import ChatCompletionRequest
 
 
 class LLMBackend(ABC):

--- a/src/backends/gemini.py
+++ b/src/backends/gemini.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import httpx
+from typing import AsyncIterator, Dict, Optional, Union, Any, List
+
+from src.models import (
+    ChatCompletionRequest,
+    ChatMessage,
+    MessageContentPartText,
+    MessageContentPartImage,
+)
+from .base import LLMBackend
+
+
+class GeminiBackend(LLMBackend):
+    """LLM backend for Google Gemini AI."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        api_keys: List[str],
+        api_base_url: str = "https://generativelanguage.googleapis.com/v1beta",
+    ) -> None:
+        if not api_keys:
+            raise ValueError("At least one API key must be provided")
+        self.client = client
+        self.api_keys = api_keys
+        self.api_base_url = api_base_url.rstrip("/")
+        self._key_index = 0
+
+    def _next_key(self) -> str:
+        key = self.api_keys[self._key_index]
+        self._key_index = (self._key_index + 1) % len(self.api_keys)
+        return key
+
+    def _build_headers(self, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if extra:
+            headers.update(extra)
+        return headers
+
+    def _convert_messages(self, messages: List[ChatMessage]) -> List[Dict[str, Any]]:
+        contents: List[Dict[str, Any]] = []
+        for msg in messages:
+            parts: List[Dict[str, Any]] = []
+            if isinstance(msg.content, str):
+                parts.append({"text": msg.content})
+            else:
+                for part in msg.content:
+                    if isinstance(part, MessageContentPartText):
+                        parts.append({"text": part.text})
+                    elif isinstance(part, MessageContentPartImage):
+                        parts.append(
+                            {
+                                "inline_data": {
+                                    "mime_type": "image/png",
+                                    "data": part.image_url.url,
+                                }
+                            }
+                        )
+            contents.append({"role": msg.role, "parts": parts})
+        return contents
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        extra_headers: Optional[Dict[str, str]] = None,
+        stream: bool = False,
+    ) -> Union[Dict[str, Any], AsyncIterator[bytes]]:
+        key = self._next_key()
+        endpoint = "streamGenerateContent" if stream else "generateContent"
+        url = f"{self.api_base_url}/models/{request.model}:{endpoint}?key={key}"
+        payload = {"contents": self._convert_messages(request.messages)}
+        if request.extra_params:
+            payload.update(request.extra_params)
+        headers = self._build_headers(extra_headers)
+
+        if stream:
+            async def iterator() -> AsyncIterator[bytes]:
+                async with self.client.stream("POST", url, json=payload, headers=headers) as resp:
+                    resp.raise_for_status()
+                    async for chunk in resp.aiter_bytes():
+                        yield chunk
+            return iterator()
+
+        resp = await self.client.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return {"data": resp.json(), "headers": dict(resp.headers)}
+
+    async def list_models(self, *, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        key = self._next_key()
+        url = f"{self.api_base_url}/models?key={key}"
+        headers = self._build_headers(extra_headers)
+        resp = await self.client.get(url, headers=headers)
+        resp.raise_for_status()
+        return {"data": resp.json(), "headers": dict(resp.headers)}

--- a/src/backends/openrouter.py
+++ b/src/backends/openrouter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import httpx
 from typing import AsyncIterator, Dict, Optional, Union, Any
 
-from models import ChatCompletionRequest
+from src.models import ChatCompletionRequest
 from .base import LLMBackend
 
 

--- a/src/gemini_cli.py
+++ b/src/gemini_cli.py
@@ -1,0 +1,58 @@
+import argparse
+import asyncio
+import os
+from typing import List
+
+import httpx
+
+from src.models import ChatCompletionRequest, ChatMessage
+from src.backends.gemini import GeminiBackend
+
+
+def load_gemini_api_keys() -> List[str]:
+    numbered = []
+    single = os.getenv("GEMINI_API_KEY")
+    for i in range(1, 21):
+        val = os.getenv(f"GEMINI_API_KEY_{i}")
+        if val:
+            numbered.append(val)
+    if single and numbered:
+        raise ValueError("Set either GEMINI_API_KEY or GEMINI_API_KEY_<n>, not both")
+    keys = numbered if numbered else ([single] if single else [])
+    if not keys:
+        raise ValueError("No Gemini API key provided")
+    for key in keys:
+        if not key.startswith("AI") or len(key) < 32:
+            raise ValueError(f"Invalid Gemini API key: {key}")
+    return keys
+
+
+async def _run(args: argparse.Namespace) -> None:
+    keys = load_gemini_api_keys()
+    async with httpx.AsyncClient() as client:
+        backend = GeminiBackend(client, api_keys=keys)
+        req = ChatCompletionRequest(
+            model=args.model,
+            messages=[ChatMessage(role="user", content=args.prompt)],
+            stream=args.stream,
+        )
+        result = await backend.chat_completion(req, stream=args.stream)
+        if args.stream:
+            async for chunk in result:
+                print(chunk.decode(), end="")
+        else:
+            print(result["data"])
+            print("Response headers:", result["headers"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with Google Gemini AI")
+    parser.add_argument("prompt")
+    parser.add_argument("--model", default="gemini-pro")
+    parser.add_argument("--stream", action="store_true")
+    args = parser.parse_args()
+    asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -10,8 +10,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse, JSONResponse
 
-import models # Import the models module directly
-from proxy_logic import process_commands_in_messages, ProxyState # Import process_commands_in_messages and ProxyState class
+import src.models as models  # Import the models module directly
+from src.proxy_logic import process_commands_in_messages, ProxyState  # Import process_commands_in_messages and ProxyState class
 from src.connectors.openrouter import OpenRouterBackend  # Import the backend used in tests
 
 # --- Configuration ---

--- a/tests/unit/gemini_backend_tests/test_backend.py
+++ b/tests/unit/gemini_backend_tests/test_backend.py
@@ -1,0 +1,89 @@
+import json
+import pytest
+import httpx
+from pytest_httpx import HTTPXMock
+import pytest_asyncio
+
+import src.models as models
+from src.backends.gemini import GeminiBackend
+
+TEST_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+
+
+@pytest_asyncio.fixture
+async def backend():
+    async with httpx.AsyncClient() as client:
+        yield GeminiBackend(client, api_keys=["AI" + "z" * 30])
+
+
+@pytest.fixture
+def sample_request() -> models.ChatCompletionRequest:
+    return models.ChatCompletionRequest(
+        model="gemini-pro",
+        messages=[models.ChatMessage(role="user", content="Hello")],
+        stream=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_non_streaming_success(backend: GeminiBackend, httpx_mock: HTTPXMock, sample_request):
+    expected_response = {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}
+    httpx_mock.add_response(
+        url=f"{TEST_BASE_URL}/models/gemini-pro:generateContent?key={'AI'+'z'*30}",
+        method="POST",
+        json=expected_response,
+        headers={"X-Token-Usage": "5"},
+    )
+
+    resp = await backend.chat_completion(sample_request)
+
+    assert resp["data"] == expected_response
+    assert resp["headers"]["x-token-usage"] == "5"
+
+    request = httpx_mock.get_request()
+    payload = json.loads(request.content)
+    assert payload["contents"][0]["parts"][0]["text"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_streaming_success(backend: GeminiBackend, httpx_mock: HTTPXMock, sample_request):
+    sample_request.stream = True
+    stream_chunks = [b"chunk1", b"chunk2"]
+    httpx_mock.add_response(
+        url=f"{TEST_BASE_URL}/models/gemini-pro:streamGenerateContent?key={'AI'+'z'*30}",
+        method="POST",
+        stream=httpx.ByteStream(b"".join(stream_chunks)),
+        headers={"Content-Type": "application/json"},
+    )
+
+    iterator = await backend.chat_completion(sample_request, stream=True)
+    data = b""
+    async for chunk in iterator:
+        data += chunk
+    assert data == b"".join(stream_chunks)
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_http_error(backend: GeminiBackend, httpx_mock: HTTPXMock, sample_request):
+    httpx_mock.add_response(
+        url=f"{TEST_BASE_URL}/models/gemini-pro:generateContent?key={'AI'+'z'*30}",
+        method="POST",
+        status_code=400,
+        json={"error": "bad"},
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await backend.chat_completion(sample_request)
+
+
+@pytest.mark.asyncio
+async def test_list_models_success(backend: GeminiBackend, httpx_mock: HTTPXMock):
+    models_resp = {"models": ["a", "b"]}
+    httpx_mock.add_response(
+        url=f"{TEST_BASE_URL}/models?key={'AI'+'z'*30}",
+        method="GET",
+        json=models_resp,
+        headers={"X-Token-Usage": "1"},
+    )
+    resp = await backend.list_models()
+    assert resp["data"] == models_resp
+    assert resp["headers"]["x-token-usage"] == "1"

--- a/tests/unit/gemini_backend_tests/test_key_loading.py
+++ b/tests/unit/gemini_backend_tests/test_key_loading.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+from src.gemini_cli import load_gemini_api_keys
+
+
+def test_single_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY_1", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "AI" + "a" * 30)
+    assert load_gemini_api_keys() == ["AI" + "a" * 30]
+
+
+def test_multiple_keys(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY_1", "AI" + "b" * 30)
+    monkeypatch.setenv("GEMINI_API_KEY_2", "AI" + "c" * 30)
+    assert load_gemini_api_keys() == ["AI" + "b" * 30, "AI" + "c" * 30]
+
+
+def test_both_single_and_numbered(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "AI" + "x" * 30)
+    monkeypatch.setenv("GEMINI_API_KEY_1", "AI" + "y" * 30)
+    with pytest.raises(ValueError):
+        load_gemini_api_keys()
+
+
+def test_invalid_key(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "badkey")
+    with pytest.raises(ValueError):
+        load_gemini_api_keys()
+
+
+def test_no_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 3):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    with pytest.raises(ValueError):
+        load_gemini_api_keys()


### PR DESCRIPTION
## Summary
- implement new `GeminiBackend` with support for list_models, chat completions, streaming and header passthrough
- add CLI `gemini_cli.py` with API key rotation and validation
- support Google Gemini backend exports
- update imports to use `src.` prefix
- include unit tests for Gemini backend and API key loader
- ensure Pydantic 2 compatibility in tests

## Testing
- `pip install fastapi httpx pytest-httpx pytest-asyncio starlette`
- `pip install python-dotenv`
- `pip install --upgrade fastapi>=0.110 pydantic>=2 pydantic-core>=2 starlette>=0.36`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840787f21e883339c9dfe46504e89ad