### PR TITLE
Add session management with TTL

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -35,7 +35,7 @@ class SessionManager:
 
     def _cleanup_expired(self) -> None:
         now = datetime.utcnow()
-        expired = [sid for sid, sess in self.sessions.items() if now - sess.last_activity > timedelta(seconds=self.ttl)]
+        expired = [sid for sid, sess in self.sessions.items() if now - sess.last_activity >= timedelta(seconds=self.ttl)]
         for sid in expired:
             logger.info(f"Session {sid} expired, removing")
             self.sessions.pop(sid, None)
@@ -59,4 +59,3 @@ class SessionManager:
             return
         sess.history.append(Interaction(prompt=prompt, response=response, timestamp=datetime.utcnow()))
         sess.last_activity = datetime.utcnow()
-

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+import uuid
+
+from src.proxy_logic import ProxyState
+import logging
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class Interaction:
+    prompt: List[Any]
+    response: Any
+    timestamp: datetime
+
+@dataclass
+class Session:
+    session_id: str
+    client_app: str
+    start_time: datetime
+    proxy_state: ProxyState = field(default_factory=ProxyState)
+    history: List[Interaction] = field(default_factory=list)
+    last_activity: datetime = field(default_factory=datetime.utcnow)
+
+class SessionManager:
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        self.ttl = ttl_seconds
+        self.sessions: Dict[str, Session] = {}
+
+    def _generate_id(self) -> str:
+        return str(uuid.uuid4())
+
+    def _cleanup_expired(self) -> None:
+        now = datetime.utcnow()
+        expired = [sid for sid, sess in self.sessions.items() if now - sess.last_activity > timedelta(seconds=self.ttl)]
+        for sid in expired:
+            logger.info(f"Session {sid} expired, removing")
+            self.sessions.pop(sid, None)
+
+    def get_session(self, session_id: Optional[str], client_app: str) -> Session:
+        self._cleanup_expired()
+        now = datetime.utcnow()
+        if session_id and session_id in self.sessions:
+            sess = self.sessions[session_id]
+            sess.last_activity = now
+            return sess
+        # create new session with a fresh id
+        new_id = self._generate_id()
+        sess = Session(session_id=new_id, client_app=client_app, start_time=now)
+        self.sessions[new_id] = sess
+        return sess
+
+    def add_history(self, session_id: str, prompt: List[Any], response: Any) -> None:
+        sess = self.sessions.get(session_id)
+        if not sess:
+            return
+        sess.history.append(Interaction(prompt=prompt, response=response, timestamp=datetime.utcnow()))
+        sess.last_activity = datetime.utcnow()
+

--- a/tests/integration/chat_completions_tests/test_basic_proxying.py
+++ b/tests/integration/chat_completions_tests/test_basic_proxying.py
@@ -11,14 +11,13 @@ from fastapi import HTTPException # Import HTTPException
 # Assuming your FastAPI app instance is named 'app' in 'src/main.py'
 from src.main import app, get_openrouter_headers # Import app and any direct dependencies for mocking
 import src.models as models # For constructing request payloads
-from src.proxy_logic import ProxyState # Import ProxyState if needed for type hinting or direct instantiation
+from src.session_manager import SessionManager
 
 # Fixture to provide a TestClient instance
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        # Ensure a fresh ProxyState for each test, similar to other integration tests
-        c.app.state.proxy_state = ProxyState() # type: ignore[attr-defined]
+        c.app.state.session_manager = SessionManager(ttl_seconds=1000)  # type: ignore
         yield c
 
 # --- Test Cases ---

--- a/tests/integration/chat_completions_tests/test_command_only_requests.py
+++ b/tests/integration/chat_completions_tests/test_command_only_requests.py
@@ -8,20 +8,21 @@ from fastapi import HTTPException
 
 from src.main import app, get_openrouter_headers
 import src.models as models
