### PR TITLE
Support backend-specific model routing

### DIFF
--- a/src/proxy_logic.py
+++ b/src/proxy_logic.py
@@ -8,19 +8,29 @@ class ProxyState:
     """Manages the state of the proxy, particularly model overrides."""
 
     def __init__(self, interactive_mode: bool = False) -> None:
+        self.override_backend: Optional[str] = None
         self.override_model: Optional[str] = None
+        self.invalid_override: bool = False
         self.project: Optional[str] = None
         self.interactive_mode: bool = interactive_mode
         self.interactive_just_enabled: bool = False
         self.hello_requested: bool = False
 
-    def set_override_model(self, model_name: str) -> None:
-        logger.info(f"Setting override model to: {model_name}")
+    def set_override_model(
+        self, backend: str, model_name: str, *, invalid: bool = False
+    ) -> None:
+        logger.info(
+            f"Setting override model to: {backend}:{model_name} (invalid={invalid})"
+        )
+        self.override_backend = backend
         self.override_model = model_name
+        self.invalid_override = invalid
 
     def unset_override_model(self) -> None:
         logger.info("Unsetting override model.")
+        self.override_backend = None
         self.override_model = None
+        self.invalid_override = False
 
     def set_project(self, project_name: str) -> None:
         logger.info(f"Setting project to: {project_name}")
@@ -45,7 +55,9 @@ class ProxyState:
 
     def reset(self) -> None:
         logger.info("Resetting ProxyState instance.")
+        self.override_backend = None
         self.override_model = None
+        self.invalid_override = False
         self.project = None
         self.interactive_mode = False
         self.interactive_just_enabled = False
@@ -58,6 +70,9 @@ class ProxyState:
             )
             return self.override_model
         return requested_model
+
+    def get_selected_backend(self, default_backend: str) -> str:
+        return self.override_backend or default_backend
 
 
 # Re-export command parsing helpers from the dedicated module for backward compatibility

--- a/tests/integration/chat_completions_tests/test_command_only_requests.py
+++ b/tests/integration/chat_completions_tests/test_command_only_requests.py
@@ -17,16 +17,17 @@ def client():
         yield c
 
 def test_command_only_request_direct_response(client: TestClient):
+    client.app.state.openrouter_backend.available_models = ["command-only-model"]
     payload = {
         "model": "some-model",
-        "messages": [{"role": "user", "content": "!/set(model=command-only-model)"}]
+        "messages": [{"role": "user", "content": "!/set(model=openrouter:command-only-model)"}]
     }
     response = client.post("/v1/chat/completions", json=payload)
 
     assert response.status_code == 200
     response_json = response.json()
     assert response_json["id"] == "proxy_cmd_processed"
-    assert "model set to command-only-model" in response_json["choices"][0]["message"]["content"]
+    assert "model set to openrouter:command-only-model" in response_json["choices"][0]["message"]["content"]
     assert response_json["model"] == "command-only-model"
 
     # The backend's chat_completions method should not be called in this scenario

--- a/tests/integration/chat_completions_tests/test_interactive_commands.py
+++ b/tests/integration/chat_completions_tests/test_interactive_commands.py
@@ -25,10 +25,11 @@ def test_set_command_confirmation(interactive_client: TestClient):
     mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
     with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
         mock_method.return_value = mock_backend_response
-        payload = {"model": "m", "messages": [{"role": "user", "content": "hello !/set(model=foo)"}]}
+        interactive_client.app.state.openrouter_backend.available_models = ["foo"]
+        payload = {"model": "m", "messages": [{"role": "user", "content": "hello !/set(model=openrouter:foo)"}]}
         resp = interactive_client.post("/v1/chat/completions", json=payload)
     assert resp.status_code == 200
     content = resp.json()["choices"][0]["message"]["content"]
-    assert "model set to foo" in content
+    assert "model set to openrouter:foo" in content
     assert "ok" in content
 

--- a/tests/integration/chat_completions_tests/test_model_commands.py
+++ b/tests/integration/chat_completions_tests/test_model_commands.py
@@ -24,9 +24,10 @@ def test_set_model_command_integration(client: TestClient):
     with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
         mock_method.return_value = mock_backend_response
 
+        client.app.state.openrouter_backend.available_models = ["override-model"]
         payload = {
             "model": "original-model",
-            "messages": [{"role": "user", "content": "Use this: !/set(model=override-model) Hello"}]
+            "messages": [{"role": "user", "content": "Use this: !/set(model=openrouter:override-model) Hello"}]
         }
         response = client.post("/v1/chat/completions", json=payload)
 
@@ -44,13 +45,14 @@ def test_set_model_command_integration(client: TestClient):
 
 def test_unset_model_command_integration(client: TestClient):
     # Access proxy_state from the app state within the test client
-    client.app.state.session_manager.get_session("default").proxy_state.set_override_model("initial-override")  # type: ignore
+    client.app.state.session_manager.get_session("default").proxy_state.set_override_model("openrouter", "initial-override")  # type: ignore
 
     mock_backend_response = {"choices": [{"message": {"content": "Model unset and called."}}]}
 
     with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
         mock_method.return_value = mock_backend_response
 
