### PR TITLE
Fix startup circular import and duplicate API key generation

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import sys
 
 from src.core.config import _load_config
-from src.main import build_app # Temporarily import from src.main
+from typing import Callable, Optional
 
 
 def _check_privileges() -> None:
@@ -100,7 +100,10 @@ def apply_cli_args(args: argparse.Namespace) -> Dict[str, Any]:
     return _load_config()
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(
+    argv: list[str] | None = None,
+    build_app_fn: Optional[Callable[[Dict[str, Any] | None], Any]] = None,
+) -> None:
     args = parse_cli_args(argv)
     cfg = apply_cli_args(args)
     logging.basicConfig(
@@ -120,5 +123,8 @@ def main(argv: list[str] | None = None) -> None:
             )
             raise SystemExit(1)
 
-    app = build_app(cfg, config_file=args.config_file)
+    if build_app_fn is None:
+        from src.main import build_app as build_app_fn
+
+    app = build_app_fn(cfg, config_file=args.config_file)
     uvicorn.run(app, host=cfg["proxy_host"], port=cfg["proxy_port"])

--- a/src/main.py
+++ b/src/main.py
@@ -684,10 +684,10 @@ def build_app(cfg: Dict[str, Any] | None = None, *, config_file: str | None = No
 
 
 # Create a default application instance for importers
-app = build_app()
-
-
-from src.core.cli import main as cli_main
+if __name__ != "__main__":
+    app = build_app()
 
 if __name__ == "__main__":
-    cli_main()
+    from src.core.cli import main as cli_main
+
+    cli_main(build_app_fn=build_app)


### PR DESCRIPTION
## Summary
- avoid importing cli at module import time
- only build app when imported, not during CLI startup
- allow `cli.main` to accept a build function

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f4809e708333a32fcfff3517d4f7