### PR TITLE
Configurable command prefix

### DIFF
--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -84,8 +84,8 @@ This directory contains the core logic of the proxy server.
     *   **Responsibilities**:
         *   **`ProxyState` Class**: Manages the dynamic state of the proxy, such as overriding the LLM model for subsequent requests. This state is typically tied to a session or request context.
         *   **`parse_arguments(args_str)`**: Parses command arguments from a string (e.g., `model=gpt-4`).
-        *   **`_process_text_for_commands(text_content, current_proxy_state)`**: A private helper function that identifies and processes commands within a single text string. It modifies the `ProxyState` and removes the command text from the message content.
-        *   **`process_commands_in_messages(messages, current_proxy_state)`**: The primary function that iterates through a list of `ChatMessage` objects, identifies and processes commands (typically in the last user message), and returns the modified message list and a flag indicating if any commands were processed. It handles both string and multimodal message content.
+        *   **`_process_text_for_commands(text_content, current_proxy_state, command_pattern)`**: A private helper function that identifies and processes commands within a single text string using the provided regex pattern. It modifies the `ProxyState` and removes the command text from the message content.
+        *   **`process_commands_in_messages(messages, current_proxy_state, command_prefix='!/')`**: The primary function that iterates through a list of `ChatMessage` objects, identifies and processes commands (typically in the last user message), and returns the modified message list and a flag indicating if any commands were processed. It handles both string and multimodal message content. The `command_prefix` parameter controls which command syntax is recognized.
 
 *   **`src/connectors/`**:
     *   **Role**: Contains implementations for connecting to various LLM providers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "uvicorn[standard]",
     "httpx",
     "python-dotenv",
-    "pydantic",
+    "pydantic>=2",
     "openai==1.84.0",
 ]
 requires-python = ">=3.10"

--- a/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
+++ b/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
@@ -160,3 +160,17 @@ class TestProcessCommandsInMessages:
         assert len(processed_messages) == 1
         assert processed_messages[0].content == "Hello !/unknown(cmd) there"
         assert current_proxy_state.override_model is None
+
+    def test_custom_command_prefix(self):
+        current_proxy_state = ProxyState()
+        messages = [
+            models.ChatMessage(role="user", content="Hello $$set(model=foo)")
+        ]
+        processed_messages, processed = process_commands_in_messages(
+            messages,
+            current_proxy_state,
+            command_prefix="$$",
+        )
+        assert processed
+        assert processed_messages[0].content == "Hello"
+        assert current_proxy_state.override_model == "foo"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,21 +10,27 @@ def test_apply_cli_args_sets_env(monkeypatch):
         "TESTKEY",
         "--port",
         "1234",
+        "--command-prefix",
+        "$/",
     ])
     cfg = app_main.apply_cli_args(args)
     assert os.environ["LLM_BACKEND"] == "gemini"
     assert os.environ["GEMINI_API_KEY"] == "TESTKEY"
     assert os.environ["PROXY_PORT"] == "1234"
+    assert os.environ["COMMAND_PREFIX"] == "$/"
     assert cfg["backend"] == "gemini"
     assert cfg["proxy_port"] == 1234
+    assert cfg["command_prefix"] == "$/"
 
 
 def test_build_app_uses_env(monkeypatch):
     monkeypatch.setenv("LLM_BACKEND", "gemini")
     monkeypatch.setenv("GEMINI_API_KEY", "KEY")
+    monkeypatch.setenv("COMMAND_PREFIX", "??/")
     app = app_main.build_app()
     from fastapi.testclient import TestClient
 
     with TestClient(app) as client:
         assert client.app.state.backend_type == "gemini"
         assert hasattr(client.app.state, "gemini_backend")
+        assert client.app.state.command_prefix == "??/"


### PR DESCRIPTION
## Summary
- allow custom command prefix via CLI and env vars
- parse prefix in main app and pass to processing logic
- generate command regex dynamically
- update docs to describe new parameters
- expand tests to cover CLI environment prefix and custom prefixes
- require pydantic>=2 for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c24580f08333a5f9b5652703e41d