+        client.app.state.openrouter_backend.available_models = ["another-model"]
         payload = {
             "model": "another-model",
             "messages": [{"role": "user", "content": "Please !/unset(model) use default."}]

--- a/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
+++ b/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
@@ -11,7 +11,7 @@ class TestProcessCommandsInMessages:
         current_proxy_state = ProxyState()
         messages = [
             models.ChatMessage(role="user", content="Hello"),
-            models.ChatMessage(role="user", content="Please use !/set(model=new-model) for this query.")
+            models.ChatMessage(role="user", content="Please use !/set(model=openrouter:new-model) for this query.")
         ]
         processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
         assert processed
@@ -45,7 +45,7 @@ class TestProcessCommandsInMessages:
         current_proxy_state = ProxyState()
         messages = [
             models.ChatMessage(role="user", content=[
-                models.MessageContentPartText(type="text", text="!/set(model=text-only)"),
+                models.MessageContentPartText(type="text", text="!/set(model=openrouter:text-only)"),
                 models.MessageContentPartImage(type="image_url", image_url=models.ImageURL(url="fake.jpg", detail=None))
             ])
         ]
@@ -63,7 +63,7 @@ class TestProcessCommandsInMessages:
         current_proxy_state = ProxyState()
         messages = [
             models.ChatMessage(role="user", content=[
-                models.MessageContentPartText(type="text", text="!/set(model=empty-message-model)")
+                models.MessageContentPartText(type="text", text="!/set(model=openrouter:empty-message-model)")
             ])
         ]
         processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
@@ -75,13 +75,13 @@ class TestProcessCommandsInMessages:
         current_proxy_state = ProxyState()
         current_proxy_state.override_model = "initial-model"
         messages = [
-            models.ChatMessage(role="user", content="First message !/set(model=first-try)"),
-            models.ChatMessage(role="user", content="Second message !/set(model=second-try)")
+            models.ChatMessage(role="user", content="First message !/set(model=openrouter:first-try)"),
+            models.ChatMessage(role="user", content="Second message !/set(model=openrouter:second-try)")
         ]
         processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
         assert processed
         assert len(processed_messages) == 2
-        assert processed_messages[0].content == "First message !/set(model=first-try)"
+        assert processed_messages[0].content == "First message !/set(model=openrouter:first-try)"
         assert processed_messages[1].content == "Second message"
         assert current_proxy_state.override_model == "second-try"
 
@@ -89,7 +89,7 @@ class TestProcessCommandsInMessages:
         current_proxy_state = ProxyState()
         current_proxy_state.override_model = "initial-model"
         messages = [
-            models.ChatMessage(role="user", content="First message with !/set(model=model-from-past)"),
+            models.ChatMessage(role="user", content="First message with !/set(model=openrouter:model-from-past)"),
             models.ChatMessage(role="user", content="Second message, plain text.")
         ]
         processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
@@ -121,7 +121,7 @@ class TestProcessCommandsInMessages:
     def test_message_with_only_command_string_content(self):
         current_proxy_state = ProxyState()
         messages = [
-            models.ChatMessage(role="user", content="!/set(model=full-command-message)")
+            models.ChatMessage(role="user", content="!/set(model=openrouter:full-command-message)")
         ]
         processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
         assert processed
@@ -164,7 +164,7 @@ class TestProcessCommandsInMessages:
     def test_custom_command_prefix(self):
         current_proxy_state = ProxyState()
         messages = [
-            models.ChatMessage(role="user", content="Hello $$set(model=foo)")
+            models.ChatMessage(role="user", content="Hello $$set(model=openrouter:foo)")
         ]
         processed_messages, processed = process_commands_in_messages(
             messages,
@@ -180,7 +180,7 @@ class TestProcessCommandsInMessages:
         messages = [
             models.ChatMessage(
                 role="user",
-                content="Line1\n!/set(model=multi)\nLine3",
+                content="Line1\n!/set(model=openrouter:multi)\nLine3",
             )
         ]
         processed_messages, processed = process_commands_in_messages(messages, current_proxy_state)
@@ -200,7 +200,7 @@ class TestProcessCommandsInMessages:
 
     def test_unset_model_and_project_in_message(self):
         current_proxy_state = ProxyState()
-        current_proxy_state.set_override_model("foo")
+        current_proxy_state.set_override_model("openrouter", "foo")
         current_proxy_state.set_project("bar")
         messages = [
             models.ChatMessage(role="user", content="!/unset(model, project)")


### PR DESCRIPTION
## Summary
- require `<backend>:<model>` syntax when setting model
- validate requested model against each backend's discovered models
- track backend and invalid state in `ProxyState`
- route chat completions according to session override backend
- when a model is invalid, interactive sessions show an error and non-interactive sessions store an invalid route that later triggers an HTTP 400 response
- update tests for new model syntax and behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a59ded0c8333a055e157abe752f6