### PR TITLE
Fix Gemini streaming error handling

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -156,62 +156,47 @@ class GeminiBackend(LLMBackend):
         if request_data.stream:
             url = f"{base_url}:streamGenerateContent?key={api_key}"
             try:
+                request = self.client.build_request("POST", url, json=payload)
+                response = await self.client.send(request, stream=True)
+                if response.status_code >= 400:
+                    try:
+                        body_text = (await response.aread()).decode("utf-8")
+                    except Exception:
+                        body_text = ""
+                    logger.error(
+                        "HTTP error during Gemini stream: %s - %s",
+                        response.status_code,
+                        body_text,
+                    )
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail={
+                            "message": f"Gemini stream error: {response.status_code} - {body_text}",
+                            "type": "gemini_error",
+                            "code": response.status_code,
+                        },
+                    )
 
-                async def stream_generator():
+                async def stream_generator() -> bytes:
                     buffer = ""
                     try:
-                        async with self.client.stream("POST", url, json=payload) as response:
-                            response.raise_for_status()
-                            async for chunk in response.aiter_text():
-                                buffer += chunk
-                                while "\n" in buffer:
-                                    line, buffer = buffer.split("\n", 1)
-                                    line = line.strip()
-                                    if not line:
-                                        continue
-                                    data = json.loads(line)
-                                    converted = self._convert_stream_chunk(data, effective_model)
-                                    yield f"data: {json.dumps(converted)}\n\n".encode()
+                        async for chunk in response.aiter_text():
+                            buffer += chunk
+                            while "\n" in buffer:
+                                line, buffer = buffer.split("\n", 1)
+                                line = line.strip()
+                                if not line:
+                                    continue
+                                data = json.loads(line)
+                                converted = self._convert_stream_chunk(data, effective_model)
+                                yield f"data: {json.dumps(converted)}\n\n".encode()
                         if buffer.strip():
                             data = json.loads(buffer.strip())
                             converted = self._convert_stream_chunk(data, effective_model)
                             yield f"data: {json.dumps(converted)}\n\n".encode()
                         yield b"data: [DONE]\n\n"
-                    except httpx.HTTPStatusError as e_stream:
-                        logger.info(
-                            "Caught httpx.HTTPStatusError in Gemini stream_generator"
-                        )
-                        try:
-                            body_text = (
-                                await e_stream.response.aread()
-                            ).decode("utf-8")
-                        except Exception:
-                            body_text = ""
-                        logger.error(
-                            "HTTP error during Gemini stream: %s - %s",
-                            e_stream.response.status_code,
-                            body_text,
-                        )
-                        raise HTTPException(
-                            status_code=e_stream.response.status_code,
-                            detail={
-                                "message": f"Gemini stream error: {e_stream.response.status_code} - {body_text}",
-                                "type": "gemini_error",
-                                "code": e_stream.response.status_code,
-                            },
-                        )
-                    except Exception as e_gen:
-                        logger.error(
-                            f"Error in Gemini stream generator: {e_gen}", exc_info=True
-                        )
-                        raise HTTPException(
-                            status_code=500,
-                            detail={
-                                "message": f"Proxy stream generator error: {str(e_gen)}",
-                                "type": "proxy_error",
-                                "code": "proxy_stream_error",
-                            },
-                        )
+                    finally:
+                        await response.aclose()
 
                 return StreamingResponse(stream_generator(), media_type="text/event-stream")
             except httpx.RequestError as e:

--- a/tests/unit/gemini_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/gemini_connector_tests/test_http_error_streaming.py
@@ -29,41 +29,28 @@ async def test_chat_completions_http_error_streaming(
     sample_chat_request_data.stream = True
     error_text_response = "Gemini internal server error"
 
-    def mock_stream_method(self, method, url, **kwargs):
-        mock_response = httpx.Response(
+    async def mock_send(self, request, **kwargs):
+        return httpx.Response(
             status_code=500,
-            request=httpx.Request(method, url),
-            stream=httpx.ByteStream(error_text_response.encode("utf-8")),
+            request=request,
+            content=error_text_response.encode("utf-8"),
             headers={"Content-Type": "text/plain"},
         )
 
-        class MockAsyncStream:
-            async def __aenter__(self):
-                return mock_response
-
-            async def __aexit__(self, exc_type, exc_val, exc_tb):
-                pass
-
-        return MockAsyncStream()
-
-    monkeypatch.setattr(httpx.AsyncClient, "stream", mock_stream_method)
+    monkeypatch.setattr(httpx.AsyncClient, "send", mock_send)
 
     async with httpx.AsyncClient() as client:
         gemini_backend = GeminiBackend(client=client)
-        response = await gemini_backend.chat_completions(
-            request_data=sample_chat_request_data,
-            processed_messages=sample_processed_messages,
-            effective_model="test-model",
-            openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
-            openrouter_headers_provider=None,
-            key_name="GEMINI_API_KEY_1",
-            api_key="FAKE_KEY",
-        )
-        assert isinstance(response, StreamingResponse)
-
         with pytest.raises(HTTPException) as exc_info:
-            async for _ in response.body_iterator:
-                pass
+            await gemini_backend.chat_completions(
+                request_data=sample_chat_request_data,
+                processed_messages=sample_processed_messages,
+                effective_model="test-model",
+                openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+                openrouter_headers_provider=None,
+                key_name="GEMINI_API_KEY_1",
+                api_key="FAKE_KEY",
+            )
 
     assert exc_info.value.status_code == 500
     detail = exc_info.value.detail


### PR DESCRIPTION
## Summary
- fix gemini backend streaming logic to detect HTTP errors before returning a StreamingResponse
- update gemini streaming error test to patch httpx.AsyncClient.send

## Testing
- `pytest tests/unit/gemini_connector_tests/test_streaming_success.py tests/unit/gemini_connector_tests/test_http_error_streaming.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843268c754c8333acc1101732abb4eb