### PR TITLE
Add backend override command

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -68,6 +68,18 @@ class SetCommand(BaseCommand):
                     )
                 state.set_override_model(backend_part, model_name, invalid=True)
                 handled = True
+        if isinstance(args.get("backend"), str):
+            backend_val = args["backend"].strip().lower()
+            if backend_val not in {"openrouter", "gemini"}:
+                if state.interactive_mode:
+                    return CommandResult(
+                        self.name,
+                        False,
+                        f"backend {backend_val} not supported",
+                    )
+            state.set_override_backend(backend_val)
+            handled = True
+            messages.append(f"backend set to {backend_val}")
         if isinstance(args.get("project"), str):
             state.set_project(args["project"])
             handled = True
@@ -93,6 +105,9 @@ class UnsetCommand(BaseCommand):
         if "model" in keys_to_unset:
             state.unset_override_model()
             messages.append("model unset")
+        if "backend" in keys_to_unset:
+            state.unset_override_backend()
+            messages.append("backend unset")
         if "project" in keys_to_unset:
             state.unset_project()
             messages.append("project unset")

--- a/src/main.py
+++ b/src/main.py
@@ -217,6 +217,20 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
         processed_messages, commands_processed = parser.process_messages(
             request_data.messages
         )
+        if proxy_state.override_backend:
+            backend_type = proxy_state.override_backend
+            if backend_type == "openrouter":
+                backend = http_request.app.state.openrouter_backend
+            elif backend_type == "gemini":
+                backend = http_request.app.state.gemini_backend
+            else:
+                raise HTTPException(status_code=400, detail=f"unknown backend {backend_type}")
+        else:
+            backend_type = http_request.app.state.backend_type
+            if backend_type == "gemini":
+                backend = http_request.app.state.gemini_backend
+            else:
+                backend = http_request.app.state.openrouter_backend
         show_banner = False
         if proxy_state.interactive_mode:
             if not session.history:

--- a/src/proxy_logic.py
+++ b/src/proxy_logic.py
@@ -26,8 +26,22 @@ class ProxyState:
         self.override_model = model_name
         self.invalid_override = invalid
 
+    def set_override_backend(self, backend: str) -> None:
+        """Override only the backend to use for this session."""
+        logger.info(f"Setting override backend to: {backend}")
+        self.override_backend = backend
+        self.override_model = None
+        self.invalid_override = False
+
     def unset_override_model(self) -> None:
         logger.info("Unsetting override model.")
+        self.override_backend = None
+        self.override_model = None
+        self.invalid_override = False
+
+    def unset_override_backend(self) -> None:
+        """Remove any backend override."""
+        logger.info("Unsetting override backend.")
         self.override_backend = None
         self.override_model = None
         self.invalid_override = False

--- a/tests/integration/chat_completions_tests/test_backend_commands.py
+++ b/tests/integration/chat_completions_tests/test_backend_commands.py
@@ -1,0 +1,48 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.session import SessionManager
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        c.app.state.session_manager = SessionManager()  # type: ignore
+        yield c
+
+
+def test_set_backend_command_integration(client: TestClient):
+    mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
+    with patch.object(app.state.gemini_backend, 'chat_completions', new_callable=AsyncMock) as gem_mock, \
+         patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as open_mock:
+        gem_mock.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "!/set(backend=gemini) hi"}]
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    gem_mock.assert_called_once()
+    open_mock.assert_not_called()
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.override_backend == "gemini"
+    assert response.json()["choices"][0]["message"]["content"] == "ok"
+
+
+def test_unset_backend_command_integration(client: TestClient):
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    session.proxy_state.set_override_backend("gemini")
+    mock_backend_response = {"choices": [{"message": {"content": "done"}}]}
+    with patch.object(app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as open_mock:
+        open_mock.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "!/unset(backend) hi"}]
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    open_mock.assert_called_once()
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.override_backend is None
+    assert response.json()["choices"][0]["message"]["content"] == "done"

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -219,3 +219,23 @@ class TestProcessTextForCommands:
         assert state.override_model == "bad"
         assert state.invalid_override is True
 
+    def test_set_backend(self):
+        state = ProxyState()
+        pattern = get_command_pattern("!/")
+        text = "!/set(backend=gemini) hi"
+        processed, found = _process_text_for_commands(text, state, pattern)
+        assert found
+        assert processed == "hi"
+        assert state.override_backend == "gemini"
+        assert state.override_model is None
+
+    def test_unset_backend(self):
+        state = ProxyState()
+        state.set_override_backend("gemini")
+        pattern = get_command_pattern("!/")
+        text = "!/unset(backend)"
+        processed, found = _process_text_for_commands(text, state, pattern)
+        assert found
+        assert processed == ""
+        assert state.override_backend is None
+


### PR DESCRIPTION
## Summary
- support `!/set(backend=...)` and `!/unset(backend)` commands
- store backend override in session state
- update request routing to apply backend changes immediately
- confirm backend override in interactive mode
- test backend override behaviour and parser logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ab3726b88333a2a4db10456d0516