### PR TITLE
Handle raw responses in empty response middleware

### DIFF
--- a/src/core/services/empty_response_middleware.py
+++ b/src/core/services/empty_response_middleware.py
@@ -150,6 +150,9 @@ class EmptyResponseMiddleware(IResponseMiddleware):
             raw_content = response.get("content")
             if isinstance(raw_content, str):
                 content = raw_content
+            elif raw_content is not None:
+                # Convert non-None content (including structured content) to string
+                content = str(raw_content)
             elif "choices" in response:
                 try:
                     first_choice = response.get("choices", [])[0]

--- a/src/core/services/empty_response_middleware.py
+++ b/src/core/services/empty_response_middleware.py
@@ -140,7 +140,7 @@ class EmptyResponseMiddleware(IResponseMiddleware):
 
         # Prefer explicit ``content`` attribute when present
         if hasattr(response, "content"):
-            raw_content = getattr(response, "content")
+            raw_content = response.content
             if isinstance(raw_content, str):
                 content = raw_content
             elif raw_content is not None:

--- a/tests/unit/test_empty_response_middleware.py
+++ b/tests/unit/test_empty_response_middleware.py
@@ -122,6 +122,46 @@ class TestEmptyResponseMiddleware:
         assert "session123" not in middleware._retry_counts
 
     @pytest.mark.asyncio
+    async def test_process_handles_dict_responses(self):
+        """Middleware should safely handle raw dictionary responses."""
+        middleware = EmptyResponseMiddleware()
+
+        # Non-empty OpenAI-style payload should pass through unchanged
+        raw_response = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "All good here",
+                    }
+                }
+            ]
+        }
+
+        result = await middleware.process(raw_response, "sess-dict", context={})
+        assert result is raw_response
+        assert "sess-dict" not in middleware._retry_counts
+
+        # Empty payload without tool calls should trigger retry logic
+        empty_response = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                    }
+                }
+            ]
+        }
+
+        with pytest.raises(EmptyResponseRetryException):
+            await middleware.process(
+                empty_response,
+                "sess-empty",
+                context={"original_request": "req"},
+            )
+
+    @pytest.mark.asyncio
     @patch("builtins.open", mock_open(read_data="Recovery prompt"))
     @patch("pathlib.Path.exists", return_value=True)
     async def test_process_empty_response_first_retry(self, mock_exists):


### PR DESCRIPTION
## Summary
- normalize arbitrary backend responses before empty-response checks so middleware no longer raises when given raw dict payloads
- extend empty response middleware unit tests to cover OpenAI-style dictionary inputs and retry behaviour

## Testing
- `pytest tests/unit/test_empty_response_middleware.py` *(fails: requires repository-specific pytest plugins defined in pyproject addopts)*

------
https://chatgpt.com/codex/tasks/task_e_68de8fca2c348333b2355db6dd3f2f02