### PR TITLE
Add project enforcement and alias support

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -130,10 +130,11 @@ class SetCommand(BaseCommand):
             else:  # If model not available AND NOT in interactive mode
                 state.set_override_model(backend_part, model_name, invalid=True)
                 handled = True
-        if isinstance(args.get("project"), str):
-            state.set_project(args["project"])
+        project_val = args.get("project") or args.get("project-name")
+        if isinstance(project_val, str):
+            state.set_project(project_val)
             handled = True
-            messages.append(f"project set to {args['project']}")
+            messages.append(f"project set to {project_val}")
         for key in ("interactive", "interactive-mode"):
             if isinstance(args.get(key), str):
                 val = self._parse_bool(args[key])
@@ -182,7 +183,7 @@ class UnsetCommand(BaseCommand):
                     self.app.state.backend = self.app.state.openrouter_backend
             messages.append("default-backend unset")
             persistent_change = True
-        if "project" in keys_to_unset:
+        if any(k in keys_to_unset for k in ("project", "project-name")):
             state.unset_project()
             messages.append("project unset")
         if any(k in keys_to_unset for k in ("interactive", "interactive-mode")):

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -77,6 +77,12 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Disable client API key authentication",
     )
+    parser.add_argument(
+        "--force-set-project",
+        action="store_true",
+        default=None,
+        help="Require project name to be set before sending prompts",
+    )
     return parser.parse_args(argv)
 
 
@@ -93,6 +99,7 @@ def apply_cli_args(args: argparse.Namespace) -> Dict[str, Any]:
         "command_prefix": "COMMAND_PREFIX",
         "interactive_mode": "INTERACTIVE_MODE",
         "disable_auth": "DISABLE_AUTH",
+        "force_set_project": "FORCE_SET_PROJECT",
     }
     for attr, env_name in mappings.items():
         value = getattr(args, attr)
@@ -102,6 +109,8 @@ def apply_cli_args(args: argparse.Namespace) -> Dict[str, Any]:
         os.environ["REDACT_API_KEYS_IN_PROMPTS"] = "false"
     if getattr(args, "disable_auth", None):
         os.environ["DISABLE_AUTH"] = "true"
+    if getattr(args, "force_set_project", None):
+        os.environ["FORCE_SET_PROJECT"] = "true"
     return _load_config()
 
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -66,6 +66,7 @@ def _load_config() -> Dict[str, Any]:
             os.getenv("REDACT_API_KEYS_IN_PROMPTS"), True
         ),
         "disable_auth": _str_to_bool(os.getenv("DISABLE_AUTH"), False),
+        "force_set_project": _str_to_bool(os.getenv("FORCE_SET_PROJECT"), False),
     }
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -164,6 +164,7 @@ def build_app(cfg: Dict[str, Any] | None = None, *, config_file: str | None = No
             app.state.default_api_key_redaction_enabled
         )
         app.state.rate_limits = RateLimitRegistry()
+        app.state.force_set_project = cfg.get("force_set_project", False)
 
         if config_file:
             app.state.config_manager = ConfigManager(app, config_file)
@@ -343,6 +344,12 @@ def build_app(cfg: Dict[str, Any] | None = None, *, config_file: str | None = No
             raise HTTPException(
                 status_code=400,
                 detail="No messages provided in the request or messages became empty after processing.",
+            )
+
+        if http_request.app.state.force_set_project and proxy_state.project is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Project name not set. Use !/set(project=<name>) before sending prompts.",
             )
 
         effective_model = proxy_state.get_effective_model(request_data.model)

--- a/tests/integration/chat_completions_tests/test_project_commands.py
+++ b/tests/integration/chat_completions_tests/test_project_commands.py
@@ -39,3 +39,71 @@ def test_unset_project_command_integration(client):
     call_args = mock_method.call_args[1]
     assert call_args["project"] is None
     assert call_args["processed_messages"][0].content == "please"
