### PR TITLE
Fix proxy error handler payload shape

### DIFF
--- a/src/core/app/error_handlers.py
+++ b/src/core/app/error_handlers.py
@@ -201,14 +201,17 @@ async def proxy_exception_handler(request: Request, exc: LLMProxyError) -> Respo
             }
         else:
             # Standard error response for non-chat completions endpoints
+            error_payload: dict[str, Any] = {
+                "message": exc_message,
+                "type": exc_name,
+                "status_code": status_code,
+            }
+            if getattr(exc, "details", None):
+                error_payload["details"] = exc.details
+
             content = {
                 "detail": {
-                    "error": exc_message,
-                    **(
-                        {"details": exc.details}
-                        if getattr(exc, "details", None)
-                        else {}
-                    ),
+                    "error": error_payload,
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure proxy_exception_handler returns a structured error payload for non-chat completions requests
- keep error responses consistent with other handlers by embedding message, type, status code, and optional details

## Testing
- pytest tests/unit/chat_completions_tests/test_error_handling_di.py::test_get_openrouter_headers_no_api_key -q *(fails: repository configuration passes unsupported options without required plugins in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8fca2c348333b2355db6dd3f2f02