### PR TITLE
Add project session command

### DIFF
--- a/src/connectors/base.py
+++ b/src/connectors/base.py
@@ -21,10 +21,11 @@ class LLMBackend(abc.ABC):
     async def chat_completions(
         self,
         request_data: 'ChatCompletionRequest',
-        processed_messages: list, # Messages after command processing
-        effective_model: str, # Model after considering override
-        openrouter_api_base_url: str, # This might need to be more generic if we have more backends
-        openrouter_headers_provider: Callable[[], Dict[str, str]] # Same as above
+        processed_messages: list,  # Messages after command processing
+        effective_model: str,  # Model after considering override
+        openrouter_api_base_url: str,  # This might need to be more generic if we have more backends
+        openrouter_headers_provider: Callable[[], Dict[str, str]],  # Same as above
+        project: str | None = None,
     ) -> Union[StreamingResponse, Dict[str, Any]]:
         """
         Forwards a chat completion request to the LLM backend.

--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -24,6 +24,7 @@ class GeminiBackend(LLMBackend):
         effective_model: str,
         gemini_api_base_url: str,
         gemini_api_key: str,
+        project: str | None = None,
     ) -> Dict[str, Any]:
         if request_data.stream:
             raise HTTPException(status_code=501, detail="Streaming not implemented for Gemini backend")
@@ -43,6 +44,8 @@ class GeminiBackend(LLMBackend):
         }
         if request_data.extra_params:
             payload.update(request_data.extra_params)
+        if project is not None:
+            payload["project"] = project
 
         url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models/{effective_model}:generateContent?key={gemini_api_key}"
         try:

--- a/src/connectors/openrouter.py
+++ b/src/connectors/openrouter.py
@@ -28,11 +28,12 @@ class OpenRouterBackend(LLMBackend):
 
     async def chat_completions(
         self,
-        request_data: ChatCompletionRequest, # This is the original request
-        processed_messages: list, # Messages after command processing
-        effective_model: str, # Model after considering override
+        request_data: ChatCompletionRequest,  # This is the original request
+        processed_messages: list,  # Messages after command processing
+        effective_model: str,  # Model after considering override
         openrouter_api_base_url: str,
-        openrouter_headers_provider: Callable[[], Dict[str, str]]
+        openrouter_headers_provider: Callable[[], Dict[str, str]],
+        project: str | None = None,
     ) -> Union[StreamingResponse, Dict[str, Any]]:
         """
         Forwards a chat completion request to the OpenRouter API.
@@ -57,6 +58,8 @@ class OpenRouterBackend(LLMBackend):
         openrouter_payload["model"] = effective_model
         # Ensure messages are in dict format, not Pydantic models
         openrouter_payload["messages"] = [msg.model_dump(exclude_unset=True) for msg in processed_messages]
+        if project is not None:
+            openrouter_payload["project"] = project
 
         logger.info(f"Forwarding to OpenRouter. Effective model: {effective_model}. Stream: {request_data.stream}")
         logger.debug(f"Payload for OpenRouter: {json.dumps(openrouter_payload, indent=2)}")

--- a/src/main.py
+++ b/src/main.py
@@ -115,6 +115,7 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
                     prompt=raw_prompt,
                     handler="proxy",
                     model=proxy_state.get_effective_model(request_data.model),
+                    project=proxy_state.project,
                     response="Proxy command processed. No query sent to LLM.",
                 )
             )
@@ -143,6 +144,7 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
                 request_data=request_data,
                 processed_messages=processed_messages,
                 effective_model=effective_model,
+                project=proxy_state.project,
                 gemini_api_base_url=cfg["gemini_api_base_url"],
                 gemini_api_key=cfg["gemini_api_key"],
             )
@@ -152,6 +154,7 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
                     handler="backend",
                     backend="gemini",
                     model=effective_model,
+                    project=proxy_state.project,
                     parameters=request_data.model_dump(exclude_unset=True),
                     response=response.get("choices", [{}])[0].get("message", {}).get("content"),
                     usage=models.CompletionUsage(**response.get("usage")) if response.get("usage") else None,
@@ -165,6 +168,7 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
             effective_model=effective_model,
             openrouter_api_base_url=cfg["openrouter_api_base_url"],
             openrouter_headers_provider=lambda: get_openrouter_headers(cfg),
+            project=proxy_state.project,
         )
         if isinstance(response, StreamingResponse):
             session.add_interaction(
@@ -173,6 +177,7 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
                     handler="backend",
                     backend="openrouter",
                     model=effective_model,
+                    project=proxy_state.project,
                     parameters=request_data.model_dump(exclude_unset=True),
                     response="<streaming>",
                 )
@@ -184,6 +189,7 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
                 handler="backend",
                 backend="openrouter",
                 model=effective_model,
+                project=proxy_state.project,
                 parameters=request_data.model_dump(exclude_unset=True),
                 response=response.get("choices", [{}])[0].get("message", {}).get("content"),
                 usage=models.CompletionUsage(**response.get("usage")) if response.get("usage") else None,

