### PR TITLE
Fix Gemini streaming error handling

### DIFF
--- a/tests/unit/gemini_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/gemini_connector_tests/test_http_error_streaming.py
@@ -29,41 +29,28 @@ async def test_chat_completions_http_error_streaming(
     sample_chat_request_data.stream = True
     error_text_response = "Gemini internal server error"
 
-    def mock_stream_method(self, method, url, **kwargs):
-        mock_response = httpx.Response(
+    async def mock_send(self, request, **kwargs):
+        return httpx.Response(
             status_code=500,
-            request=httpx.Request(method, url),
-            stream=httpx.ByteStream(error_text_response.encode("utf-8")),
+            request=request,
+            content=error_text_response.encode("utf-8"),
             headers={"Content-Type": "text/plain"},
         )
 
-        class MockAsyncStream:
-            async def __aenter__(self):
-                return mock_response
-
-            async def __aexit__(self, exc_type, exc_val, exc_tb):
-                pass
-
-        return MockAsyncStream()
-
-    monkeypatch.setattr(httpx.AsyncClient, "stream", mock_stream_method)
+    monkeypatch.setattr(httpx.AsyncClient, "send", mock_send)
 
     async with httpx.AsyncClient() as client:
         gemini_backend = GeminiBackend(client=client)
-        response = await gemini_backend.chat_completions(
-            request_data=sample_chat_request_data,
-            processed_messages=sample_processed_messages,
-            effective_model="test-model",
-            openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
-            openrouter_headers_provider=None,
-            key_name="GEMINI_API_KEY_1",
-            api_key="FAKE_KEY",
-        )
-        assert isinstance(response, StreamingResponse)
-
         with pytest.raises(HTTPException) as exc_info:
-            async for _ in response.body_iterator:
-                pass
+            await gemini_backend.chat_completions(
+                request_data=sample_chat_request_data,
+                processed_messages=sample_processed_messages,
+                effective_model="test-model",
+                openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+                openrouter_headers_provider=None,
+                key_name="GEMINI_API_KEY_1",
+                api_key="FAKE_KEY",
+            )
 
     assert exc_info.value.status_code == 500
     detail = exc_info.value.detail

--- a/tests/unit/gemini_connector_tests/test_part_conversion.py
+++ b/tests/unit/gemini_connector_tests/test_part_conversion.py
@@ -1,0 +1,49 @@
+import json
+import httpx
+from pytest_httpx import HTTPXMock
+import pytest
+import pytest_asyncio
+
+import src.models as models
+from src.connectors.gemini import GeminiBackend
+
+TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+@pytest_asyncio.fixture(name="gemini_backend")
+async def gemini_backend_fixture():
+    async with httpx.AsyncClient() as client:
+        yield GeminiBackend(client=client)
+
+
+@pytest.mark.asyncio
+async def test_text_part_type_removed(gemini_backend: GeminiBackend, httpx_mock: HTTPXMock):
+    request_data = models.ChatCompletionRequest(
+        model="test-model",
+        messages=[models.ChatMessage(role="user", content=[models.MessageContentPartText(type="text", text="Hi")])],
+    )
+    processed_messages = [
+        models.ChatMessage(role="user", content=[models.MessageContentPartText(type="text", text="Hi")])
+    ]
+    httpx_mock.add_response(
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent?key=FAKE_KEY",
+        method="POST",
+        json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    await gemini_backend.chat_completions(
+        request_data=request_data,
+        processed_messages=processed_messages,
+        effective_model="test-model",
+        openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+        openrouter_headers_provider=None,
+        key_name="GEMINI_API_KEY_1",
+        api_key="FAKE_KEY",
+    )
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    payload = json.loads(request.content)
+    part = payload["contents"][0]["parts"][0]
+    assert part == {"text": "Hi"}


### PR DESCRIPTION
## Summary
- fix gemini backend streaming logic to detect HTTP errors before returning a StreamingResponse
- correct Gemini payload conversion so text parts omit the `type` field
- add regression test for Gemini text part conversion

## Testing
- `pytest tests/unit/gemini_connector_tests/test_part_conversion.py tests/unit/gemini_connector_tests/test_streaming_success.py tests/unit/gemini_connector_tests/test_http_error_streaming.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843268c754c8333acc1101732abb4eb