### PR TITLE
Improve interactive command handling

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any, List
+
+from .proxy_logic import ProxyState
+
+
+@dataclass
+class CommandResult:
+    name: str
+    success: bool
+    message: str
+
+
+class BaseCommand:
+    name: str
+
+    def execute(self, args: Dict[str, Any], state: ProxyState) -> CommandResult:
+        raise NotImplementedError
+
+
+class SetCommand(BaseCommand):
+    name = "set"
+
+    def _parse_bool(self, value: str) -> bool | None:
+        val = value.strip().lower()
+        if val in ("true", "1", "yes", "on"):
+            return True
+        if val in ("false", "0", "no", "off", "none"):
+            return False
+        return None
+
+    def execute(self, args: Dict[str, Any], state: ProxyState) -> CommandResult:
+        messages: List[str] = []
+        handled = False
+        if isinstance(args.get("model"), str):
+            state.set_override_model(args["model"])
+            handled = True
+            messages.append(f"model set to {args['model']}")
+        if isinstance(args.get("project"), str):
+            state.set_project(args["project"])
+            handled = True
+            messages.append(f"project set to {args['project']}")
+        for key in ("interactive", "interactive-mode"):
+            if isinstance(args.get(key), str):
+                val = self._parse_bool(args[key])
+                if val is not None:
+                    state.set_interactive_mode(val)
+                    handled = True
+                    messages.append(f"interactive mode set to {val}")
+        if not handled:
+            return CommandResult(self.name, False, "set: no valid parameters")
+        return CommandResult(self.name, True, "; ".join(messages))
+
+
+class UnsetCommand(BaseCommand):
+    name = "unset"
+
+    def execute(self, args: Dict[str, Any], state: ProxyState) -> CommandResult:
+        messages: List[str] = []
+        keys_to_unset = [k for k, v in args.items() if v is True]
+        if "model" in keys_to_unset:
+            state.unset_override_model()
+            messages.append("model unset")
+        if "project" in keys_to_unset:
+            state.unset_project()
+            messages.append("project unset")
+        if any(k in keys_to_unset for k in ("interactive", "interactive-mode")):
+            state.unset_interactive_mode()
+            messages.append("interactive mode unset")
+        if not keys_to_unset or not messages:
+            return CommandResult(self.name, False, "unset: nothing to do")
+        return CommandResult(self.name, True, "; ".join(messages))
+
+
+class HelloCommand(BaseCommand):
+    name = "hello"
+
+    def execute(self, args: Dict[str, Any], state: ProxyState) -> CommandResult:
+        state.hello_requested = True
+        return CommandResult(self.name, True, "hello acknowledged")

--- a/tests/integration/chat_completions_tests/test_command_only_requests.py
+++ b/tests/integration/chat_completions_tests/test_command_only_requests.py
@@ -26,7 +26,7 @@ def test_command_only_request_direct_response(client: TestClient):
     assert response.status_code == 200
     response_json = response.json()
     assert response_json["id"] == "proxy_cmd_processed"
-    assert "Proxy command processed" in response_json["choices"][0]["message"]["content"]
+    assert "model set to command-only-model" in response_json["choices"][0]["message"]["content"]
     assert response_json["model"] == "command-only-model"
 
     # The backend's chat_completions method should not be called in this scenario

--- a/tests/integration/chat_completions_tests/test_interactive_commands.py
+++ b/tests/integration/chat_completions_tests/test_interactive_commands.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.session import SessionManager
+
+@pytest.fixture
+def interactive_client():
+    with TestClient(app) as c:
+        c.app.state.session_manager = SessionManager(default_interactive_mode=True)  # type: ignore
+        yield c
+
+def test_unknown_command_error(interactive_client: TestClient):
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        payload = {"model": "m", "messages": [{"role": "user", "content": "!/bad()"}]}
+        resp = interactive_client.post("/v1/chat/completions", json=payload)
+        mock_method.assert_not_called()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "proxy_cmd_processed"
+    assert "unknown command" in data["choices"][0]["message"]["content"].lower()
+
+def test_set_command_confirmation(interactive_client: TestClient):
+    mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_backend_response
+        payload = {"model": "m", "messages": [{"role": "user", "content": "hello !/set(model=foo)"}]}
+        resp = interactive_client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200
+    content = resp.json()["choices"][0]["message"]["content"]
+    assert "model set to foo" in content
+    assert "ok" in content
+

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -3,6 +3,7 @@ from src.proxy_logic import (
     _process_text_for_commands,
     ProxyState,
     get_command_pattern,
+    CommandParser,
 )
 
 class TestProcessTextForCommands:
@@ -190,4 +191,14 @@ class TestProcessTextForCommands:
         assert processed_text == "Greetings friend"
         assert found
         assert current_proxy_state.hello_requested is True
+
+    def test_unknown_command_removed_interactive(self):
+        state = ProxyState(interactive_mode=True)
+        parser = CommandParser(state, command_prefix="!/", preserve_unknown=False)
+        text = "Hi !/foo(bar=1)"
+        processed, found = parser.process_text(text)
+        assert found
+        assert processed == "Hi"
+        assert parser.results[0].success is False
+        assert "unknown command" in parser.results[0].message
 


### PR DESCRIPTION
## Summary
- add new commands module with command classes and results
- update `CommandParser` to use command objects and collect command results
- enhance interactive session logic in `main` to display confirmations
- handle unknown commands when interactive mode is on
- add new unit and integration tests for interactive command confirmations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197fa147883338068bf322b0037e3