### PR TITLE
Fix backend factory to use supplied config

### DIFF
--- a/src/core/services/backend_factory.py
+++ b/src/core/services/backend_factory.py
@@ -57,9 +57,10 @@ class BackendFactory:
         """
         backend_factory = self._backend_registry.get_backend_factory(backend_type)
         # Backend connectors only accept the client and config in constructor
+        effective_config = config if config is not None else self._config
         return backend_factory(
-            self._client, self._config, self._translation_service
-        )  # Modified
+            self._client, effective_config, self._translation_service
+        )
 
     async def initialize_backend(
         self, backend: LLMBackend, init_config: dict[str, Any]


### PR DESCRIPTION
## Summary
- ensure BackendFactory passes the supplied configuration into backend constructors so dynamically updated settings are respected

## Testing
- python -m pytest tests/unit/core/test_backend_factory_ensure_backend.py -k ensure_backend -o addopts= # fails: async plugin missing in environment

------
https://chatgpt.com/codex/tasks/task_e_68ddb0c2dd70833384e1bf14ddc91ee5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes the provided AppConfig into backend constructors (with fallback to stored config) and wires ensure_backend to call create_backend with app_config.
> 
> - **BackendFactory**:
>   - Update `create_backend` to accept `config` and pass it to backend constructors, using the supplied `AppConfig` with fallback to `self._config`.
>   - Wire `ensure_backend` to call `create_backend(backend_type, app_config)` so dynamically provided settings are honored.
>   - No changes to initialization flow; continues building `init_config` and applying backend-specific augmentations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a28de106bdbb9da98940a70d6527c141d02c9bf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->