### PR TITLE
Implement session history tracking

### DIFF
--- a/src/session.py
+++ b/src/session.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import List, Dict, Optional, Any
+
+from pydantic import BaseModel, ConfigDict
+
+from .proxy_logic import ProxyState
+import src.models as models
+
+
+class SessionInteraction(BaseModel):
+    """Represents one user prompt and the resulting response."""
+
+    prompt: str
+    handler: str  # "proxy" or "backend"
+    backend: Optional[str] = None
+    model: Optional[str] = None
+    parameters: Dict[str, Any] = {}
+    response: Optional[str] = None
+    usage: Optional[models.CompletionUsage] = None
+
+
+class Session(BaseModel):
+    """Container for conversation state and history."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    session_id: str
+    proxy_state: ProxyState = ProxyState()
+    history: List[SessionInteraction] = []
+
+    def add_interaction(self, interaction: SessionInteraction) -> None:
+        self.history.append(interaction)
+
+
+class SessionManager:
+    """Manages Session instances keyed by session_id."""
+
+    def __init__(self) -> None:
+        self.sessions: Dict[str, Session] = {}
+
+    def get_session(self, session_id: str) -> Session:
+        if session_id not in self.sessions:
+            self.sessions[session_id] = Session(session_id=session_id)
+        return self.sessions[session_id]

--- a/tests/integration/chat_completions_tests/test_basic_proxying.py
+++ b/tests/integration/chat_completions_tests/test_basic_proxying.py
@@ -11,14 +11,13 @@ from fastapi import HTTPException # Import HTTPException
 # Assuming your FastAPI app instance is named 'app' in 'src/main.py'
 from src.main import app, get_openrouter_headers # Import app and any direct dependencies for mocking
 import src.models as models # For constructing request payloads
-from src.proxy_logic import ProxyState # Import ProxyState if needed for type hinting or direct instantiation
+from src.session import SessionManager
 
 # Fixture to provide a TestClient instance
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        # Ensure a fresh ProxyState for each test, similar to other integration tests
-        c.app.state.proxy_state = ProxyState() # type: ignore[attr-defined]
+        c.app.state.session_manager = SessionManager()  # type: ignore[attr-defined]
         yield c
 
 # --- Test Cases ---

--- a/tests/integration/chat_completions_tests/test_command_only_requests.py
+++ b/tests/integration/chat_completions_tests/test_command_only_requests.py
@@ -8,12 +8,12 @@ from fastapi import HTTPException
 
 from src.main import app, get_openrouter_headers
 import src.models as models
-from src.proxy_logic import ProxyState # Import ProxyState class
+from src.session import SessionManager
 
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        c.app.state.proxy_state = ProxyState() # type: ignore
+        c.app.state.session_manager = SessionManager()  # type: ignore
         yield c
 
 def test_command_only_request_direct_response(client: TestClient):
@@ -31,4 +31,5 @@ def test_command_only_request_direct_response(client: TestClient):
 
     # The backend's chat_completions method should not be called in this scenario
     # No mock needed here as we are testing the direct proxy response
-    assert client.app.state.proxy_state.override_model == "command-only-model" # type: ignore
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.override_model == "command-only-model"

--- a/tests/integration/chat_completions_tests/test_error_handling.py
+++ b/tests/integration/chat_completions_tests/test_error_handling.py
@@ -8,12 +8,12 @@ from fastapi import HTTPException
 
 from src.main import app, get_openrouter_headers
 import src.models as models
-from src.proxy_logic import ProxyState # Import ProxyState
+from src.session import SessionManager
 
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        c.app.state.proxy_state = ProxyState() # type: ignore[attr-defined]
+        c.app.state.session_manager = SessionManager()  # type: ignore[attr-defined]
         yield c
 
 def test_empty_messages_after_processing_no_commands_bad_request(client: TestClient):

--- a/tests/integration/chat_completions_tests/test_model_commands.py
+++ b/tests/integration/chat_completions_tests/test_model_commands.py
@@ -8,15 +8,14 @@ from fastapi import HTTPException, FastAPI # Import FastAPI for type hinting
 
 from src.main import app, get_openrouter_headers
 import src.models as models
-from src.proxy_logic import ProxyState # Import ProxyState class
+from src.session import SessionManager
 # import src.main # No longer needed to access module-level proxy_state
 
 @pytest.fixture
 def client():
     # Use TestClient and set a new ProxyState instance in app.state for each test
     with TestClient(app) as c:
-        # Set a new instance in app.state
-        c.app.state.proxy_state = ProxyState() # type: ignore
+        c.app.state.session_manager = SessionManager()  # type: ignore
         yield c
 
 def test_set_model_command_integration(client: TestClient):
@@ -33,7 +32,8 @@ def test_set_model_command_integration(client: TestClient):
 
     assert response.status_code == 200
     # Access proxy_state from the app state within the test client
-    assert client.app.state.proxy_state.override_model == "override-model" # type: ignore
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.override_model == "override-model"
 
     mock_method.assert_called_once()
     call_args = mock_method.call_args[1]
@@ -44,7 +44,7 @@ def test_set_model_command_integration(client: TestClient):
 
 def test_unset_model_command_integration(client: TestClient):
     # Access proxy_state from the app state within the test client
-    client.app.state.proxy_state.set_override_model("initial-override") # type: ignore
+    client.app.state.session_manager.get_session("default").proxy_state.set_override_model("initial-override")  # type: ignore
 
     mock_backend_response = {"choices": [{"message": {"content": "Model unset and called."}}]}
 
@@ -59,7 +59,8 @@ def test_unset_model_command_integration(client: TestClient):
 
     assert response.status_code == 200
     # Access proxy_state from the app state within the test client
-    assert client.app.state.proxy_state.override_model is None # type: ignore
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.override_model is None
 
     mock_method.assert_called_once()
     call_args = mock_method.call_args[1]

--- a/tests/integration/chat_completions_tests/test_session_history.py
+++ b/tests/integration/chat_completions_tests/test_session_history.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
+
+from src.main import app
+import src.models as models
+from src.session import SessionManager
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        c.app.state.session_manager = SessionManager()  # type: ignore
+        yield c
+
+def test_session_records_proxy_and_backend_interactions(client: TestClient):
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = {
+            'choices': [{'message': {'content': 'backend reply'}}],
+            'usage': {'prompt_tokens': 1, 'completion_tokens': 2, 'total_tokens': 3}
+        }
+        payload1 = {
+            'model': 'model-a',
+            'messages': [{'role': 'user', 'content': '!/set(model=override)'}]
+        }
+        client.post('/v1/chat/completions', json=payload1, headers={'X-Session-ID': 'abc'})
+
+        payload2 = {
+            'model': 'model-a',
+            'messages': [{'role': 'user', 'content': 'hello'}]
+        }
+        client.post('/v1/chat/completions', json=payload2, headers={'X-Session-ID': 'abc'})
+
+    session = client.app.state.session_manager.get_session('abc')  # type: ignore
+    assert len(session.history) == 2
+    assert session.history[0].handler == 'proxy'
+    assert session.history[0].prompt == '!/set(model=override)'
+    assert session.history[1].handler == 'backend'
+    assert session.history[1].backend == 'openrouter'
+    assert session.history[1].model == 'override'
+    assert session.history[1].response == 'backend reply'
+    assert session.history[1].usage.total_tokens == 3
+
+def test_session_records_streaming_placeholder(client: TestClient):
+    async def gen():
+        yield b'data: hi\n\n'
+    stream_resp = StreamingResponse(gen(), media_type='text/event-stream')
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = stream_resp
+        payload = {
+            'model': 'model-a',
+            'messages': [{'role': 'user', 'content': 'hello'}],
+            'stream': True
+        }
+        client.post('/v1/chat/completions', json=payload, headers={'X-Session-ID': 's2'})
+
+    session = client.app.state.session_manager.get_session('s2')  # type: ignore
+    assert session.history[0].response == '<streaming>'


### PR DESCRIPTION
## Summary
- add `SessionManager` and history models to capture conversation events
- store per-session state and history in FastAPI app
- log proxy- or backend-handled interactions
- adjust existing tests for new session management
- add integration tests for session history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684148b6942083339df8ac4c17054e53