### PR TITLE
Fix Anthropic metadata merging with extra_body overrides

### DIFF
--- a/src/connectors/anthropic.py
+++ b/src/connectors/anthropic.py
@@ -212,6 +212,14 @@ class AnthropicBackend(LLMBackend):
             "stream": bool(request_data.stream),
         }
 
+        metadata_payload: Any | None = None
+        if project or request_data.user is not None:
+            metadata_payload = {}
+            if project:
+                metadata_payload["project"] = project
+            if request_data.user is not None:
+                metadata_payload["user_id"] = request_data.user
+
         # System message extraction (Anthropic expects it separately)
         system_prompt = None
         anth_messages: list[dict[str, Any]] = []
@@ -253,10 +261,22 @@ class AnthropicBackend(LLMBackend):
             payload["top_p"] = request_data.top_p
         if request_data.stop is not None:
             payload["stop_sequences"] = request_data.stop
-        if project:
-            payload["metadata"] = {"project": project}
-        if request_data.user is not None:
-            payload.setdefault("metadata", {})["user_id"] = request_data.user
+        extra_body: dict[str, Any] = dict(request_data.extra_body or {})
+        extra_metadata = extra_body.pop("metadata", None)
+        if extra_metadata is not None:
+            if metadata_payload is None:
+                metadata_payload = (
+                    dict(extra_metadata)
+                    if isinstance(extra_metadata, dict)
+                    else extra_metadata
+                )
+            elif isinstance(metadata_payload, dict) and isinstance(extra_metadata, dict):
+                metadata_payload.update(extra_metadata)
+            else:
+                metadata_payload = extra_metadata
+
+        if metadata_payload is not None:
+            payload["metadata"] = metadata_payload
 
         # Unsupported parameters
         if request_data.seed is not None and logger.isEnabledFor(logging.WARNING):
@@ -283,7 +303,7 @@ class AnthropicBackend(LLMBackend):
             payload["tools"] = request_data.tools
 
         # Include extra params from domain extra_body directly (allows reasoning, etc.)
-        payload.update(request_data.extra_body or {})
+        payload.update(extra_body)
 
         # Include reasoning_effort when provided
         if getattr(request_data, "reasoning_effort", None) is not None:

--- a/src/connectors/anthropic.py
+++ b/src/connectors/anthropic.py
@@ -270,7 +270,9 @@ class AnthropicBackend(LLMBackend):
                     if isinstance(extra_metadata, dict)
                     else extra_metadata
                 )
-            elif isinstance(metadata_payload, dict) and isinstance(extra_metadata, dict):
+            elif isinstance(metadata_payload, dict) and isinstance(
+                extra_metadata, dict
+            ):
                 metadata_payload.update(extra_metadata)
             else:
                 metadata_payload = extra_metadata

--- a/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
+++ b/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
@@ -211,7 +211,6 @@ async def test_chat_completions_merges_metadata(
     assert sent_payload["custom_flag"] is True
 
 
-
 @pytest.mark.asyncio
 async def test_chat_completions_with_tools(
     anthropic_backend: AnthropicBackend, httpx_mock: HTTPXMock


### PR DESCRIPTION
## Summary
- merge project and user metadata with any metadata provided through `extra_body` when building Anthropic payloads
- add a regression test covering the combined metadata behaviour for Anthropic chat completions

## Testing
- pytest --override-ini addopts="" tests/unit/anthropic_connector_tests/test_domain_to_connector.py *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68de8fbd74a08333b202a1dd9426986f