### PR TITLE
Add Gemini backend end-to-end tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ pytest
 
 Ensure you have installed the development dependencies (`requirements-dev.txt`) before running tests.
 
+Some integration tests communicate with the real Gemini backend. Provide the key at
+runtime using the environment variable `GEMINI_API_KEY_1`. The tests read this variable
+on startup and no API keys are stored in the repository.
+
 ## Usage
 
 Once the proxy server is running, you can configure your OpenAI-compatible client applications to point to the proxy's address (e.g., `http://localhost:8000/v1`) instead of the official OpenAI API base URL.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ import pytest
 from unittest.mock import AsyncMock
 from src.connectors import OpenRouterBackend, GeminiBackend
 
+# Preserve original Gemini API key for integration tests
+ORIG_GEMINI_KEY = os.environ.get("GEMINI_API_KEY_1")
+
 # Ensure external API keys do not interfere with tests
 for i in range(1, 21):
     os.environ.pop(f"GEMINI_API_KEY_{i}", None)

--- a/tests/integration/test_gemini_end_to_end.py
+++ b/tests/integration/test_gemini_end_to_end.py
@@ -1,0 +1,124 @@
+import json
+import os
+import random
+import socket
+import subprocess
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patch_backend_discovery():
+    # Override the autouse fixture from tests.conftest - we want real network calls
+    yield
+
+
+from tests.conftest import ORIG_GEMINI_KEY as ORIG_KEY
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    if ORIG_KEY:
+        monkeypatch.setenv("GEMINI_API_KEY_1", ORIG_KEY)
+    yield
+
+
+def _wait_port(port: int, host: str = "127.0.0.1", timeout: float = 10.0) -> None:
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError("server did not start")
+
+
+def _run_client(cfg_path: str, port: int) -> str:
+    env = os.environ.copy()
+    env.setdefault("OPENAI_API_KEY", "dummy")
+    result = subprocess.run(
+        ["python", os.path.join("dev", "test_client.py"), cfg_path],
+        text=True,
+        env=env,
+        capture_output=True,
+    )
+    return result.stdout + result.stderr
+
+
+def _start_server(port: int) -> subprocess.Popen:
+    env = os.environ.copy()
+    proc = subprocess.Popen(
+        [
+            "uvicorn",
+            "src.main:build_app",
+            "--factory",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "info",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    _wait_port(port)
+    return proc
+
+
+def _stop_server(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+MODEL = "gemini-2.0-flash-lite-preview-02-05"
+
+
+def test_gemini_basic(tmp_path):
+    port = random.randint(8100, 8200)
+    assert os.getenv("GEMINI_API_KEY_1"), "GEMINI_API_KEY_1 missing"
+    server = _start_server(port)
+    try:
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "api_base": f"http://127.0.0.1:{port}/v1",
+                    "model": MODEL,
+                    "prompts": ["Hello"],
+                }
+            )
+        )
+        out = _run_client(str(cfg), port)
+        assert out.strip()
+    finally:
+        _stop_server(server)
+
+
+def test_gemini_interactive_banner(tmp_path):
+    port = random.randint(8201, 8300)
+    assert os.getenv("GEMINI_API_KEY_1"), "GEMINI_API_KEY_1 missing"
+    server = _start_server(port)
+    try:
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "api_base": f"http://127.0.0.1:{port}/v1",
+                    "model": MODEL,
+                    "prompts": ["!/set(interactive=True)", "Hello"],
+                }
+            )
+        )
+        out = _run_client(str(cfg), port)
+        assert "Hello, this is" in out
+    finally:
+        _stop_server(server)
+


### PR DESCRIPTION
## Summary
- extend dev test client to handle Gemini responses
- preserve original Gemini key in `tests/conftest.py`
- add integration tests exercising Gemini backend end-to-end
- document how Gemini API key is provided for integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b76870b48333b14dfce2d136d5c0