+
+
+def test_set_project_name_alias_integration(client):
+    mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
+    with patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "!/set(project-name='alias') hi"}]
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.project == "alias"
+    mock_method.assert_called_once()
+    call_args = mock_method.call_args[1]
+    assert call_args["project"] == "alias"
+    assert call_args["processed_messages"][0].content == "hi"
+
+
+def test_unset_project_name_alias_integration(client):
+    client.app.state.session_manager.get_session("default").proxy_state.set_project("foo")  # type: ignore
+    mock_backend_response = {"choices": [{"message": {"content": "ok"}}]}
+    with patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_backend_response
+        payload = {
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "!/unset(project-name) hi"}]
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.project is None
+    mock_method.assert_called_once()
+    call_args = mock_method.call_args[1]
+    assert call_args["project"] is None
+    assert call_args["processed_messages"][0].content == "hi"
+
+
+def test_force_set_project_blocks_requests(client):
+    client.app.state.force_set_project = True
+    with patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        payload = {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hello"}]
+        }
+        resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 400
+    assert "project" in resp.json()["detail"].lower()
+    mock_method.assert_not_called()
+
+
+def test_force_set_project_allows_after_set(client):
+    client.app.state.force_set_project = True
+    mock_response = {"choices": [{"message": {"content": "ok"}}]}
+    with patch.object(client.app.state.openrouter_backend, 'chat_completions', new_callable=AsyncMock) as mock_method:
+        mock_method.return_value = mock_response
+        payload = {
+            "model": "m",
+            "messages": [{"role": "user", "content": "!/set(project=foo) hi"}]
+        }
+        resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200
+    session = client.app.state.session_manager.get_session("default")  # type: ignore
+    assert session.proxy_state.project == "foo"
+    mock_method.assert_called_once()

--- a/tests/unit/proxy_logic_tests/test_parse_arguments.py
+++ b/tests/unit/proxy_logic_tests/test_parse_arguments.py
@@ -51,3 +51,13 @@ class TestParseArguments:
         args_str = "project=myproject"
         expected = {"project": "myproject"}
         assert parse_arguments(args_str) == expected
+
+    def test_parse_project_name_alias_quotes(self):
+        args_str = "project-name='my project'"
+        expected = {"project-name": "my project"}
+        assert parse_arguments(args_str) == expected
+
+    def test_parse_project_name_alias_no_quotes(self):
+        args_str = "project-name=myproj"
+        expected = {"project-name": "myproj"}
+        assert parse_arguments(args_str) == expected

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -61,6 +61,18 @@ def test_cli_redaction_flag(monkeypatch):
     monkeypatch.delenv("INTERACTIVE_MODE", raising=False)
 
 
+def test_cli_force_set_project(monkeypatch):
+    monkeypatch.delenv("FORCE_SET_PROJECT", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    for i in range(1, 21):
+        monkeypatch.delenv(f"GEMINI_API_KEY_{i}", raising=False)
+    args = parse_cli_args(["--force-set-project"])
+    cfg = apply_cli_args(args)
+    assert os.environ["FORCE_SET_PROJECT"] == "true"
+    assert cfg["force_set_project"] is True
+    monkeypatch.delenv("FORCE_SET_PROJECT", raising=False)
+
+
 def test_cli_log_argument(tmp_path):
     args = parse_cli_args(["--log", str(tmp_path / "out.log")])
     assert args.log_file == str(tmp_path / "out.log")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -112,3 +112,10 @@ def test_redaction_env(monkeypatch):
     cfg = app_main._load_config()
     assert cfg["redact_api_keys_in_prompts"] is False
     monkeypatch.delenv("REDACT_API_KEYS_IN_PROMPTS", raising=False)
+
+
+def test_force_set_project_env(monkeypatch):
+    monkeypatch.setenv("FORCE_SET_PROJECT", "true")
+    cfg = app_main._load_config()
+    assert cfg["force_set_project"] is True
+    monkeypatch.delenv("FORCE_SET_PROJECT", raising=False)


### PR DESCRIPTION
## Summary
- support `project-name` alias for set/unset commands
- add `--force-set-project` CLI flag and config value
- enforce project requirement in main request handler
- extend CLI and config tests
- extend parse_argument tests and integration tests for new alias and flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c1ba65808333bbc3c1e2984ad8da