### PR TITLE
Fix rate limit earliest calculation

### DIFF
--- a/tests/unit/test_rate_limit_registry.py
+++ b/tests/unit/test_rate_limit_registry.py
@@ -135,6 +135,22 @@ class TestRateLimitRegistry:
         result = registry.earliest(combos)
         assert result is None
 
+    def test_earliest_removes_expired_entries(
+        self, registry: RateLimitRegistry
+    ) -> None:
+        """Expired entries should be ignored and removed when checking earliest."""
+
+        registry.set("backend1", "model1", "key1", 30.0)
+        key = ("backend1", "model1", "key1")
+        # Simulate expiration by moving timestamp into the past
+        registry._until[key] = time.time() - 5.0
+
+        result = registry.earliest()
+
+        assert result is None
+        # Ensure expired entries are cleaned up to avoid stale data
+        assert key not in registry._until
+
     def test_multiple_keys_same_backend_model(
         self, registry: RateLimitRegistry
     ) -> None:


### PR DESCRIPTION
## Summary
- update `RateLimitRegistry.earliest` to ignore and prune expired retry entries
- add a regression test ensuring expired timestamps are removed before computing the earliest retry

## Testing
- python -m pytest -o addopts="" tests/unit/test_rate_limit_registry.py::TestRateLimitRegistry::test_earliest_removes_expired_entries

------
https://chatgpt.com/codex/tasks/task_e_68ddb0daec34833389c6243eede77299