### PR TITLE
Use header for Gemini API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These instructions will get you a copy of the project up and running on your loc
     # Gemini backend keys follow the same pattern
     # GEMINI_API_KEY="your_gemini_api_key_here"
     # GEMINI_API_KEY_1="first_gemini_key"
+    # Keys are sent using the `x-goog-api-key` header to avoid exposing them in URLs
 
     # Client API key for accessing this proxy
     # LLM_INTERACTIVE_PROXY_API_KEY="choose_a_secret_key"

--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -193,10 +193,14 @@ class GeminiBackend(LLMBackend):
             model_name = model_name.split("/", 1)[1]
         base_url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models/{model_name}"
 
+        headers = {"x-goog-api-key": api_key}
+
         if request_data.stream:
-            url = f"{base_url}:streamGenerateContent?key={api_key}"
+            url = f"{base_url}:streamGenerateContent"
             try:
-                request = self.client.build_request("POST", url, json=payload)
+                request = self.client.build_request(
+                    "POST", url, json=payload, headers=headers
+                )
                 response = await self.client.send(request, stream=True)
                 if response.status_code >= 400:
                     try:
@@ -274,9 +278,9 @@ class GeminiBackend(LLMBackend):
                     detail=f"Service unavailable: Could not connect to Gemini ({e})",
                 )
 
-        url = f"{base_url}:generateContent?key={api_key}"
+        url = f"{base_url}:generateContent"
         try:
-            response = await self.client.post(url, json=payload)
+            response = await self.client.post(url, json=payload, headers=headers)
             if response.status_code >= 400:
                 try:
                     error_detail = response.json()
@@ -301,9 +305,10 @@ class GeminiBackend(LLMBackend):
         key_name: str,
         api_key: str,
     ) -> Dict[str, Any]:
-        url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models?key={api_key}"
+        headers = {"x-goog-api-key": api_key}
+        url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models"
         try:
-            response = await self.client.get(url)
+            response = await self.client.get(url, headers=headers)
             if response.status_code >= 400:
                 try:
                     error_detail = response.json()

--- a/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
+++ b/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
@@ -43,11 +43,12 @@ async def test_chat_completions_model_prefix_handled(
         "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
     }
     httpx_mock.add_response(
-        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/gemini-1:generateContent?key=FAKE_KEY",
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/gemini-1:generateContent",
         method="POST",
         json=mock_response_payload,
         status_code=200,
         headers={"Content-Type": "application/json"},
+        match_headers={"x-goog-api-key": "FAKE_KEY"},
     )
 
     response = await gemini_backend.chat_completions(
@@ -63,4 +64,5 @@ async def test_chat_completions_model_prefix_handled(
     assert isinstance(response, dict)
     request = httpx_mock.get_request()
     assert request is not None
-    assert str(request.url) == f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/gemini-1:generateContent?key=FAKE_KEY"
+    assert str(request.url) == f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/gemini-1:generateContent"
+    assert request.headers.get("x-goog-api-key") == "FAKE_KEY"

--- a/tests/unit/gemini_connector_tests/test_part_conversion.py
+++ b/tests/unit/gemini_connector_tests/test_part_conversion.py
@@ -35,11 +35,12 @@ async def test_text_part_type_removed(gemini_backend: GeminiBackend, httpx_mock:
         models.ChatMessage(role="user", content=[models.MessageContentPartText(type="text", text="Hi")])
     ]
     httpx_mock.add_response(
-        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent?key=FAKE_KEY",
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent",
         method="POST",
         json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
         status_code=200,
         headers={"Content-Type": "application/json"},
+        match_headers={"x-goog-api-key": "FAKE_KEY"},
     )
 
     await gemini_backend.chat_completions(
@@ -54,6 +55,7 @@ async def test_text_part_type_removed(gemini_backend: GeminiBackend, httpx_mock:
 
     request = httpx_mock.get_request()
     assert request is not None
+    assert request.headers.get("x-goog-api-key") == "FAKE_KEY"
     payload = json.loads(request.content)
     part = payload["contents"][0]["parts"][0]
     assert part == {"text": "Hi"}
@@ -83,11 +85,12 @@ async def test_system_message_filtered(gemini_backend: GeminiBackend, httpx_mock
         models.ChatMessage(role="user", content="Hello"),
     ]
     httpx_mock.add_response(
-        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent?key=FAKE_KEY",
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/test-model:generateContent",
         method="POST",
         json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
         status_code=200,
         headers={"Content-Type": "application/json"},
+        match_headers={"x-goog-api-key": "FAKE_KEY"},
     )
 
     await gemini_backend.chat_completions(
@@ -102,6 +105,7 @@ async def test_system_message_filtered(gemini_backend: GeminiBackend, httpx_mock
 
     request = httpx_mock.get_request()
     assert request is not None
+    assert request.headers.get("x-goog-api-key") == "FAKE_KEY"
     payload = json.loads(request.content)
     assert len(payload["contents"]) == 1
     assert payload["contents"][0]["role"] == "user"

--- a/tests/unit/gemini_connector_tests/test_streaming_success.py
+++ b/tests/unit/gemini_connector_tests/test_streaming_success.py
@@ -47,11 +47,12 @@ async def test_chat_completions_streaming_success(
         b"]",
     ]
     httpx_mock.add_response(
-        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/{effective_model}:streamGenerateContent?key=FAKE_KEY",
+        url=f"{TEST_GEMINI_API_BASE_URL}/v1beta/models/{effective_model}:streamGenerateContent",
         method="POST",
         stream=httpx.ByteStream(b"".join(stream_chunks)),
         status_code=200,
         headers={"Content-Type": "application/json"},
+        match_headers={"x-goog-api-key": "FAKE_KEY"},
     )
 
     response = await gemini_backend.chat_completions(
@@ -78,6 +79,7 @@ async def test_chat_completions_streaming_success(
 
     request = httpx_mock.get_request()
     assert request is not None
+    assert request.headers.get("x-goog-api-key") == "FAKE_KEY"
     sent_payload = json.loads(request.content)
     assert sent_payload["contents"][0]["parts"][0]["text"] == "Hello"
     assert sent_payload.get("stream") is None


### PR DESCRIPTION
## Summary
- hide Gemini API key from logged URLs by sending it via `x-goog-api-key` header
- adjust unit tests for header-based auth
- document new header usage in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446c624e588333b5331c56f3a7fbbb