### PR TITLE
Add backend model discovery on startup

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -17,6 +17,28 @@ class GeminiBackend(LLMBackend):
 
     def __init__(self, client: httpx.AsyncClient) -> None:
         self.client = client
+        self.available_models: list[str] = []
+
+    async def initialize(
+        self,
+        *,
+        gemini_api_base_url: str,
+        key_name: str,
+        api_key: str,
+    ) -> None:
+        """Fetch available models and cache them."""
+        data = await self.list_models(
+            gemini_api_base_url=gemini_api_base_url,
+            key_name=key_name,
+            api_key=api_key,
+        )
+        self.available_models = [
+            m.get("name") for m in data.get("models", []) if m.get("name")
+        ]
+
+    def get_available_models(self) -> list[str]:
+        """Return cached Gemini model names."""
+        return list(self.available_models)
 
     async def chat_completions(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from unittest.mock import AsyncMock
+from src.connectors import OpenRouterBackend, GeminiBackend
+
+@pytest.fixture(autouse=True)
+def patch_backend_discovery(monkeypatch):
+    monkeypatch.setattr(
+        OpenRouterBackend,
+        "list_models",
+        AsyncMock(return_value={"data": [{"id": "model-a"}]}),
+    )
+    monkeypatch.setattr(
+        GeminiBackend,
+        "list_models",
+        AsyncMock(return_value={"models": [{"name": "model-a"}]}),
+    )
+    yield

--- a/tests/unit/test_model_discovery.py
+++ b/tests/unit/test_model_discovery.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from src import main as app_main
+from src.connectors import OpenRouterBackend, GeminiBackend
+
+
+def test_openrouter_models_cached(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "KEY")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"OPENROUTER_API_KEY_{i}", raising=False)
+    response = {"data": [{"id": "m1"}, {"id": "m2"}]}
+    with patch.object(OpenRouterBackend, "list_models", new=AsyncMock(return_value=response)) as mock_list:
+        app = app_main.build_app()
+        with TestClient(app) as client:
+            assert client.app.state.openrouter_backend.get_available_models() == ["m1", "m2"]
+            mock_list.assert_awaited_once()
+
+
+def test_gemini_models_cached(monkeypatch):
+    monkeypatch.setenv("LLM_BACKEND", "gemini")
+    monkeypatch.setenv("GEMINI_API_KEY", "KEY")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"OPENROUTER_API_KEY_{i}", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    response = {"models": [{"name": "g1"}]}
+    with patch.object(GeminiBackend, "list_models", new=AsyncMock(return_value=response)) as mock_list:
+        app = app_main.build_app()
+        from fastapi.testclient import TestClient
+        with TestClient(app) as client:
+            assert client.app.state.gemini_backend.get_available_models() == ["g1"]
+            mock_list.assert_awaited_once()


### PR DESCRIPTION
## Summary
- backends now keep a cached list of models
- initialize backends during FastAPI lifespan to fetch available models
- expose `get_available_models` on backends
- patch tests to avoid network calls and add unit tests for model discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a07ede88833398e3181b08926f2b