### PR TITLE
Implement backend rate limit tracking

### DIFF
--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple, Optional
+import time
+import json
+
+class RateLimitRegistry:
+    """Tracks when a backend/model/key combination can be retried."""
+
+    def __init__(self) -> None:
+        self._until: Dict[Tuple[str, str, str], float] = {}
+
+    def set(self, backend: str, model: str | None, key_name: str, delay_seconds: float) -> None:
+        self._until[(backend, model or "", key_name)] = time.time() + delay_seconds
+
+    def get(self, backend: str, model: str | None, key_name: str) -> Optional[float]:
+        key = (backend, model or "", key_name)
+        ts = self._until.get(key)
+        if ts is None:
+            return None
+        if time.time() >= ts:
+            del self._until[key]
+            return None
+        return ts
+
+
+def parse_retry_delay(detail: object) -> Optional[float]:
+    """Parse retry delay (seconds) from backend 429 error details."""
+    data: object = detail
+    if isinstance(detail, str):
+        try:
+            data = json.loads(detail)
+        except Exception:
+            return None
+    if isinstance(data, dict):
+        err = data.get("error", data)
+        details = err.get("details") if isinstance(err, dict) else None
+        if isinstance(details, list):
+            for item in details:
+                if isinstance(item, dict) and item.get("@type", "").endswith("RetryInfo"):
+                    delay = item.get("retryDelay")
+                    if isinstance(delay, str) and delay.endswith("s"):
+                        try:
+                            return float(delay[:-1])
+                        except ValueError:
+                            pass
+    return None

--- a/tests/integration/chat_completions_tests/test_rate_limiting.py
+++ b/tests/integration/chat_completions_tests/test_rate_limiting.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+
+from src import main as app_main
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("LLM_BACKEND", "gemini")
+    monkeypatch.setenv("GEMINI_API_KEY", "KEY")
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    test_app = app_main.build_app()
+    with TestClient(test_app) as c:
+        yield c
+
+def test_rate_limit_memory(client: TestClient):
+    error_detail = {
+        "error": {
+            "code": 429,
+            "message": "quota exceeded",
+            "status": "RESOURCE_EXHAUSTED",
+            "details": [
+                {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "1s"}
+            ],
+        }
+    }
+
+    async def raise_429(*args, **kwargs):
+        raise HTTPException(status_code=429, detail=error_detail)
+
+    with patch.object(client.app.state.gemini_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.side_effect = raise_429
+        payload = {"model": "gemini-1", "messages": [{"role": "user", "content": "hi"}]}
+        r1 = client.post("/v1/chat/completions", json=payload)
+        assert r1.status_code == 429
+        r2 = client.post("/v1/chat/completions", json=payload)
+        assert r2.status_code == 429
+        assert mock_method.call_count == 1


### PR DESCRIPTION
## Summary
- track per-backend/model API rate limits
- refuse requests locally while waiting for retry
- fallback to env vars for API keys each request
- test new rate limit behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684195b1b83c83338ab54c309561629d