### PR TITLE
Add --log option for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project provides an intercepting proxy server that is compatible with the O
 - **Configurable Interactive Mode** – enable or disable interactive mode by default via environment variable, CLI argument, or in-chat commands.
 - **Interactive Welcome Banner** – shows functional backends with API key and model counts when interactive mode is enabled.
 - **Prompt API Key Redaction** – redact configured API keys from prompts. Enabled by default; can be turned off via the `--disable-redact-api-keys-in-prompts` CLI flag, environment variable, or commands.
+- **File Logging** – provide `--log path/to/file` to write logs to a file instead of stderr.
 
 ## Getting Started
 
@@ -91,6 +92,8 @@ To start the proxy server, run the `main.py` script from the `src` directory:
 ```bash
 python src/main.py --config config/settings.json
 ```
+
+Add `--log server.log` to write logs to a file.
 
 The server will typically start on `http://127.0.0.1:8000` (or as configured in your `.env` file). You should see log output indicating the server has started, e.g.:
 `INFO:     Started server process [xxxxx]`

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -19,11 +19,10 @@ def _check_privileges() -> None:
             import ctypes
 
             if ctypes.windll.shell32.IsUserAnAdmin() != 0:
-                raise SystemExit(
-                    "Refusing to run with administrative privileges"
-                )
+                raise SystemExit("Refusing to run with administrative privileges")
         except Exception:
             pass
+
 
 def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the LLM proxy server")
@@ -48,6 +47,12 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--port", type=int)
     parser.add_argument("--timeout", type=int)
     parser.add_argument("--command-prefix")
+    parser.add_argument(
+        "--log",
+        dest="log_file",
+        metavar="FILE",
+        help="Write logs to FILE",
+    )
     parser.add_argument(
         "--config",
         dest="config_file",
@@ -109,6 +114,7 @@ def main(
     logging.basicConfig(
         level=logging.DEBUG,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        filename=args.log_file,
     )
     _check_privileges()
 


### PR DESCRIPTION
## Summary
- support `--log FILE` for CLI
- document logging option in README
- test new log file argument

## Testing
- `pytest -q tests/unit/test_cli.py::test_cli_log_argument tests/unit/test_cli.py::test_main_log_file`

------
https://chatgpt.com/codex/tasks/task_e_684484598b3883338e074674a25ff8ae