### PR TITLE
Implement API key redaction

### DIFF
--- a/src/connectors/base.py
+++ b/src/connectors/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 from typing import Union, Dict, Any, Callable
 import httpx
@@ -10,6 +12,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.models import ChatCompletionRequest # Corrected path assuming models.py is in src
+    from src.security import APIKeyRedactor
 
 class LLMBackend(abc.ABC):
     """
@@ -28,6 +31,7 @@ class LLMBackend(abc.ABC):
         key_name: str,
         api_key: str,
         project: str | None = None,
+        prompt_redactor: "APIKeyRedactor" | None = None,
     ) -> Union[StreamingResponse, Dict[str, Any]]:
         """
         Forwards a chat completion request to the LLM backend.
@@ -42,6 +46,7 @@ class LLMBackend(abc.ABC):
                                          required for OpenRouter API. (Needs generalization)
             key_name: The environment variable name of the API key in use.
             api_key: The secret value of the API key.
+            prompt_redactor: Optional APIKeyRedactor used to sanitize messages.
 
         Returns:
             A StreamingResponse if the request is for a stream, or a dictionary

--- a/src/security.py
+++ b/src/security.py
@@ -1,0 +1,20 @@
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+class APIKeyRedactor:
+    """Redact known API keys from user provided prompts."""
+
+    def __init__(self, api_keys: Iterable[str] | None = None) -> None:
+        # filter out falsy values
+        self.api_keys = [k for k in (api_keys or []) if k]
+
+    def redact(self, text: str) -> str:
+        """Replace any occurrences of known API keys in *text*."""
+        redacted_text = text
+        for key in self.api_keys:
+            if key and key in redacted_text:
+                logger.warning("API key detected in prompt. Redacting before forwarding.")
+                redacted_text = redacted_text.replace(key, "(API_KEY_HAS_BEEN_REDACTED)")
+        return redacted_text

--- a/tests/unit/openrouter_connector_tests/test_redaction.py
+++ b/tests/unit/openrouter_connector_tests/test_redaction.py
@@ -1,0 +1,46 @@
+import json
+import pytest
+import httpx
+import pytest_asyncio
+from pytest_httpx import HTTPXMock
+
+import src.models as models
+from src.connectors.openrouter import OpenRouterBackend
+from src.security import APIKeyRedactor
+
+TEST_OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1"
+
+def mock_get_openrouter_headers(key_name: str, api_key: str):
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "http://localhost:test",
+        "X-Title": "TestProxy",
+    }
+
+@pytest_asyncio.fixture(name="openrouter_backend")
+async def openrouter_backend_fixture():
+    async with httpx.AsyncClient() as client:
+        yield OpenRouterBackend(client=client)
+
+@pytest.fixture
+def sample_request() -> models.ChatCompletionRequest:
+    return models.ChatCompletionRequest(model="m", messages=[models.ChatMessage(role="user", content="leak SECRET")])
+
+@pytest.mark.asyncio
+async def test_prompt_redaction(openrouter_backend: OpenRouterBackend, httpx_mock: HTTPXMock, sample_request: models.ChatCompletionRequest):
+    httpx_mock.add_response(status_code=200, json={"choices": [{"message": {"content": "ok"}}]})
+    redactor = APIKeyRedactor(["SECRET"])
+    await openrouter_backend.chat_completions(
+        request_data=sample_request,
+        processed_messages=sample_request.messages,
+        effective_model="model",
+        openrouter_api_base_url=TEST_OPENROUTER_API_BASE_URL,
+        openrouter_headers_provider=mock_get_openrouter_headers,
+        key_name="OPENROUTER_API_KEY_1",
+        api_key="FAKE",
+        prompt_redactor=redactor,
+    )
+    request = httpx_mock.get_request()
+    payload = json.loads(request.content)
+    assert payload["messages"][0]["content"] == "leak (API_KEY_HAS_BEEN_REDACTED)"

--- a/tests/unit/test_prompt_redaction.py
+++ b/tests/unit/test_prompt_redaction.py
@@ -1,0 +1,10 @@
+import logging
+from src.security import APIKeyRedactor
+
+
+def test_redactor_replaces_keys_and_logs(caplog):
+    redactor = APIKeyRedactor(["SECRET"])
+    with caplog.at_level(logging.WARNING):
+        result = redactor.redact("my SECRET key")
+    assert result == "my (API_KEY_HAS_BEEN_REDACTED) key"
+    assert any("API key detected" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `APIKeyRedactor` utility for prompt sanitisation
- integrate redactor in main application and backend connectors
- redact prompts in OpenRouter and Gemini connectors
- test the redaction logic and usage in OpenRouter backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416daffa708333a7bc919851faeb0b