### PR TITLE
Improve env var coverage in tests and fix failover routing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -350,7 +350,10 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
             elif policy == "m":
                 for el in elems:
                     b, m = el.split(":", 1)
-                    kname, key = _keys_for(cfg, b)[0] # Pass cfg
+                    keys = _keys_for(cfg, b)
+                    if not keys:
+                        continue
+                    kname, key = keys[0]
                     attempts.append((b, m, kname, key))
             elif policy == "km":
                 for el in elems:


### PR DESCRIPTION
## Summary
- skip invalid backends in failover when no keys available
- test failover behaviour when a backend lacks keys
- extend config tests for many API key combinations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421c36e9c8833397957ad2c5b55f2d