### PR TITLE
Fix rate limit earliest cleanup and add regression test

### DIFF
--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -24,3 +24,17 @@ def test_rate_limit_registry_earliest(monkeypatch: Any) -> None:
     monkeypatch.setattr(time, "time", lambda: t)
     assert registry.get("b2", "m1", "k2") is None
     assert registry.earliest() == 5
+
+
+def test_rate_limit_registry_earliest_prunes_expired(monkeypatch: Any) -> None:
+    t: float = 0.0
+    monkeypatch.setattr(time, "time", lambda: t)
+    registry = RateLimitRegistry()
+    registry.set("b1", "m1", "k1", 10)
+    registry.set("b2", "m2", "k2", 2)
+
+    t = 5
+    monkeypatch.setattr(time, "time", lambda: t)
+
+    assert registry.earliest() == 10
+    assert ("b2", "m2", "k2") not in registry._until


### PR DESCRIPTION
## Summary
- ensure `RateLimitRegistry.earliest` skips expired retry entries and cleans up stale state
- add a regression test covering automatic pruning of expired entries

## Testing
- PYTHONPATH=src:. pytest tests/unit/test_rate_limit.py -q --override-ini="addopts="

------
https://chatgpt.com/codex/tasks/task_e_68ddb0daec34833389c6243eede77299