### PR TITLE
Fix auth disable flag and model listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This project provides an intercepting proxy server that is compatible with the O
 - **Dynamic Model Override** – commands like `!/set(model=...)` change the model for subsequent requests.
 - **Multiple Backends** – forward requests to OpenRouter or Google Gemini, chosen with `LLM_BACKEND`.
 - **Streaming and Non‑Streaming Support** for both OpenRouter and Gemini backends.
-- **Aggregated Model Listing** – the `/models` endpoint returns the union of all
-  models discovered from configured backends, prefixed with the backend name.
+- **Aggregated Model Listing** – the `/models` and `/v1/models` endpoints return
+  the union of all models discovered from configured backends, prefixed with the
+  backend name.
 - **Session History Tracking** – optional per-session logs using the `X-Session-ID` header.
 - **Agent Detection** – recognizes popular coding agents and formats proxy responses accordingly.
 - **CLI Configuration** – command line flags can override environment variables for quick testing, including interactive mode.
@@ -100,7 +101,8 @@ By default the server expects an API key from connecting clients. Set the key in
 the `LLM_INTERACTIVE_PROXY_API_KEY` environment variable or let the server
 generate one on startup. The value must be supplied in the `Authorization`
 header using the `Bearer <key>` scheme. Authentication can be disabled with the
-`--disable-auth` flag, but this is only allowed when binding to `127.0.0.1`.
+`--disable-auth` flag (only allowed when binding to `127.0.0.1`). When disabled,
+no client API key is generated or checked.
 
 ### Running Tests
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -30,3 +30,14 @@ def test_disable_auth(monkeypatch):
         assert resp.status_code != 401
     monkeypatch.delenv("LLM_INTERACTIVE_PROXY_API_KEY", raising=False)
     monkeypatch.delenv("DISABLE_AUTH", raising=False)
+
+
+def test_disable_auth_no_key_generated(monkeypatch):
+    monkeypatch.delenv("LLM_INTERACTIVE_PROXY_API_KEY", raising=False)
+    monkeypatch.setenv("DISABLE_AUTH", "true")
+    app = build_app()
+    assert app.state.client_api_key is None
+    with TestClient(app) as client:
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+    monkeypatch.delenv("DISABLE_AUTH", raising=False)

--- a/tests/unit/test_models_endpoint.py
+++ b/tests/unit/test_models_endpoint.py
@@ -15,3 +15,18 @@ def test_models_endpoint_lists_all(monkeypatch):
         ids = {m["id"] for m in resp.json()["data"]}
         assert "openrouter:model-a" in ids
         assert "gemini:model-a" in ids
+
+
+def test_v1_models_endpoint_lists_all(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY_1", "K1")
+    monkeypatch.setenv("GEMINI_API_KEY_1", "K2")
+    monkeypatch.setenv("LLM_BACKEND", "openrouter")
+    app = app_main.build_app()
+    with TestClient(app, headers={"Authorization": "Bearer test-proxy-key"}) as client:
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+        ids = {m["id"] for m in resp.json()["data"]}
+        assert "openrouter:model-a" in ids
+        assert "gemini:model-a" in ids


### PR DESCRIPTION
## Summary
- avoid generating API key when authentication is disabled
- return cached models from all backends for `/v1/models`
- update docs about auth flag and model listing
- test aggregated model listing via `/v1/models`
- test that no API key is generated when auth disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431e42f60c83339cae13d237a76eba