### PR TITLE
Fix loop detection result repetitions count

### DIFF
--- a/src/loop_detection/detector.py
+++ b/src/loop_detection/detector.py
@@ -219,15 +219,17 @@ class LoopDetector(ILoopDetector):
         if event is None:
             return LoopDetectionResult(has_loop=False)
 
+        repetition_count = event.repetition_count
+
         return LoopDetectionResult(
             has_loop=True,
             pattern=event.pattern,
-            repetitions=getattr(event, "repetitions", 0),
+            repetitions=repetition_count,
             details={
                 "pattern_length": len(event.pattern) if event.pattern else 0,
                 "total_repeated_chars": (
-                    (len(event.pattern) if event.pattern else 0)
-                    * getattr(event, "repetitions", 0)
+                    (len(event.pattern) if event.pattern else 0) * repetition_count
                 ),
+                "repetitions": repetition_count,
             },
         )


### PR DESCRIPTION
## Summary
- ensure `LoopDetector.check_for_loops` returns the detected repetition count and includes it in the event details

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/loop_detection/test_detector.py *(fails: interpreter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de8feb69b883339da2e28ee43b7de9