-from src.proxy_logic import ProxyState # Import ProxyState class
+from src.session_manager import SessionManager
 
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        c.app.state.proxy_state = ProxyState() # type: ignore
+        c.app.state.session_manager = SessionManager(ttl_seconds=1000)  # type: ignore
         yield c
 
 def test_command_only_request_direct_response(client: TestClient):
+    session = client.app.state.session_manager.get_session(None, "test")
     payload = {
         "model": "some-model",
         "messages": [{"role": "user", "content": "!/set(model=command-only-model)"}]
     }
-    response = client.post("/v1/chat/completions", json=payload)
+    response = client.post("/v1/chat/completions", json=payload, headers={"X-Session-ID": session.session_id})
 
     assert response.status_code == 200
     response_json = response.json()
@@ -31,4 +32,5 @@ def test_command_only_request_direct_response(client: TestClient):
 
     # The backend's chat_completions method should not be called in this scenario
     # No mock needed here as we are testing the direct proxy response
-    assert client.app.state.proxy_state.override_model == "command-only-model" # type: ignore
+    assert response.headers["X-Session-ID"] == session.session_id
+    assert client.app.state.session_manager.sessions[session.session_id].proxy_state.override_model == "command-only-model"  # type: ignore

--- a/tests/integration/chat_completions_tests/test_error_handling.py
+++ b/tests/integration/chat_completions_tests/test_error_handling.py
@@ -8,12 +8,12 @@ from fastapi import HTTPException
 
 from src.main import app, get_openrouter_headers
 import src.models as models
-from src.proxy_logic import ProxyState # Import ProxyState
+from src.session_manager import SessionManager
 
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        c.app.state.proxy_state = ProxyState() # type: ignore[attr-defined]
+        c.app.state.session_manager = SessionManager(ttl_seconds=1000)  # type: ignore
         yield c
 
 def test_empty_messages_after_processing_no_commands_bad_request(client: TestClient):

--- a/tests/integration/chat_completions_tests/test_model_commands.py
+++ b/tests/integration/chat_completions_tests/test_model_commands.py
@@ -8,15 +8,13 @@ from fastapi import HTTPException, FastAPI # Import FastAPI for type hinting
 
 from src.main import app, get_openrouter_headers
 import src.models as models
-from src.proxy_logic import ProxyState # Import ProxyState class
+from src.session_manager import SessionManager
 # import src.main # No longer needed to access module-level proxy_state
 
 @pytest.fixture
 def client():
-    # Use TestClient and set a new ProxyState instance in app.state for each test
     with TestClient(app) as c:
-        # Set a new instance in app.state
-        c.app.state.proxy_state = ProxyState() # type: ignore
+        c.app.state.session_manager = SessionManager(ttl_seconds=1000)  # type: ignore
         yield c
 
 def test_set_model_command_integration(client: TestClient):
@@ -25,15 +23,16 @@ def test_set_model_command_integration(client: TestClient):
     with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
         mock_method.return_value = mock_backend_response
 
+        session = client.app.state.session_manager.get_session(None, "test")
         payload = {
             "model": "original-model",
             "messages": [{"role": "user", "content": "Use this: !/set(model=override-model) Hello"}]
         }
-        response = client.post("/v1/chat/completions", json=payload)
+        response = client.post("/v1/chat/completions", json=payload, headers={"X-Session-ID": session.session_id})
 
     assert response.status_code == 200
-    # Access proxy_state from the app state within the test client
-    assert client.app.state.proxy_state.override_model == "override-model" # type: ignore
+    assert response.headers["X-Session-ID"] == session.session_id
+    assert client.app.state.session_manager.sessions[session.session_id].proxy_state.override_model == "override-model"  # type: ignore
 
     mock_method.assert_called_once()
     call_args = mock_method.call_args[1]
@@ -43,8 +42,8 @@ def test_set_model_command_integration(client: TestClient):
 
 
 def test_unset_model_command_integration(client: TestClient):
-    # Access proxy_state from the app state within the test client
-    client.app.state.proxy_state.set_override_model("initial-override") # type: ignore
+    session = client.app.state.session_manager.get_session(None, "test")
+    session.proxy_state.set_override_model("initial-override")
 
     mock_backend_response = {"choices": [{"message": {"content": "Model unset and called."}}]}
 
