### PR TITLE
Refactor backend key handling

### DIFF
--- a/src/connectors/base.py
+++ b/src/connectors/base.py
@@ -24,7 +24,9 @@ class LLMBackend(abc.ABC):
         processed_messages: list,  # Messages after command processing
         effective_model: str,  # Model after considering override
         openrouter_api_base_url: str,  # This might need to be more generic if we have more backends
-        openrouter_headers_provider: Callable[[], Dict[str, str]],  # Same as above
+        openrouter_headers_provider: Callable[[str, str], Dict[str, str]],  # Same as above
+        key_name: str,
+        api_key: str,
         project: str | None = None,
     ) -> Union[StreamingResponse, Dict[str, Any]]:
         """
@@ -38,6 +40,8 @@ class LLMBackend(abc.ABC):
                                      (Will need generalization if supporting other backends)
             openrouter_headers_provider: A callable that returns a dictionary of headers
                                          required for OpenRouter API. (Needs generalization)
+            key_name: The environment variable name of the API key in use.
+            api_key: The secret value of the API key.
 
         Returns:
             A StreamingResponse if the request is for a stream, or a dictionary

--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -23,7 +23,8 @@ class GeminiBackend(LLMBackend):
         processed_messages: list,
         effective_model: str,
         gemini_api_base_url: str,
-        gemini_api_key: str,
+        key_name: str,
+        api_key: str,
         project: str | None = None,
     ) -> Dict[str, Any]:
         if request_data.stream:
@@ -47,7 +48,7 @@ class GeminiBackend(LLMBackend):
         if project is not None:
             payload["project"] = project
 
-        url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models/{effective_model}:generateContent?key={gemini_api_key}"
+        url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models/{effective_model}:generateContent?key={api_key}"
         try:
             response = await self.client.post(url, json=payload)
             response.raise_for_status()
@@ -65,8 +66,14 @@ class GeminiBackend(LLMBackend):
             logger.error(f"Unexpected error in GeminiBackend.chat_completions: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
 
-    async def list_models(self, *, gemini_api_base_url: str, gemini_api_key: str) -> Dict[str, Any]:
-        url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models?key={gemini_api_key}"
+    async def list_models(
+        self,
+        *,
+        gemini_api_base_url: str,
+        key_name: str,
+        api_key: str,
+    ) -> Dict[str, Any]:
+        url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models?key={api_key}"
         try:
             response = await self.client.get(url)
             response.raise_for_status()

--- a/src/connectors/openrouter.py
+++ b/src/connectors/openrouter.py
@@ -32,7 +32,9 @@ class OpenRouterBackend(LLMBackend):
         processed_messages: list,  # Messages after command processing
         effective_model: str,  # Model after considering override
         openrouter_api_base_url: str,
-        openrouter_headers_provider: Callable[[], Dict[str, str]],
+        openrouter_headers_provider: Callable[[str, str], Dict[str, str]],
+        key_name: str,
+        api_key: str,
         project: str | None = None,
     ) -> Union[StreamingResponse, Dict[str, Any]]:
         """
@@ -64,7 +66,7 @@ class OpenRouterBackend(LLMBackend):
         logger.info(f"Forwarding to OpenRouter. Effective model: {effective_model}. Stream: {request_data.stream}")
         logger.debug(f"Payload for OpenRouter: {json.dumps(openrouter_payload, indent=2)}")
 
-        headers = openrouter_headers_provider()
+        headers = openrouter_headers_provider(key_name, api_key)
 
         try:
             if request_data.stream:
@@ -141,10 +143,12 @@ class OpenRouterBackend(LLMBackend):
         self,
         *,
         openrouter_api_base_url: str,
-        openrouter_headers_provider: Callable[[], Dict[str, str]],
+        openrouter_headers_provider: Callable[[str, str], Dict[str, str]],
+        key_name: str,
+        api_key: str,
     ) -> Dict[str, Any]:
         """Fetch available models from OpenRouter."""
-        headers = openrouter_headers_provider()
+        headers = openrouter_headers_provider(key_name, api_key)
         try:
             response = await self.client.get(f"{openrouter_api_base_url}/models", headers=headers)
             response.raise_for_status()