--- a/src/session.py
+++ b/src/session.py
@@ -15,6 +15,7 @@ class SessionInteraction(BaseModel):
     handler: str  # "proxy" or "backend"
     backend: Optional[str] = None
     model: Optional[str] = None
+    project: Optional[str] = None
     parameters: Dict[str, Any] = {}
     response: Optional[str] = None
     usage: Optional[models.CompletionUsage] = None

--- a/tests/integration/chat_completions_tests/test_project_commands.py
+++ b/tests/integration/chat_completions_tests/test_project_commands.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.session import SessionManager
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        c.app.state.session_manager = SessionManager()  # type: ignore
+        yield c
+
+
+def test_set_project_command_integration(client: TestClient):
+    mock_backend_response = {"choices": [{"message": {"content": "Project set"}}]}
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "!/set(project='proj x') hi"}]
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.project == "proj x"
+    mock_method.assert_called_once()
+    call_args = mock_method.call_args[1]
+    assert call_args["project"] == "proj x"
+    assert call_args["processed_messages"][0].content == "hi"
+
+
+def test_unset_project_command_integration(client: TestClient):
+    client.app.state.session_manager.get_session("default").proxy_state.set_project("initial")  # type: ignore
+    mock_backend_response = {"choices": [{"message": {"content": "unset"}}]}
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "please !/unset(project)"}]
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.project is None
+    mock_method.assert_called_once()
+    call_args = mock_method.call_args[1]
+    assert call_args["project"] is None
+    assert call_args["processed_messages"][0].content == "please"
+

--- a/tests/integration/chat_completions_tests/test_session_history.py
+++ b/tests/integration/chat_completions_tests/test_session_history.py
@@ -22,7 +22,7 @@ def test_session_records_proxy_and_backend_interactions(client: TestClient):
         }
         payload1 = {
             'model': 'model-a',
-            'messages': [{'role': 'user', 'content': '!/set(model=override)'}]
+            'messages': [{'role': 'user', 'content': "!/set(project=proj1)"}]
         }
         client.post('/v1/chat/completions', json=payload1, headers={'X-Session-ID': 'abc'})
 
@@ -35,10 +35,10 @@ def test_session_records_proxy_and_backend_interactions(client: TestClient):
     session = client.app.state.session_manager.get_session('abc')  # type: ignore
     assert len(session.history) == 2
     assert session.history[0].handler == 'proxy'
-    assert session.history[0].prompt == '!/set(model=override)'
+    assert session.history[0].prompt == '!/set(project=proj1)'
     assert session.history[1].handler == 'backend'
     assert session.history[1].backend == 'openrouter'
-    assert session.history[1].model == 'override'
+    assert session.history[1].project == 'proj1'
     assert session.history[1].response == 'backend reply'
     assert session.history[1].usage.total_tokens == 3
 

--- a/tests/unit/proxy_logic_tests/test_parse_arguments.py
+++ b/tests/unit/proxy_logic_tests/test_parse_arguments.py
@@ -36,3 +36,18 @@ class TestParseArguments:
         args_str = "model=claude/opus, debug_mode"
         expected = {"model": "claude/opus", "debug_mode": True}
         assert parse_arguments(args_str) == expected
+
+    def test_parse_project_with_spaces_and_quotes(self):
+        args_str = "project='my cool project'"
+        expected = {"project": "my cool project"}
+        assert parse_arguments(args_str) == expected
+
+    def test_parse_project_with_double_quotes(self):
+        args_str = 'project="another project"'
+        expected = {"project": "another project"}
+        assert parse_arguments(args_str) == expected
+
+    def test_parse_project_without_quotes(self):
+        args_str = "project=myproject"
+        expected = {"project": "myproject"}
+        assert parse_arguments(args_str) == expected

--- a/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
+++ b/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
@@ -174,3 +174,13 @@ class TestProcessCommandsInMessages:
         assert processed
         assert processed_messages[0].content == "Hello"
         assert current_proxy_state.override_model == "foo"
+
+    def test_set_project_in_messages(self):
+        current_proxy_state = ProxyState()
+        messages = [
+            models.ChatMessage(role="user", content="!/set(project=proj1) hi")
+        ]
+        processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
+        assert processed
+        assert processed_messages[0].content == "hi"
+        assert current_proxy_state.project == "proj1"

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -131,3 +131,13 @@ class TestProcessTextForCommands:
         assert processed_text == "" # Command is stripped
         assert commands_found
         assert current_proxy_state.override_model == "gpt-4" # Model remains set
+
+    def test_set_and_unset_project(self):
+        current_proxy_state = ProxyState()
+        pattern = get_command_pattern("!/")
+        processed_text, _ = _process_text_for_commands("!/set(project='abc def')", current_proxy_state, pattern)
+        assert processed_text == ""
+        assert current_proxy_state.project == "abc def"
+        processed_text, _ = _process_text_for_commands("!/unset(project)", current_proxy_state, pattern)
+        assert processed_text == ""
+        assert current_proxy_state.project is None


### PR DESCRIPTION
## Summary
- support new `set(project=...)` command
- track project in session state/history
- forward project parameter to backends
- handle quoting in argument parser
- test new command behavior and session history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684154d8fcd88333b785ce795076d12c