### PR TITLE
Refactor failover routes to be global

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -46,8 +46,10 @@ def build_app(cfg: Dict[str, Any] | None = None) -> FastAPI:
     async def lifespan(app: FastAPI):
         client = httpx.AsyncClient(timeout=cfg["proxy_timeout"])
         app.state.httpx_client = client
+        app.state.failover_routes = {}
         app.state.session_manager = SessionManager(
-            default_interactive_mode=cfg["interactive_mode"]
+            default_interactive_mode=cfg["interactive_mode"],
+            failover_routes=app.state.failover_routes,
         )
         app.state.command_prefix = cfg["command_prefix"]
 

--- a/src/proxy_logic.py
+++ b/src/proxy_logic.py
@@ -7,7 +7,11 @@ logger = logging.getLogger(__name__)
 class ProxyState:
     """Manages the state of the proxy, particularly model overrides."""
 
-    def __init__(self, interactive_mode: bool = False) -> None:
+    def __init__(
+        self,
+        interactive_mode: bool = False,
+        failover_routes: Optional[dict[str, dict[str, object]]] | None = None,
+    ) -> None:
         self.override_backend: Optional[str] = None
         self.override_model: Optional[str] = None
         self.invalid_override: bool = False
@@ -15,7 +19,9 @@ class ProxyState:
         self.interactive_mode: bool = interactive_mode
         self.interactive_just_enabled: bool = False
         self.hello_requested: bool = False
-        self.failover_routes: dict[str, dict[str, object]] = {}
+        self.failover_routes: dict[str, dict[str, object]] = (
+            failover_routes if failover_routes is not None else {}
+        )
 
     def set_override_model(
         self, backend: str, model_name: str, *, invalid: bool = False
@@ -106,7 +112,6 @@ class ProxyState:
         self.interactive_mode = False
         self.interactive_just_enabled = False
         self.hello_requested = False
-        self.failover_routes = {}
 
     def get_effective_model(self, requested_model: str) -> str:
         if self.override_model:

--- a/src/session.py
+++ b/src/session.py
@@ -37,14 +37,22 @@ class Session(BaseModel):
 class SessionManager:
     """Manages Session instances keyed by session_id."""
 
-    def __init__(self, default_interactive_mode: bool = False) -> None:
+    def __init__(
+        self,
+        default_interactive_mode: bool = False,
+        failover_routes: Optional[dict[str, dict[str, object]]] | None = None,
+    ) -> None:
         self.sessions: Dict[str, Session] = {}
         self.default_interactive_mode = default_interactive_mode
+        self.failover_routes = failover_routes if failover_routes is not None else {}
 
     def get_session(self, session_id: str) -> Session:
         if session_id not in self.sessions:
             self.sessions[session_id] = Session(
                 session_id=session_id,
-                proxy_state=ProxyState(interactive_mode=self.default_interactive_mode),
+                proxy_state=ProxyState(
+                    interactive_mode=self.default_interactive_mode,
+                    failover_routes=self.failover_routes,
+                ),
             )
         return self.sessions[session_id]

--- a/tests/unit/test_failover_routes.py
+++ b/tests/unit/test_failover_routes.py
@@ -41,3 +41,16 @@ class TestFailoverRoutes:
         parser.process_text("!/route-append(name=bar,gemini:model-c)")
         parser.process_text("!/route-list(name=bar)")
         assert state.list_route("bar") == ["gemini:model-c"]
+
+    def test_routes_are_server_wide(self):
+        shared = {}
+        state1 = ProxyState(failover_routes=shared)
+        parser1 = CommandParser(state1, self.mock_app, command_prefix="!/")
+        parser1.process_text("!/create-failover-route(name=r,policy=k)")
+        parser1.process_text("!/route-append(name=r,openrouter:model-a)")
+
+        state2 = ProxyState(interactive_mode=True, failover_routes=shared)
+        parser2 = CommandParser(state2, self.mock_app, command_prefix="!/")
+        assert state2.list_route("r") == ["openrouter:model-a"]
+        parser2.process_text("!/route-append(name=r,gemini:model-b)")
+        assert state1.list_route("r") == ["openrouter:model-a", "gemini:model-b"]

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -12,3 +12,12 @@ def test_session_manager_default_non_interactive():
     session = mgr.get_session("y")
     assert session.proxy_state.interactive_mode is False
 
+
+def test_failover_routes_shared_across_sessions():
+    mgr = SessionManager(failover_routes={})
+    s1 = mgr.get_session("a")
+    s2 = mgr.get_session("b")
+    s1.proxy_state.create_failover_route("foo", "k")
+    s1.proxy_state.append_route_element("foo", "openrouter:model-a")
+    assert s2.proxy_state.list_route("foo") == ["openrouter:model-a"]
+


### PR DESCRIPTION
## Summary
- move failover route storage to app-level state
- inject shared routes to each `ProxyState` via `SessionManager`
- adjust `reset` to keep failover routes
- extend unit tests for shared routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdad346c83338e4869ef218322d9