--- a/tests/unit/openrouter_connector_tests/test_http_error_non_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_non_streaming.py
@@ -14,9 +14,9 @@ from src.connectors.openrouter import OpenRouterBackend
 # Default OpenRouter settings for tests
 TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1" # Real one for realistic requests
 
-def mock_get_openrouter_headers() -> Dict[str, str]:
+def mock_get_openrouter_headers(key_name: str, api_key: str) -> Dict[str, str]:
     return {
-        "Authorization": "Bearer FAKE_KEY",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "HTTP-Referer": "http://localhost:test",
         "X-Title": "TestProxy",
@@ -72,7 +72,9 @@ async def test_chat_completions_http_error_non_streaming(
             processed_messages=sample_processed_messages,
             effective_model="test-model",
             openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
-            openrouter_headers_provider=mock_get_openrouter_headers
+            openrouter_headers_provider=mock_get_openrouter_headers,
+            key_name="OPENROUTER_API_KEY_1",
+            api_key="FAKE_KEY"
         )
 
     assert exc_info.value.status_code == 402

--- a/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
@@ -14,9 +14,9 @@ from src.connectors.openrouter import OpenRouterBackend
 # Default OpenRouter settings for tests
 TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1" # Real one for realistic requests
 
-def mock_get_openrouter_headers() -> Dict[str, str]:
+def mock_get_openrouter_headers(key_name: str, api_key: str) -> Dict[str, str]:
     return {
-        "Authorization": "Bearer FAKE_KEY",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "HTTP-Referer": "http://localhost:test",
         "X-Title": "TestProxy",
@@ -84,7 +84,9 @@ async def test_chat_completions_http_error_streaming(
             processed_messages=sample_processed_messages,
             effective_model="test-model",
             openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
-            openrouter_headers_provider=mock_get_openrouter_headers
+            openrouter_headers_provider=mock_get_openrouter_headers,
+            key_name="OPENROUTER_API_KEY_1",
+            api_key="FAKE_KEY"
         )
 
         assert isinstance(response, StreamingResponse)

--- a/tests/unit/openrouter_connector_tests/test_non_streaming_success.py
+++ b/tests/unit/openrouter_connector_tests/test_non_streaming_success.py
@@ -14,9 +14,9 @@ from src.connectors.openrouter import OpenRouterBackend
 # Default OpenRouter settings for tests
 TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1" # Real one for realistic requests
 
-def mock_get_openrouter_headers() -> Dict[str, str]:
+def mock_get_openrouter_headers(key_name: str, api_key: str) -> Dict[str, str]:
     return {
-        "Authorization": "Bearer FAKE_KEY",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "HTTP-Referer": "http://localhost:test",
         "X-Title": "TestProxy",
@@ -78,7 +78,9 @@ async def test_chat_completions_non_streaming_success(
         processed_messages=sample_processed_messages,
         effective_model=effective_model,
         openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
-        openrouter_headers_provider=mock_get_openrouter_headers
+        openrouter_headers_provider=mock_get_openrouter_headers,
+        key_name="OPENROUTER_API_KEY_1",
+        api_key="FAKE_KEY"
     )
 
     assert isinstance(response, dict)

--- a/tests/unit/openrouter_connector_tests/test_payload_construction_and_headers.py
+++ b/tests/unit/openrouter_connector_tests/test_payload_construction_and_headers.py
@@ -14,9 +14,9 @@ from src.connectors.openrouter import OpenRouterBackend
 # Default OpenRouter settings for tests
 TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1" # Real one for realistic requests
 
-def mock_get_openrouter_headers() -> Dict[str, str]:
+def mock_get_openrouter_headers(key_name: str, api_key: str) -> Dict[str, str]:
     return {
-        "Authorization": "Bearer FAKE_KEY",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "HTTP-Referer": "http://localhost:test",
         "X-Title": "TestProxy",
@@ -76,7 +76,9 @@ async def test_payload_construction_and_headers(
         processed_messages=processed_msgs,
         effective_model=effective_model,
         openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
-        openrouter_headers_provider=mock_get_openrouter_headers
+        openrouter_headers_provider=mock_get_openrouter_headers,
+        key_name="OPENROUTER_API_KEY_1",
+        api_key="FAKE_KEY"
     )
 
     request = httpx_mock.get_request()

--- a/tests/unit/openrouter_connector_tests/test_request_error.py
+++ b/tests/unit/openrouter_connector_tests/test_request_error.py
@@ -14,9 +14,9 @@ from src.connectors.openrouter import OpenRouterBackend
 # Default OpenRouter settings for tests
 TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1" # Real one for realistic requests
 
-def mock_get_openrouter_headers() -> Dict[str, str]:
+def mock_get_openrouter_headers(key_name: str, api_key: str) -> Dict[str, str]:
     return {
-        "Authorization": "Bearer FAKE_KEY",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "HTTP-Referer": "http://localhost:test",
         "X-Title": "TestProxy",
@@ -64,7 +64,9 @@ async def test_chat_completions_request_error(
                 processed_messages=sample_processed_messages,
                 effective_model="test-model",
                 openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
-                openrouter_headers_provider=mock_get_openrouter_headers
+                openrouter_headers_provider=mock_get_openrouter_headers,
+                key_name="OPENROUTER_API_KEY_1",
+                api_key="FAKE_KEY"
             )
 
     assert exc_info.value.status_code == 503 # Service Unavailable

--- a/tests/unit/openrouter_connector_tests/test_streaming_success.py
+++ b/tests/unit/openrouter_connector_tests/test_streaming_success.py
@@ -14,9 +14,9 @@ from src.connectors.openrouter import OpenRouterBackend
 # Default OpenRouter settings for tests
 TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1" # Real one for realistic requests
 
-def mock_get_openrouter_headers() -> Dict[str, str]:
+def mock_get_openrouter_headers(key_name: str, api_key: str) -> Dict[str, str]:
     return {
-        "Authorization": "Bearer FAKE_KEY",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "HTTP-Referer": "http://localhost:test",
         "X-Title": "TestProxy",
@@ -86,7 +86,9 @@ async def test_chat_completions_streaming_success(
         processed_messages=sample_processed_messages,
         effective_model=effective_model,
         openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
-        openrouter_headers_provider=mock_get_openrouter_headers
+        openrouter_headers_provider=mock_get_openrouter_headers,
+        key_name="OPENROUTER_API_KEY_1",
+        api_key="FAKE_KEY"
     )
 
     assert isinstance(response, StreamingResponse)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -24,7 +24,7 @@ def test_apply_cli_args_sets_env(monkeypatch):
     assert os.environ["PROXY_PORT"] == "1234"
     assert os.environ["COMMAND_PREFIX"] == "$/"
     assert cfg["backend"] == "gemini"
-    assert cfg["gemini_api_keys"] == ["TESTKEY"]
+    assert cfg["gemini_api_keys"] == {"GEMINI_API_KEY": "TESTKEY"}
     assert cfg["proxy_port"] == 1234
     assert cfg["command_prefix"] == "$/"
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,7 @@ def test_collect_single_gemini_key(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "A")
     cfg = app_main._load_config()
     assert cfg["gemini_api_key"] == "A"
-    assert cfg["gemini_api_keys"] == ["A"]
+    assert cfg["gemini_api_keys"] == {"GEMINI_API_KEY": "A"}
 
 
 def test_collect_numbered_openrouter_keys(monkeypatch):
@@ -24,7 +24,10 @@ def test_collect_numbered_openrouter_keys(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY_2", "K2")
     cfg = app_main._load_config()
     assert cfg["openrouter_api_key"] == "K1"
-    assert cfg["openrouter_api_keys"] == ["K1", "K2"]
+    assert cfg["openrouter_api_keys"] == {
+        "OPENROUTER_API_KEY_1": "K1",
+        "OPENROUTER_API_KEY_2": "K2",
+    }
 
 
 def test_conflicting_key_formats(monkeypatch):


### PR DESCRIPTION
## Summary
- return API keys as mapping with environment variable names
- add key name & value parameters to `LLMBackend` and concrete backends
- propagate key info through `main` when calling backends
- ensure integration tests set a dummy OpenRouter key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416900b3f4833392721d27b30b3b58