### PR TITLE
Add agent detection and formatted responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project provides an intercepting proxy server that is compatible with the O
 - **Aggregated Model Listing** – the `/models` endpoint returns the union of all
   models discovered from configured backends, prefixed with the backend name.
 - **Session History Tracking** – optional per-session logs using the `X-Session-ID` header.
+- **Agent Detection** – recognizes popular coding agents and formats proxy responses accordingly.
 - **CLI Configuration** – command line flags can override environment variables for quick testing, including interactive mode.
 - **Persistent Configuration** – use `--config config/file.json` to save and reload failover routes and defaults across restarts.
 - **Configurable Interactive Mode** – enable or disable interactive mode by default via environment variable, CLI argument, or in-chat commands.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -22,6 +22,7 @@ This document describes the layout of the repository and the purpose of the main
 │   ├── proxy_logic.py       # ProxyState class and re-exports
 │   ├── command_parser.py    # Command parsing utilities
 │   ├── session.py           # Simple in-memory session/history tracking
+│   ├── agents.py            # Agent detection and response helpers
 │   ├── security.py          # Client authentication and API key redaction
 │   └── connectors/          # Concrete connector implementations and LLMBackend interface
 │       ├── __init__.py

--- a/src/agents.py
+++ b/src/agents.py
@@ -1,0 +1,27 @@
+import re
+from typing import Optional
+
+
+def detect_agent(prompt: str) -> Optional[str]:
+    p = prompt.lower()
+    if "cline" in p or "xml-style" in p or "tool use" in p:
+        return "cline"
+    if "roocode" in p or re.search(r"you are\s+roo", p):
+        return "roocode"
+    if "v4a diff" in p or "*** begin patch" in p or "aider" in p:
+        return "aider"
+    return None
+
+
+def wrap_proxy_message(agent: Optional[str], text: str) -> str:
+    if not text:
+        return text
+    if agent in {"cline", "roocode"}:
+        return f"[Proxy Result]\n\n{text}"
+    if agent == "aider":
+        lines = text.splitlines()
+        patch = ["*** Begin Patch", "*** Add File: PROXY_OUTPUT.txt"]
+        patch += ["+" + line for line in lines]
+        patch.append("*** End Patch")
+        return "\n".join(patch)
+    return text

--- a/src/session.py
+++ b/src/session.py
@@ -29,6 +29,7 @@ class Session(BaseModel):
     session_id: str
     proxy_state: ProxyState
     history: List[SessionInteraction] = Field(default_factory=list)
+    agent: Optional[str] = None
 
     def add_interaction(self, interaction: SessionInteraction) -> None:
         self.history.append(interaction)

--- a/tests/integration/chat_completions_tests/test_agent_wrapping.py
+++ b/tests/integration/chat_completions_tests/test_agent_wrapping.py
@@ -1,0 +1,19 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def test_cline_command_wrapping(client):
+    # Prime session with first message to detect agent
+    with patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = {"choices": [{"message": {"content": "ok"}}]}
+        payload = {"model": "m", "messages": [{"role": "system", "content": "You are Cline, use tools"}]}
+        client.post('/v1/chat/completions', json=payload)
+
+    session = client.app.state.session_manager.get_session('default')
+    assert session.agent == 'cline'
+
+    payload = {"model": "m", "messages": [{"role": "user", "content": "!/hello"}]}
+    resp = client.post('/v1/chat/completions', json=payload)
+    data = resp.json()
+    assert data['id'] == 'proxy_cmd_processed'
+    assert data['choices'][0]['message']['content'].startswith('[Proxy Result')

--- a/tests/unit/test_agent_utils.py
+++ b/tests/unit/test_agent_utils.py
@@ -1,0 +1,27 @@
+from src.agents import detect_agent, wrap_proxy_message
+
+
+def test_detect_agent_cline():
+    prompt = "You are Cline, use tools with XML-style tags"
+    assert detect_agent(prompt) == "cline"
+
+
+def test_detect_agent_roocode():
+    prompt = "You are Roo, follow RooCode rules"
+    assert detect_agent(prompt) == "roocode"
+
+
+def test_detect_agent_aider():
+    prompt = "Please use the V4A diff format.*** Begin Patch"
+    assert detect_agent(prompt) == "aider"
+
+
+def test_wrap_proxy_message_cline():
+    out = wrap_proxy_message("cline", "hi")
+    assert out.startswith("[Proxy Result]\n\n")
+
+
+def test_wrap_proxy_message_aider():
+    out = wrap_proxy_message("aider", "line1\nline2")
+    assert out.splitlines()[0] == "*** Begin Patch"
+    assert out.splitlines()[-1] == "*** End Patch"


### PR DESCRIPTION
## Summary
- detect agents from the first prompt and store in session
- wrap proxy-generated replies for Cline/RooCode/Aider
- document new module in STRUCTURE and README
- test agent utilities and integration behaviour

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684317ed35cc8333b827c869f4624814