### PR TITLE
Handle interactive welcome banner

### DIFF
--- a/src/proxy_logic.py
+++ b/src/proxy_logic.py
@@ -11,6 +11,8 @@ class ProxyState:
         self.override_model: Optional[str] = None
         self.project: Optional[str] = None
         self.interactive_mode: bool = interactive_mode
+        self.interactive_just_enabled: bool = False
+        self.hello_requested: bool = False
 
     def set_override_model(self, model_name: str) -> None:
         logger.info(f"Setting override model to: {model_name}")
@@ -30,17 +32,24 @@ class ProxyState:
 
     def set_interactive_mode(self, value: bool) -> None:
         logger.info(f"Setting interactive mode to: {value}")
+        if value and not self.interactive_mode:
+            self.interactive_just_enabled = True
+        else:
+            self.interactive_just_enabled = False
         self.interactive_mode = value
 
     def unset_interactive_mode(self) -> None:
         logger.info("Unsetting interactive mode (setting to False).")
         self.interactive_mode = False
+        self.interactive_just_enabled = False
 
     def reset(self) -> None:
         logger.info("Resetting ProxyState instance.")
         self.override_model = None
         self.project = None
         self.interactive_mode = False
+        self.interactive_just_enabled = False
+        self.hello_requested = False
 
     def get_effective_model(self, requested_model: str) -> str:
         if self.override_model:

--- a/tests/integration/chat_completions_tests/test_interactive_banner.py
+++ b/tests/integration/chat_completions_tests/test_interactive_banner.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.session import SessionManager
+
+
+@pytest.fixture
+def interactive_client():
+    with TestClient(app) as c:
+        c.app.state.session_manager = SessionManager(default_interactive_mode=True)  # type: ignore
+        yield c
+
+
+def test_banner_on_first_reply(interactive_client: TestClient):
+    mock_backend_response = {"choices": [{"message": {"content": "backend"}}]}
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_backend_response
+        payload = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+        resp = interactive_client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200
+    content = resp.json()["choices"][0]["message"]["content"]
+    assert "Hello, this is" in content
+    assert "Session id" in content
+    assert "backend" in content
+    mock_method.assert_called_once()
+
+
+def test_hello_command_returns_banner(interactive_client: TestClient):
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        payload = {"model": "m", "messages": [{"role": "user", "content": "!/hello"}]}
+        resp = interactive_client.post("/v1/chat/completions", json=payload)
+        mock_method.assert_not_called()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "proxy_cmd_processed"
+    assert "Hello, this is" in data["choices"][0]["message"]["content"]

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -173,3 +173,21 @@ class TestProcessTextForCommands:
         assert found
         assert current_proxy_state.interactive_mode is False
 
+    def test_hello_command(self):
+        current_proxy_state = ProxyState()
+        pattern = get_command_pattern("!/")
+        text = "!/hello"
+        processed_text, found = _process_text_for_commands(text, current_proxy_state, pattern)
+        assert processed_text == ""
+        assert found
+        assert current_proxy_state.hello_requested is True
+
+    def test_hello_command_with_text(self):
+        current_proxy_state = ProxyState()
+        pattern = get_command_pattern("!/")
+        text = "Greetings !/hello friend"
+        processed_text, found = _process_text_for_commands(text, current_proxy_state, pattern)
+        assert processed_text == "Greetings friend"
+        assert found
+        assert current_proxy_state.hello_requested is True
+


### PR DESCRIPTION
## Summary
- extend `ProxyState` to track interactive state and hello command
- parse `!/hello` and output interactive banner
- implement banner injection logic in API responses
- add integration tests for banner behavior
- ensure command parser handles hello command

## Testing
- `pip install -e .`
- `pip install pytest_httpx pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417c8158488333ac9b2938beffdb77