### PR TITLE
Implement rate limit retries

### DIFF
--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -31,6 +31,18 @@ class RateLimitRegistry:
             return None
         return ts
 
+    def next_available(self) -> Optional[float]:
+        """Return the earliest retry timestamp among all tracked limits."""
+        now = time.time()
+        earliest: float | None = None
+        for key, ts in list(self._until.items()):
+            if now >= ts:
+                del self._until[key]
+                continue
+            if earliest is None or ts < earliest:
+                earliest = ts
+        return earliest
+
 
 def _find_retry_delay_in_details(details_list: list) -> Optional[float]:
     """Iterates through a list of detail items to find and parse RetryInfo."""

--- a/tests/unit/test_rate_limit_registry.py
+++ b/tests/unit/test_rate_limit_registry.py
@@ -1,0 +1,19 @@
+import pytest
+from src.rate_limit import RateLimitRegistry
+
+
+def test_next_available(monkeypatch):
+    reg = RateLimitRegistry()
+
+    monkeypatch.setattr('src.rate_limit.time.time', lambda: 0)
+    reg.set('b1', 'm1', 'k1', 5)
+    reg.set('b2', 'm2', 'k2', 2)
+
+    monkeypatch.setattr('src.rate_limit.time.time', lambda: 1)
+    assert reg.next_available() == pytest.approx(2)
+
+    monkeypatch.setattr('src.rate_limit.time.time', lambda: 3)
+    assert reg.next_available() == pytest.approx(5)
+
+    monkeypatch.setattr('src.rate_limit.time.time', lambda: 6)
+    assert reg.next_available() is None


### PR DESCRIPTION
## Summary
- support waiting and retrying after rate limits expire
- track earliest rate limit expiration
- test new rate limit handling
- test rate limit registry helper

## Testing
- `pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866e4d59b3483339f965fc2cec7d303