### PR TITLE
Fix tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -357,6 +357,13 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
 
         effective_model = proxy_state.get_effective_model(request_data.model)
 
+        if (
+            backend_type == "openrouter"
+            and effective_model.lower().startswith("gemini")
+        ):
+            backend_type = "gemini"
+            backend = http_request.app.state.gemini_backend
+
         async def _call_backend(b_type: str, model: str, key_name: str, api_key: str):
             if b_type == "gemini":
                 retry_at = http_request.app.state.rate_limits.get(


### PR DESCRIPTION
## Summary
- set up tests with explicit config objects rather than env vars
- clean numbered API key environment variables before and after tests
- sync global FastAPI app with configured fixtures
- auto-select Gemini backend for models starting with `gemini`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e29832f08333966fe0740ce7f4c9