### PR TITLE
Fix Gemini streaming system-role bug

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -8,7 +8,11 @@ from typing import Union, Dict, Any, Optional
 
 from fastapi import HTTPException
 from starlette.responses import StreamingResponse
-from src.models import ChatCompletionRequest
+from src.models import (
+    ChatCompletionRequest,
+    MessageContentPartText,
+    MessageContentPartImage,
+)
 from src.connectors.base import LLMBackend
 from src.security import APIKeyRedactor
 
@@ -99,6 +103,35 @@ class GeminiBackend(LLMBackend):
             },
         }
 
+    def _convert_part_for_gemini(
+        self, part: Union[MessageContentPartText, MessageContentPartImage], prompt_redactor: APIKeyRedactor | None
+    ) -> Dict[str, Any]:
+        """Convert a MessageContentPart into Gemini API format."""
+        if isinstance(part, MessageContentPartText):
+            text = part.text
+            if prompt_redactor:
+                text = prompt_redactor.redact(text)
+            return {"text": text}
+        if isinstance(part, MessageContentPartImage):
+            url = part.image_url.url
+            # Data URL -> inlineData
+            if url.startswith("data:"):
+                try:
+                    header, b64_data = url.split(",", 1)
+                    mime = header.split(";")[0][5:]
+                except Exception:
+                    mime = "application/octet-stream"
+                    b64_data = ""
+                return {"inlineData": {"mimeType": mime, "data": b64_data}}
+            # Otherwise treat as remote file URI
+            return {"fileData": {"mimeType": "application/octet-stream", "fileUri": url}}
+        data = part.model_dump(exclude_unset=True)
+        if data.get("type") == "text" and "text" in data:
+            if prompt_redactor:
+                data["text"] = prompt_redactor.redact(data["text"])
+            data.pop("type", None)
+        return data
+
     async def chat_completions(
         self,
         request_data: ChatCompletionRequest,
@@ -123,22 +156,19 @@ class GeminiBackend(LLMBackend):
             )
         payload_contents = []
         for msg in processed_messages:
+            if msg.role == "system":
+                # Gemini API does not support system role
+                continue
             if isinstance(msg.content, str):
                 text = msg.content
                 if prompt_redactor:
                     text = prompt_redactor.redact(text)
                 parts = [{"text": text}]
             else:
-                parts = []
-                for part in msg.content:
-                    data = part.model_dump(exclude_unset=True)
-                    if (
-                        data.get("type") == "text"
-                        and "text" in data
-                        and prompt_redactor
-                    ):
-                        data["text"] = prompt_redactor.redact(data["text"])
-                    parts.append(data)
+                parts = [
+                    self._convert_part_for_gemini(part, prompt_redactor)
+                    for part in msg.content
+                ]
             payload_contents.append({"role": msg.role, "parts": parts})
 
         payload = {"contents": payload_contents}
@@ -156,62 +186,49 @@ class GeminiBackend(LLMBackend):
         if request_data.stream:
             url = f"{base_url}:streamGenerateContent?key={api_key}"
             try:
+                request = self.client.build_request("POST", url, json=payload)
+                response = await self.client.send(request, stream=True)
+                if response.status_code >= 400:
+                    try:
+                        body_text = (await response.aread()).decode("utf-8")
+                    except Exception:
+                        body_text = ""
+                    finally:
+                        await response.aclose()
+                    logger.error(
+                        "HTTP error during Gemini stream: %s - %s",
+                        response.status_code,
+                        body_text,
+                    )
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail={
+                            "message": f"Gemini stream error: {response.status_code} - {body_text}",
+                            "type": "gemini_error",
+                            "code": response.status_code,
+                        },
+                    )
 
-                async def stream_generator():
+                async def stream_generator() -> bytes:
                     buffer = ""
                     try:
