### PR TITLE
Add runtime API key redaction control

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project provides an intercepting proxy server that is compatible with the O
 - **Session History Tracking** – optional per-session logs using the `X-Session-ID` header.
 - **CLI Configuration** – command line flags can override environment variables for quick testing, including interactive mode.
 - **Configurable Interactive Mode** – enable or disable interactive mode by default via environment variable, CLI argument, or in-chat commands.
+- **Prompt API Key Redaction** – redact configured API keys from prompts. Enabled by default; can be turned off via the `--disable-redact-api-keys-in-prompts` CLI flag, environment variable, or commands.
 
 ## Getting Started
 
@@ -54,6 +55,9 @@ These instructions will get you a copy of the project up and running on your loc
     # Gemini backend keys follow the same pattern
     # GEMINI_API_KEY="your_gemini_api_key_here"
     # GEMINI_API_KEY_1="first_gemini_key"
+
+    # Enable or disable prompt redaction (default true)
+    # REDACT_API_KEYS_IN_PROMPTS="false"  # same as passing --disable-redact-api-keys-in-prompts
     ```
 
     Replace `"your_openrouter_api_key_here"` (or numbered variants) with your
@@ -114,6 +118,8 @@ You can embed special commands within your chat messages to control the proxy's 
 - `!/set(interactive=true|false|on|off)`: Enables or disables interactive mode for the current session.
     Example: `!/set(interactive=true)` to enable, `!/set(interactive=off)` to disable.
 - `!/unset(interactive)`: Resets interactive mode to its default setting (configured at startup).
+- `!/set(redact-api-keys-in-prompts=true|false)`: Enable or disable prompt API key redaction for all sessions.
+- `!/unset(redact-api-keys-in-prompts)`: Restore the default redaction behaviour.
 
 The proxy will process these commands, strip them from the message sent to the LLM, and adjust its behavior accordingly.
 

--- a/src/command_parser.py
+++ b/src/command_parser.py
@@ -76,7 +76,7 @@ class CommandParser:
         self.functional_backends = functional_backends or set()
 
         self.register_command(SetCommand(app=self.app, functional_backends=self.functional_backends))
-        self.register_command(UnsetCommand())
+        self.register_command(UnsetCommand(app=self.app))
         self.register_command(HelloCommand())
         self.register_command(CreateFailoverRouteCommand())
         self.register_command(RouteAppendCommand())

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -36,6 +36,12 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Enable interactive mode by default for new sessions",
     )
+    parser.add_argument(
+        "--disable-redact-api-keys-in-prompts",
+        action="store_true",
+        default=None,
+        help="Disable API key redaction in prompts",
+    )
     return parser.parse_args(argv)
 
 
@@ -56,6 +62,8 @@ def apply_cli_args(args: argparse.Namespace) -> Dict[str, Any]:
         value = getattr(args, attr)
         if value is not None:
             os.environ[env_name] = str(value)
+    if getattr(args, "disable_redact_api_keys_in_prompts", None):
+        os.environ["REDACT_API_KEYS_IN_PROMPTS"] = "false"
     return _load_config()
 
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -62,6 +62,9 @@ def _load_config() -> Dict[str, Any]:
         ),
         "command_prefix": os.getenv("COMMAND_PREFIX", DEFAULT_COMMAND_PREFIX),
         "interactive_mode": _str_to_bool(os.getenv("INTERACTIVE_MODE"), False),
+        "redact_api_keys_in_prompts": _str_to_bool(
+            os.getenv("REDACT_API_KEYS_IN_PROMPTS"), True
+        ),
     }
 
 

--- a/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
+++ b/tests/unit/proxy_logic_tests/test_process_text_for_commands.py
@@ -25,7 +25,9 @@ class TestProcessTextForCommands:
         mock_app_state.openrouter_backend = mock_openrouter_backend
         mock_app_state.gemini_backend = mock_gemini_backend
         mock_app_state.functional_backends = {"openrouter", "gemini"} # Add functional backends
-        
+        mock_app_state.default_api_key_redaction_enabled = True
+        mock_app_state.api_key_redaction_enabled = True
+
         self.mock_app = Mock()
         self.mock_app.state = mock_app_state
 
@@ -264,3 +266,25 @@ class TestProcessTextForCommands:
         assert found
         assert processed == ""
         assert state.override_backend is None
+
+    def test_set_redact_api_keys_flag(self):
+        state = ProxyState()
+        pattern = get_command_pattern("!/")
+        text = "!/set(redact-api-keys-in-prompts=false)"
+        processed, found = _process_text_for_commands(text, state, pattern, app=self.mock_app)
+        assert processed == ""
+        assert found
+        assert self.mock_app.state.api_key_redaction_enabled is False
+
+    def test_unset_redact_api_keys_flag(self):
+        state = ProxyState()
+        self.mock_app.state.api_key_redaction_enabled = False
+        pattern = get_command_pattern("!/")
+        text = "!/unset(redact-api-keys-in-prompts)"
+        processed, found = _process_text_for_commands(text, state, pattern, app=self.mock_app)
+        assert processed == ""
+        assert found
+        assert (
+            self.mock_app.state.api_key_redaction_enabled
+            == self.mock_app.state.default_api_key_redaction_enabled
+        )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,6 +38,18 @@ def test_apply_cli_args_sets_env(monkeypatch):
 
 def test_cli_interactive_mode(monkeypatch):
     monkeypatch.delenv("INTERACTIVE_MODE", raising=False)
+
+
+def test_cli_redaction_flag(monkeypatch):
+    monkeypatch.delenv("REDACT_API_KEYS_IN_PROMPTS", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    args = parse_cli_args(["--disable-redact-api-keys-in-prompts"])
+    cfg = apply_cli_args(args)
+    assert os.environ["REDACT_API_KEYS_IN_PROMPTS"] == "false"
+    assert cfg["redact_api_keys_in_prompts"] is False
+    monkeypatch.delenv("REDACT_API_KEYS_IN_PROMPTS", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     for i in range(1, 21):
         monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -105,3 +105,10 @@ def test_openrouter_only(monkeypatch):
     cfg = app_main._load_config()
     assert cfg["gemini_api_keys"] == {}
     assert cfg["openrouter_api_key"] == "O"
+
+
+def test_redaction_env(monkeypatch):
+    monkeypatch.setenv("REDACT_API_KEYS_IN_PROMPTS", "false")
+    cfg = app_main._load_config()
+    assert cfg["redact_api_keys_in_prompts"] is False
+    monkeypatch.delenv("REDACT_API_KEYS_IN_PROMPTS", raising=False)


### PR DESCRIPTION
## Summary
- make API key redaction configurable via config/CLI
- allow runtime control with new `redact-api-keys-in-prompts` set/unset commands
- pass prompt redactor to backends only when enabled
- update README with new feature and commands
- add tests for new config option and commands
- rename CLI flag to `--disable-redact-api-keys-in-prompts`

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b2d8f0248333b2adcb303f17062f