### PR TITLE
Detect functional backends at startup

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -70,13 +70,24 @@ class SetCommand(BaseCommand):
                 handled = True
         if isinstance(args.get("backend"), str):
             backend_val = args["backend"].strip().lower()
+            try:
+                from src import main as app_main
+                functional = getattr(app_main.app.state, "functional_backends", {"openrouter", "gemini"})
+            except Exception:
+                functional = {"openrouter", "gemini"}
+
             if backend_val not in {"openrouter", "gemini"}:
-                if state.interactive_mode:
-                    return CommandResult(
-                        self.name,
-                        False,
-                        f"backend {backend_val} not supported",
-                    )
+                return CommandResult(
+                    self.name,
+                    False,
+                    f"backend {backend_val} not supported",
+                )
+            if backend_val not in functional:
+                return CommandResult(
+                    self.name,
+                    False,
+                    f"backend {backend_val} not functional",
+                )
             state.set_override_backend(backend_val)
             handled = True
             messages.append(f"backend set to {backend_val}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,15 @@
+import os
 import pytest
 from unittest.mock import AsyncMock
 from src.connectors import OpenRouterBackend, GeminiBackend
+
+# Ensure external API keys do not interfere with tests
+for i in range(1, 21):
+    os.environ.pop(f"GEMINI_API_KEY_{i}", None)
+    os.environ.pop(f"OPENROUTER_API_KEY_{i}", None)
+os.environ.pop("GEMINI_API_KEY", None)
+os.environ.pop("OPENROUTER_API_KEY", None)
+os.environ.pop("LLM_BACKEND", None)
 
 @pytest.fixture(autouse=True)
 def patch_backend_discovery(monkeypatch):
@@ -14,4 +23,15 @@ def patch_backend_discovery(monkeypatch):
         "list_models",
         AsyncMock(return_value={"models": [{"name": "model-a"}]}),
     )
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv("LLM_BACKEND", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+        monkeypatch.delenv(f"OPENROUTER_API_KEY_{i}", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     yield

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -221,6 +221,8 @@ class TestProcessTextForCommands:
 
     def test_set_backend(self):
         state = ProxyState()
+        from src import main as app_main
+        app_main.app.state.functional_backends = {"openrouter", "gemini"}
         pattern = get_command_pattern("!/")
         text = "!/set(backend=gemini) hi"
         processed, found = _process_text_for_commands(text, state, pattern)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,7 +9,7 @@ def test_apply_cli_args_sets_env(monkeypatch):
         monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
     args = app_main.parse_cli_args(
         [
-            "--backend",
+            "--default-backend",
             "gemini",
             "--gemini-api-key",
             "TESTKEY",

--- a/tests/unit/test_model_discovery.py
+++ b/tests/unit/test_model_discovery.py
@@ -35,3 +35,37 @@ def test_gemini_models_cached(monkeypatch):
         with TestClient(app) as client:
             assert client.app.state.gemini_backend.get_available_models() == ["g1"]
             mock_list.assert_awaited_once()
+
+
+def test_auto_default_backend(monkeypatch):
+    monkeypatch.delenv("LLM_BACKEND", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "KEY")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+        monkeypatch.delenv(f"OPENROUTER_API_KEY_{i}", raising=False)
+    resp = {"data": [{"id": "x"}]}
+    with patch.object(OpenRouterBackend, "list_models", new=AsyncMock(return_value=resp)):
+        app = app_main.build_app()
+        from fastapi.testclient import TestClient
+        with TestClient(app) as client:
+            assert client.app.state.backend_type == "openrouter"
+            assert client.app.state.functional_backends == {"openrouter"}
+
+
+def test_multiple_backends_requires_arg(monkeypatch):
+    monkeypatch.delenv("LLM_BACKEND", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "K1")
+    monkeypatch.setenv("GEMINI_API_KEY", "K2")
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+        monkeypatch.delenv(f"OPENROUTER_API_KEY_{i}", raising=False)
+    resp_or = {"data": [{"id": "x"}]}
+    resp_ge = {"models": [{"name": "g"}]}
+    with patch.object(OpenRouterBackend, "list_models", new=AsyncMock(return_value=resp_or)):
+        with patch.object(GeminiBackend, "list_models", new=AsyncMock(return_value=resp_ge)):
+            app = app_main.build_app()
+            from fastapi.testclient import TestClient
+            with pytest.raises(ValueError):
+                with TestClient(app):
+                    pass


### PR DESCRIPTION
## Summary
- auto-discover functional backends on startup
- require `--default-backend` CLI option when more than one backend works
- allow backend override only when backend implementation is available and functional
- clean environment in tests and extend unit/integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841af74e6e48333943bdb46332a91c6