### PR TITLE
Fix streaming error logging for Gemini/OpenRouter

### DIFF
--- a/tests/unit/gemini_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/gemini_connector_tests/test_http_error_streaming.py
@@ -33,7 +33,7 @@ async def test_chat_completions_http_error_streaming(
         mock_response = httpx.Response(
             status_code=500,
             request=httpx.Request(method, url),
-            content=error_text_response.encode("utf-8"),
+            stream=httpx.ByteStream(error_text_response.encode("utf-8")),
             headers={"Content-Type": "text/plain"},
         )
 
@@ -43,9 +43,6 @@ async def test_chat_completions_http_error_streaming(
 
             async def __aexit__(self, exc_type, exc_val, exc_tb):
                 pass
-
-            async def aiter_bytes(self):
-                yield mock_response.content
 
         return MockAsyncStream()
 

--- a/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
+++ b/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
@@ -1,0 +1,66 @@
+import pytest
+import httpx
+import json
+from pytest_httpx import HTTPXMock
+import pytest_asyncio
+
+import src.models as models
+from src.connectors.gemini import GeminiBackend
+
+TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+@pytest_asyncio.fixture(name="gemini_backend")
+async def gemini_backend_fixture():
+    async with httpx.AsyncClient() as client:
+        yield GeminiBackend(client=client)
+
+
+@pytest.fixture
+def sample_chat_request_data() -> models.ChatCompletionRequest:
+    return models.ChatCompletionRequest(
+        model="test-model",
+        messages=[models.ChatMessage(role="user", content="Hello")],
+    )
+
+
+@pytest.fixture
+def sample_processed_messages() -> list[models.ChatMessage]:
+    return [models.ChatMessage(role="user", content="Hello")]
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_model_prefix_handled(
+    gemini_backend: GeminiBackend,
+    httpx_mock: HTTPXMock,
+    sample_chat_request_data: models.ChatCompletionRequest,
+    sample_processed_messages: list[models.ChatMessage],
+):
+    sample_chat_request_data.stream = False
+    effective_model = "models/gemini-1"
+
+    mock_response_payload = {
+        "candidates": [{"content": {"parts": [{"text": "Hi"}]}}],
+        "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+    }
+    httpx_mock.add_response(
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/gemini-1:generateContent?key=FAKE_KEY",
+        method="POST",
+        json=mock_response_payload,
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    response = await gemini_backend.chat_completions(
+        request_data=sample_chat_request_data,
+        processed_messages=sample_processed_messages,
+        effective_model=effective_model,
+        openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+        openrouter_headers_provider=None,
+        key_name="GEMINI_API_KEY_1",
+        api_key="FAKE_KEY",
+    )
+
+    assert isinstance(response, dict)
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert str(request.url) == f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/gemini-1:generateContent?key=FAKE_KEY"

--- a/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
@@ -49,11 +49,11 @@ async def test_chat_completions_http_error_streaming(
     sample_chat_request_data.stream = True
     error_text_response = "OpenRouter internal server error"
 
-    def mock_stream_method(self, method, url, **kwargs): # Not async def
+    def mock_stream_method(self, method, url, **kwargs):
         mock_response = httpx.Response(
             status_code=500,
             request=httpx.Request(method, url),
-            content=error_text_response.encode('utf-8'),
+            stream=httpx.ByteStream(error_text_response.encode("utf-8")),
             headers={"Content-Type": "text/plain"}
         )
         class MockAsyncStream:
@@ -61,8 +61,6 @@ async def test_chat_completions_http_error_streaming(
                 return mock_response
             async def __aexit__(self, exc_type, exc_val, exc_tb):
                 pass
-            async def aiter_bytes(self): # Add aiter_bytes for stream consumption
-                yield mock_response.content # Yield the content as bytes
         return MockAsyncStream()
 
     monkeypatch.setattr(httpx.AsyncClient, "stream", mock_stream_method)


### PR DESCRIPTION
## Summary
- fix Gemini and OpenRouter connectors to read body on HTTPStatusError
- adjust unit tests to simulate unread stream errors
- handle Gemini model names that include a `models/` prefix
- add regression test for Gemini model prefix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684321f6b7648333828d76498c36ec2d