-                        async with self.client.stream("POST", url, json=payload) as response:
-                            response.raise_for_status()
-                            async for chunk in response.aiter_text():
-                                buffer += chunk
-                                while "\n" in buffer:
-                                    line, buffer = buffer.split("\n", 1)
-                                    line = line.strip()
-                                    if not line:
-                                        continue
-                                    data = json.loads(line)
-                                    converted = self._convert_stream_chunk(data, effective_model)
-                                    yield f"data: {json.dumps(converted)}\n\n".encode()
+                        async for chunk in response.aiter_text():
+                            buffer += chunk
+                            while "\n" in buffer:
+                                line, buffer = buffer.split("\n", 1)
+                                line = line.strip()
+                                if not line:
+                                    continue
+                                data = json.loads(line)
+                                converted = self._convert_stream_chunk(data, effective_model)
+                                yield f"data: {json.dumps(converted)}\n\n".encode()
                         if buffer.strip():
                             data = json.loads(buffer.strip())
                             converted = self._convert_stream_chunk(data, effective_model)
                             yield f"data: {json.dumps(converted)}\n\n".encode()
                         yield b"data: [DONE]\n\n"
-                    except httpx.HTTPStatusError as e_stream:
-                        logger.info(
-                            "Caught httpx.HTTPStatusError in Gemini stream_generator"
-                        )
-                        try:
-                            body_text = (
-                                await e_stream.response.aread()
-                            ).decode("utf-8")
-                        except Exception:
-                            body_text = ""
-                        logger.error(
-                            "HTTP error during Gemini stream: %s - %s",
-                            e_stream.response.status_code,
-                            body_text,
-                        )
-                        raise HTTPException(
-                            status_code=e_stream.response.status_code,
-                            detail={
-                                "message": f"Gemini stream error: {e_stream.response.status_code} - {body_text}",
-                                "type": "gemini_error",
-                                "code": e_stream.response.status_code,
-                            },
-                        )
-                    except Exception as e_gen:
-                        logger.error(
-                            f"Error in Gemini stream generator: {e_gen}", exc_info=True
-                        )
-                        raise HTTPException(
-                            status_code=500,
-                            detail={
-                                "message": f"Proxy stream generator error: {str(e_gen)}",
-                                "type": "proxy_error",
-                                "code": "proxy_stream_error",
-                            },
-                        )
+                    finally:
+                        await response.aclose()
 
                 return StreamingResponse(stream_generator(), media_type="text/event-stream")
             except httpx.RequestError as e:

--- a/tests/unit/gemini_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/gemini_connector_tests/test_http_error_streaming.py
@@ -2,6 +2,7 @@ import pytest
 import httpx
 from starlette.responses import StreamingResponse
 from fastapi import HTTPException
+from unittest.mock import AsyncMock
 
 import src.models as models
 from src.connectors.gemini import GeminiBackend
