### PR TITLE
Implement runtime default backend switching

### DIFF
--- a/tests/integration/chat_completions_tests/test_backend_commands.py
+++ b/tests/integration/chat_completions_tests/test_backend_commands.py
@@ -3,20 +3,29 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 # Removed: from src.main import app (will use configured_app fixture)
-from src.session import SessionManager # Keep SessionManager import
+from src.session import SessionManager  # Keep SessionManager import
 
 # No local client fixture needed, will use the one from conftest.py
+
 
 def test_set_backend_command_integration(client: TestClient):
     # Patch app.state.gemini_backend and app.state.openrouter_backend directly on the client's app
     # This ensures the mocks are applied to the specific app instance used by the TestClient
     mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
-    with patch.object(client.app.state.gemini_backend, 'chat_completions', new_callable=AsyncMock) as gem_mock, \
-         patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as open_mock:
+    with (
+        patch.object(
+            client.app.state.gemini_backend, "chat_completions", new_callable=AsyncMock
+        ) as gem_mock,
+        patch.object(
+            client.app.state.openrouter_backend,
+            "chat_completions",
+            new_callable=AsyncMock,
+        ) as open_mock,
+    ):
         gem_mock.return_value = mock_backend_response
         payload = {
             "model": "some-model",
-            "messages": [{"role": "user", "content": "!/set(backend=gemini) hi"}]
+            "messages": [{"role": "user", "content": "!/set(backend=gemini) hi"}],
         }
         response = client.post("/v1/chat/completions", json=payload)
     assert response.status_code == 200
@@ -32,11 +41,13 @@ def test_unset_backend_command_integration(client: TestClient):
     session = client.app.state.session_manager.get_session("default")  # type: ignore
     session.proxy_state.set_override_backend("gemini")
     mock_backend_response = {"choices": [{"message": {"content": "done"}}]}
-    with patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as open_mock:
+    with patch.object(
+        client.app.state.openrouter_backend, "chat_completions", new_callable=AsyncMock
+    ) as open_mock:
         open_mock.return_value = mock_backend_response
         payload = {
             "model": "some-model",
-            "messages": [{"role": "user", "content": "!/unset(backend) hi"}]
+            "messages": [{"role": "user", "content": "!/unset(backend) hi"}],
         }
         response = client.post("/v1/chat/completions", json=payload)
     assert response.status_code == 200
@@ -47,7 +58,8 @@ def test_unset_backend_command_integration(client: TestClient):
 
 
 import pytest
-from pytest_httpx import HTTPXMock # Import HTTPXMock
+from pytest_httpx import HTTPXMock  # Import HTTPXMock
+
 
 @pytest.mark.httpx_mock()
 def test_set_backend_rejects_nonfunctional(client: TestClient, httpx_mock: HTTPXMock):
@@ -60,18 +72,20 @@ def test_set_backend_rejects_nonfunctional(client: TestClient, httpx_mock: HTTPX
             url="https://openrouter.ai/api/v1/chat/completions",
             method="POST",
             json={"choices": [{"message": {"content": "ok"}}]},
-            status_code=200
+            status_code=200,
         )
-        
+
         payload = {
             "model": "some-model",
-            "messages": [{"role": "user", "content": "!/set(backend=gemini) hi"}]
+            "messages": [{"role": "user", "content": "!/set(backend=gemini) hi"}],
         }
         response = client.post("/v1/chat/completions", json=payload)
-        
+
         assert response.status_code == 200
         session = client.app.state.session_manager.get_session("default")  # type: ignore
-        assert session.proxy_state.override_backend is None # Should not be set to gemini
+        assert (
+            session.proxy_state.override_backend is None
+        )  # Should not be set to gemini
         content = response.json()["choices"][0]["message"]["content"]
         assert content == "ok" or content.endswith("(no response)")
     finally:
@@ -80,3 +94,49 @@ def test_set_backend_rejects_nonfunctional(client: TestClient, httpx_mock: HTTPX
         state_obj = getattr(app_obj, "state", None)
         if state_obj and hasattr(state_obj, "functional_backends"):
             state_obj.functional_backends = original_functional_backends
+
+
+def test_set_default_backend_command_integration(client: TestClient):
+    mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
+    with (
+        patch.object(
+            client.app.state.gemini_backend, "chat_completions", new_callable=AsyncMock
+        ) as gem_mock,
+        patch.object(
+            client.app.state.openrouter_backend,
+            "chat_completions",
+            new_callable=AsyncMock,
+        ) as open_mock,
+    ):
+        gem_mock.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [
+                {"role": "user", "content": "!/set(default-backend=gemini) hi"}
+            ],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    gem_mock.assert_called_once()
+    open_mock.assert_not_called()
+    assert client.app.state.backend_type == "gemini"
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.override_backend is None
+
+
+def test_unset_default_backend_command_integration(client: TestClient):
+    client.app.state.backend_type = "gemini"
+    client.app.state.backend = client.app.state.gemini_backend
+    mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
+    with patch.object(
+        client.app.state.openrouter_backend, "chat_completions", new_callable=AsyncMock
+    ) as open_mock:
+        open_mock.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "!/unset(default-backend) hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    open_mock.assert_called_once()
+    assert client.app.state.backend_type == client.app.state.initial_backend_type


### PR DESCRIPTION
## Summary
- support setting/unsetting default backend at runtime
- store initial backend selection to allow reverting
- add integration tests for new commands

## Testing
- `ruff format src/commands.py src/main.py tests/integration/chat_completions_tests/test_backend_commands.py`
- `black src/commands.py src/main.py tests/integration/chat_completions_tests/test_backend_commands.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c2d0cad48333b74b2bf015a46b37