@@ -55,11 +54,11 @@ def test_unset_model_command_integration(client: TestClient):
             "model": "another-model",
             "messages": [{"role": "user", "content": "Please !/unset(model) use default."}]
         }
-        response = client.post("/v1/chat/completions", json=payload)
+        response = client.post("/v1/chat/completions", json=payload, headers={"X-Session-ID": session.session_id})
 
     assert response.status_code == 200
-    # Access proxy_state from the app state within the test client
-    assert client.app.state.proxy_state.override_model is None # type: ignore
+    assert response.headers["X-Session-ID"] == session.session_id
+    assert client.app.state.session_manager.sessions[session.session_id].proxy_state.override_model is None  # type: ignore
 
     mock_method.assert_called_once()
     call_args = mock_method.call_args[1]

--- a/tests/integration/chat_completions_tests/test_session_handling.py
+++ b/tests/integration/chat_completions_tests/test_session_handling.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.session_manager import SessionManager
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        c.app.state.session_manager = SessionManager(ttl_seconds=0)  # expire immediately for TTL test
+        yield c
+
+def test_session_header_and_persistence(client: TestClient):
+    client.app.state.session_manager = SessionManager(ttl_seconds=1000)  # override TTL for this test
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = {"choices": [{"message": {"content": "ok"}}]}
+        session = client.app.state.session_manager.get_session(None, "test")
+        payload = {"model": "m1", "messages": [{"role": "user", "content": "!/set(model=foo)"}]}
+        resp1 = client.post("/v1/chat/completions", json=payload, headers={"X-Session-ID": session.session_id})
+        assert resp1.status_code == 200
+        assert resp1.headers["X-Session-ID"] == session.session_id
+        assert client.app.state.session_manager.sessions[session.session_id].proxy_state.override_model == "foo"
+
+        payload2 = {"model": "m1", "messages": [{"role": "user", "content": "hi"}]}
+        resp2 = client.post("/v1/chat/completions", json=payload2, headers={"X-Session-ID": session.session_id})
+        assert resp2.status_code == 200
+        assert resp2.headers["X-Session-ID"] == session.session_id
+        assert mock_method.call_count == 1
+
+def test_session_ttl_expiry(client: TestClient):
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = {"choices": [{"message": {"content": "ok"}}]}
+        session = client.app.state.session_manager.get_session(None, "test")
+        payload = {"model": "m1", "messages": [{"role": "user", "content": "hi"}]}
+        resp1 = client.post("/v1/chat/completions", json=payload, headers={"X-Session-ID": session.session_id})
+        first_id = resp1.headers["X-Session-ID"]
+
+        resp2 = client.post("/v1/chat/completions", json=payload, headers={"X-Session-ID": session.session_id})
+        assert resp2.headers["X-Session-ID"] != first_id
+

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -1,0 +1,19 @@
+from src.session_manager import SessionManager
+
+
+def test_session_persistence():
+    manager = SessionManager(ttl_seconds=10)
+    s1 = manager.get_session(None, "app")
+    s1.proxy_state.set_override_model("m")
+    s2 = manager.get_session(s1.session_id, "app")
+    assert s1.session_id == s2.session_id
+    assert s2.proxy_state.override_model == "m"
+
+
+def test_session_expiry():
+    manager = SessionManager(ttl_seconds=0)
+    s1 = manager.get_session(None, "app")
+    s1_id = s1.session_id
+    s2 = manager.get_session(s1_id, "app")
+    assert s2.session_id != s1_id
+


### PR DESCRIPTION
## Summary
- implement `SessionManager` for per-client sessions with expiration
- track sessions in `main.py` using header `X-Session-ID`
- record prompt/response history per session
- expose session TTL via config and CLI
- update tests for new session system and add coverage for session logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c0dad8cc8333b72b3cbb67f9e6fb