@@ -29,41 +30,31 @@ async def test_chat_completions_http_error_streaming(
     sample_chat_request_data.stream = True
     error_text_response = "Gemini internal server error"
 
-    def mock_stream_method(self, method, url, **kwargs):
-        mock_response = httpx.Response(
+    async def mock_send(self, request, **kwargs):
+        resp = httpx.Response(
             status_code=500,
-            request=httpx.Request(method, url),
-            stream=httpx.ByteStream(error_text_response.encode("utf-8")),
+            request=request,
+            content=error_text_response.encode("utf-8"),
             headers={"Content-Type": "text/plain"},
         )
+        resp.aclose = AsyncMock()
+        mock_send.response = resp
+        return resp
 
-        class MockAsyncStream:
-            async def __aenter__(self):
-                return mock_response
-
-            async def __aexit__(self, exc_type, exc_val, exc_tb):
-                pass
-
-        return MockAsyncStream()
-
-    monkeypatch.setattr(httpx.AsyncClient, "stream", mock_stream_method)
+    monkeypatch.setattr(httpx.AsyncClient, "send", mock_send)
 
     async with httpx.AsyncClient() as client:
         gemini_backend = GeminiBackend(client=client)
-        response = await gemini_backend.chat_completions(
-            request_data=sample_chat_request_data,
-            processed_messages=sample_processed_messages,
-            effective_model="test-model",
-            openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
-            openrouter_headers_provider=None,
-            key_name="GEMINI_API_KEY_1",
-            api_key="FAKE_KEY",
-        )
-        assert isinstance(response, StreamingResponse)
-
         with pytest.raises(HTTPException) as exc_info:
-            async for _ in response.body_iterator:
-                pass
+            await gemini_backend.chat_completions(
+                request_data=sample_chat_request_data,
+                processed_messages=sample_processed_messages,
+                effective_model="test-model",
+                openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+                openrouter_headers_provider=None,
+                key_name="GEMINI_API_KEY_1",
+                api_key="FAKE_KEY",
+            )
 
     assert exc_info.value.status_code == 500
     detail = exc_info.value.detail
@@ -74,3 +65,4 @@ async def test_chat_completions_http_error_streaming(
     )
     assert detail.get("type") == "gemini_error"
     assert detail.get("code") == 500
+    assert mock_send.response.aclose.await_count == 1

--- a/tests/unit/gemini_connector_tests/test_part_conversion.py
+++ b/tests/unit/gemini_connector_tests/test_part_conversion.py
@@ -1,0 +1,87 @@
+import json
+import httpx
+from pytest_httpx import HTTPXMock
+import pytest
+import pytest_asyncio
+
+import src.models as models
+from src.connectors.gemini import GeminiBackend
+
+TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+@pytest_asyncio.fixture(name="gemini_backend")
+async def gemini_backend_fixture():
+    async with httpx.AsyncClient() as client:
+        yield GeminiBackend(client=client)
+
+
+@pytest.mark.asyncio
+async def test_text_part_type_removed(gemini_backend: GeminiBackend, httpx_mock: HTTPXMock):
+    request_data = models.ChatCompletionRequest(
+        model="test-model",
+        messages=[models.ChatMessage(role="user", content=[models.MessageContentPartText(type="text", text="Hi")])],
+    )
+    processed_messages = [
+        models.ChatMessage(role="user", content=[models.MessageContentPartText(type="text", text="Hi")])
+    ]
+    httpx_mock.add_response(
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent?key=FAKE_KEY",
+        method="POST",
+        json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    await gemini_backend.chat_completions(
+        request_data=request_data,
+        processed_messages=processed_messages,
+        effective_model="test-model",
+        openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+        openrouter_headers_provider=None,
+        key_name="GEMINI_API_KEY_1",
+        api_key="FAKE_KEY",
+    )
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    payload = json.loads(request.content)
+    part = payload["contents"][0]["parts"][0]
+    assert part == {"text": "Hi"}
+
+
+@pytest.mark.asyncio
+async def test_system_message_filtered(gemini_backend: GeminiBackend, httpx_mock: HTTPXMock):
+    request_data = models.ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            models.ChatMessage(role="system", content="You are Roo"),
+            models.ChatMessage(role="user", content="Hello"),
+        ],
+    )
+    processed_messages = [
+        models.ChatMessage(role="system", content="You are Roo"),
+        models.ChatMessage(role="user", content="Hello"),
+    ]
+    httpx_mock.add_response(
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent?key=FAKE_KEY",
+        method="POST",
+        json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    await gemini_backend.chat_completions(
+        request_data=request_data,
+        processed_messages=processed_messages,
+        effective_model="test-model",
+        openrouter_api_base_url=TEST_GEMINI_API_BASE_URL,
+        openrouter_headers_provider=None,
+        key_name="GEMINI_API_KEY_1",
+        api_key="FAKE_KEY",
+    )
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    payload = json.loads(request.content)
+    assert len(payload["contents"]) == 1
+    assert payload["contents"][0]["role"] == "user"


### PR DESCRIPTION
## Summary
- skip messages with `system` role when constructing Gemini payloads
- extend tests verifying payload conversion and system role filtering
- ensure HTTP responses are closed on Gemini stream errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843268c754c8333acc1101732abb4eb