### PR TITLE
Implement configurable interactive mode

### DIFF
--- a/src/proxy_logic.py
+++ b/src/proxy_logic.py
@@ -7,9 +7,10 @@ logger = logging.getLogger(__name__)
 class ProxyState:
     """Manages the state of the proxy, particularly model overrides."""
 
-    def __init__(self) -> None:
+    def __init__(self, interactive_mode: bool = False) -> None:
         self.override_model: Optional[str] = None
         self.project: Optional[str] = None
+        self.interactive_mode: bool = interactive_mode
 
     def set_override_model(self, model_name: str) -> None:
         logger.info(f"Setting override model to: {model_name}")
@@ -27,10 +28,19 @@ class ProxyState:
         logger.info("Unsetting project.")
         self.project = None
 
+    def set_interactive_mode(self, value: bool) -> None:
+        logger.info(f"Setting interactive mode to: {value}")
+        self.interactive_mode = value
+
+    def unset_interactive_mode(self) -> None:
+        logger.info("Unsetting interactive mode (setting to False).")
+        self.interactive_mode = False
+
     def reset(self) -> None:
         logger.info("Resetting ProxyState instance.")
         self.override_model = None
         self.project = None
+        self.interactive_mode = False
 
     def get_effective_model(self, requested_model: str) -> str:
         if self.override_model:

--- a/src/session.py
+++ b/src/session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Dict, Optional, Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .proxy_logic import ProxyState
 import src.models as models
@@ -27,8 +27,8 @@ class Session(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     session_id: str
-    proxy_state: ProxyState = ProxyState()
-    history: List[SessionInteraction] = []
+    proxy_state: ProxyState
+    history: List[SessionInteraction] = Field(default_factory=list)
 
     def add_interaction(self, interaction: SessionInteraction) -> None:
         self.history.append(interaction)
@@ -37,10 +37,14 @@ class Session(BaseModel):
 class SessionManager:
     """Manages Session instances keyed by session_id."""
 
-    def __init__(self) -> None:
+    def __init__(self, default_interactive_mode: bool = False) -> None:
         self.sessions: Dict[str, Session] = {}
+        self.default_interactive_mode = default_interactive_mode
 
     def get_session(self, session_id: str) -> Session:
         if session_id not in self.sessions:
-            self.sessions[session_id] = Session(session_id=session_id)
+            self.sessions[session_id] = Session(
+                session_id=session_id,
+                proxy_state=ProxyState(interactive_mode=self.default_interactive_mode),
+            )
         return self.sessions[session_id]

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -154,3 +154,22 @@ class TestProcessTextForCommands:
         assert commands_found
         assert current_proxy_state.override_model is None
         assert current_proxy_state.project is None
+
+    def test_set_interactive_mode(self):
+        current_proxy_state = ProxyState()
+        pattern = get_command_pattern("!/")
+        text = "hello !/set(interactive-mode=ON)"
+        processed_text, found = _process_text_for_commands(text, current_proxy_state, pattern)
+        assert processed_text == "hello"
+        assert found
+        assert current_proxy_state.interactive_mode is True
+
+    def test_unset_interactive_mode(self):
+        current_proxy_state = ProxyState(interactive_mode=True)
+        pattern = get_command_pattern("!/")
+        text = "!/unset(interactive)"
+        processed_text, found = _process_text_for_commands(text, current_proxy_state, pattern)
+        assert processed_text == ""
+        assert found
+        assert current_proxy_state.interactive_mode is False
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -27,6 +27,23 @@ def test_apply_cli_args_sets_env(monkeypatch):
     assert cfg["gemini_api_keys"] == {"GEMINI_API_KEY": "TESTKEY"}
     assert cfg["proxy_port"] == 1234
     assert cfg["command_prefix"] == "$/"
+    # cleanup environment variables set by apply_cli_args
+    monkeypatch.delenv("LLM_BACKEND", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("PROXY_PORT", raising=False)
+    monkeypatch.delenv("COMMAND_PREFIX", raising=False)
+
+
+def test_cli_interactive_mode(monkeypatch):
+    monkeypatch.delenv("INTERACTIVE_MODE", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    args = app_main.parse_cli_args(["--interactive-mode"])
+    cfg = app_main.apply_cli_args(args)
+    assert os.environ["INTERACTIVE_MODE"] == "True"
+    assert cfg["interactive_mode"] is True
+    monkeypatch.delenv("INTERACTIVE_MODE", raising=False)
 
 
 def test_build_app_uses_env(monkeypatch):
@@ -43,3 +60,18 @@ def test_build_app_uses_env(monkeypatch):
         assert client.app.state.backend_type == "gemini"
         assert hasattr(client.app.state, "gemini_backend")
         assert client.app.state.command_prefix == "??/"
+
+
+def test_build_app_uses_interactive_env(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    monkeypatch.setenv("INTERACTIVE_MODE", "true")
+    app = app_main.build_app()
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        session = client.app.state.session_manager.get_session("s1")  # type: ignore
+        assert session.proxy_state.interactive_mode is True
+
+

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -1,0 +1,14 @@
+from src.session import SessionManager
+
+
+def test_session_manager_default_interactive():
+    mgr = SessionManager(default_interactive_mode=True)
+    session = mgr.get_session("x")
+    assert session.proxy_state.interactive_mode is True
+
+
+def test_session_manager_default_non_interactive():
+    mgr = SessionManager()
+    session = mgr.get_session("y")
+    assert session.proxy_state.interactive_mode is False
+


### PR DESCRIPTION
## Summary
- add server-wide interactive mode defaults via CLI `--interactive-mode`
- expose interactive mode in configuration and session manager
- extend `ProxyState` and `CommandParser` with interactive mode support
- allow commands `!/set(interactive-mode=<value>)`, `!/set(interactive=<value>)`, `!/unset(interactive)`
- add unit tests for new behaviour

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684173d55a4483339a41ce61d95bb2e6