### PR TITLE
Add integration test client for OpenAI

### DIFF
--- a/dev/example_config.json
+++ b/dev/example_config.json
@@ -1,0 +1,9 @@
+{
+  "api_base": "http://localhost:8000/v1",
+  "model": "gpt-3.5-turbo",
+  "prompts": [
+    "Hello",
+    "!/set(model=gpt-3.5-turbo)",
+    "What is 2+2?"
+  ]
+}

--- a/dev/test_client.py
+++ b/dev/test_client.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+import os
+from typing import List, Dict, Any
+
+import openai
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), 'output')
+
+
+def validate_output_filename(filename: str) -> str:
+    if os.path.sep in filename or (os.path.altsep and os.path.altsep in filename):
+        raise ValueError("Output filename must not contain path separators")
+    if not filename.endswith('.txt'):
+        raise ValueError("Output filename must end with .txt")
+    return os.path.join(OUTPUT_DIR, filename)
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def run_prompts(client: openai.OpenAI, model: str, prompts: List[Any]) -> List[str]:
+    results = []
+    for prm in prompts:
+        if isinstance(prm, dict):
+            messages = [prm]
+            if 'role' not in prm or 'content' not in prm:
+                raise ValueError('Prompt dict must contain role and content')
+        else:
+            messages = [{'role': 'user', 'content': str(prm)}]
+        resp = client.chat.completions.create(model=model, messages=messages)
+        content = resp.choices[0].message.content
+        results.append(content)
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple test client for proxy")
+    parser.add_argument('config', help='JSON configuration file')
+    parser.add_argument('-o', '--output', help='Output filename (stored under dev/output)')
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    api_key = config.get('api_key') or os.environ.get('OPENAI_API_KEY')
+    api_base = config.get('api_base')
+    model = config.get('model', 'gpt-3.5-turbo')
+    prompts = config.get('prompts', [])
+
+    client = openai.OpenAI(api_key=api_key, base_url=api_base)
+
+    results = run_prompts(client, model, prompts)
+
+    if args.output:
+        out_path = validate_output_filename(args.output)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, 'w', encoding='utf-8') as f:
+            for line in results:
+                f.write(line + '\n')
+    else:
+        for line in results:
+            print(line)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "httpx",
     "python-dotenv",
     "pydantic",
+    "openai==1.84.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "pytest",
+        "openai==1.84.0",
     ],
     # Add other metadata as needed
     author="Your Name",


### PR DESCRIPTION
## Summary
- add test client under `dev/` that sends prompts using the latest openai Python SDK
- include an example JSON configuration
- require `openai==1.84.0` in project dependencies

## Testing
- `pip install openai==1.84.0`
- `pytest -q` *(fails: AttributeError: 'ChatCompletionRequest' object has no attribute 'model_dump', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684089fcabb083339dce9208cbf83fe5