### PR TITLE
Remove stray prints and ensure logging

### DIFF
--- a/dev/test_client.py
+++ b/dev/test_client.py
@@ -1,9 +1,12 @@
 import argparse
 import json
+import logging
 import os
 from typing import List, Dict, Any
 
 import openai
+
+logger = logging.getLogger(__name__)
 
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), 'output')
 
@@ -50,6 +53,8 @@ def main() -> None:
 
     client = openai.OpenAI(api_key=api_key, base_url=api_base)
 
+    logging.basicConfig(level=logging.INFO)
+
     results = run_prompts(client, model, prompts)
 
     if args.output:
@@ -60,7 +65,7 @@ def main() -> None:
                 f.write(line + '\n')
     else:
         for line in results:
-            print(line)
+            logger.info(line)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_no_prints.py
+++ b/tests/unit/test_no_prints.py
@@ -1,0 +1,20 @@
+import ast
+import pathlib
+
+ALLOWED_FILES = {
+    pathlib.Path('src/main.py'),
+}
+
+
+def test_no_print_statements():
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    for path in repo_root.rglob('*.py'):
+        if 'tests' in path.parts:
+            continue
+        if path in ALLOWED_FILES:
+            continue
+        source = path.read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == 'print':
+                raise AssertionError(f"print() found in {path} at line {node.lineno}")

--- a/tests/unit/test_no_prints.py
+++ b/tests/unit/test_no_prints.py
@@ -9,12 +9,19 @@ ALLOWED_FILES = {
 def test_no_print_statements():
     repo_root = pathlib.Path(__file__).resolve().parents[2]
     for path in repo_root.rglob('*.py'):
-        if 'tests' in path.parts:
+        if 'tests' in path.parts or '.venv' in path.parts or 'site-packages' in path.parts:
             continue
         if path in ALLOWED_FILES:
             continue
-        source = path.read_text()
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == 'print':
-                raise AssertionError(f"print() found in {path} at line {node.lineno}")
+        if not path.is_file(): # Ensure it's a file, not a directory or symlink
+            continue
+        try:
+            source = path.read_text()
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == 'print':
+                    raise AssertionError(f"print() found in {path} at line {node.lineno}")
+        except (SyntaxError, ValueError) as e:
+            # Log a warning or just skip if the file is not valid Python
+            print(f"Skipping {path} due to parsing error: {e}") # Using print here for debugging the test itself
+            continue


### PR DESCRIPTION
## Summary
- switch `dev/test_client.py` to use logging instead of `print`
- add a regression test that asserts no `print()` calls exist outside of the allowed CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684171d059d883338fd13da3d2e58de2