### PR TITLE
Fix loop detector service to delegate to internal detector

### DIFF
--- a/src/core/services/loop_detector_service.py
+++ b/src/core/services/loop_detector_service.py
@@ -28,7 +28,17 @@ class LoopDetector(ILoopDetector):
         self._max_pattern_length = max_pattern_length
         self._min_repetitions = min_repetitions
         self._max_samples = max_samples
-        self._config: dict[str, Any] = {}
+        self._detector = self._create_internal_detector()
+
+    def _create_internal_detector(self) -> InternalLoopDetector:
+        """Create a configured instance of the internal loop detector."""
+
+        config = LoopDetectionConfig(
+            max_pattern_length=self._max_pattern_length,
+            content_loop_threshold=self._min_repetitions,
+        )
+
+        return InternalLoopDetector(config=config)
 
     async def check_for_loops(self, content: str) -> LoopDetectionResult:
         def _as_int(value: Any, default: int) -> int:
@@ -59,60 +69,20 @@ class LoopDetector(ILoopDetector):
                 return default
 
         min_len = _as_int(self._min_pattern_length, 50)
-        max_len = _as_int(self._max_pattern_length, 500)
         min_reps = _as_int(self._min_repetitions, 2)
 
         if not content or len(content) < min_len * 2:
             return LoopDetectionResult(has_loop=False)
 
         try:
-            config = LoopDetectionConfig(
-                max_pattern_length=max_len, content_loop_threshold=min_reps
-            )
-
-            _ = InternalLoopDetector(config)
-            results = []
-
-            if len(content) >= min_len * 2:
-                for pattern_length in range(
-                    min_len, min(max_len, len(content) // 2) + 1
-                ):
-                    pattern = content[:pattern_length]
-                    if content.count(pattern) >= min_reps:
-                        results.append(
-                            type(
-                                "obj",
-                                (object,),
-                                {
-                                    "repetitions": content.count(pattern),
-                                    "pattern": pattern,
-                                },
-                            )()
-                        )
-                        break
-
-            if results and results[0].repetitions >= min_reps:
-                result = results[0]
+            result = await self._detector.check_for_loops(content)
+            if result.has_loop and logger.isEnabledFor(logging.WARNING):
                 logger.warning(
-                    f"Loop detected: {result.repetitions} repetitions of pattern (length {len(result.pattern)})"
+                    "Loop detected: %s repetitions of pattern (length %s)",
+                    result.repetitions,
+                    len(result.pattern) if result.pattern else 0,
                 )
-
-                return LoopDetectionResult(
-                    has_loop=True,
-                    pattern=result.pattern,
-                    repetitions=result.repetitions,
-                    details={
-                        "pattern_length": len(result.pattern) if result.pattern else 0,
-                        "total_repeated_chars": (
-                            len(result.pattern) * result.repetitions
-                            if result.pattern
-                            else 0
-                        ),
-                        "repetitions": result.repetitions,
-                    },
-                )
-
-            return LoopDetectionResult(has_loop=False)
+            return result
 
         except (TypeError, ValueError, AttributeError, IndexError) as e:
             if logger.isEnabledFor(logging.ERROR):
@@ -128,6 +98,12 @@ class LoopDetector(ILoopDetector):
         self._min_pattern_length = min_pattern_length
         self._max_pattern_length = max_pattern_length
         self._min_repetitions = min_repetitions
+        self._detector.update_config(
+            LoopDetectionConfig(
+                max_pattern_length=self._max_pattern_length,
+                content_loop_threshold=self._min_repetitions,
+            )
+        )
 
     async def register_tool_call(
         self, tool_name: str, arguments: dict[str, Any]
@@ -135,7 +111,7 @@ class LoopDetector(ILoopDetector):
         return None
 
     async def clear_history(self) -> None:
-        return None
+        self._detector.reset()
 
     def is_enabled(self) -> bool:
         """
@@ -144,7 +120,7 @@ class LoopDetector(ILoopDetector):
         Returns:
             True if enabled, False otherwise.
         """
-        return True
+        return self._detector.is_enabled()
 
     def process_chunk(self, chunk: str) -> LoopDetectionEvent | None:
         """
@@ -156,13 +132,14 @@ class LoopDetector(ILoopDetector):
         Returns:
             A LoopDetectionEvent if a loop is detected, otherwise None.
         """
-        return None
+        return self._detector.process_chunk(chunk)
 
     def reset(self) -> None:
         """
         Resets the internal state of the loop detector.
         This should be called before processing a new sequence of chunks.
         """
+        self._detector.reset()
 
     def get_loop_history(self) -> list[LoopDetectionEvent]:
         """
@@ -171,7 +148,7 @@ class LoopDetector(ILoopDetector):
         Returns:
             A list of historical loop detection data.
         """
-        return []
+        return self._detector.get_loop_history()
 
     def get_current_state(self) -> dict[str, Any]:
         """
@@ -180,8 +157,12 @@ class LoopDetector(ILoopDetector):
         Returns:
             A dictionary representing the current state.
         """
-        return {
-            "min_pattern_length": self._min_pattern_length,
-            "max_pattern_length": self._max_pattern_length,
-            "min_repetitions": self._min_repetitions,
-        }
+        state = self._detector.get_current_state()
+        state.update(
+            {
+                "min_pattern_length": self._min_pattern_length,
+                "max_pattern_length": self._max_pattern_length,
+                "min_repetitions": self._min_repetitions,
+            }
+        )
+        return state

--- a/src/core/services/loop_detector_service.py
+++ b/src/core/services/loop_detector_service.py
@@ -69,7 +69,6 @@ class LoopDetector(ILoopDetector):
                 return default
 
         min_len = _as_int(self._min_pattern_length, 50)
-        min_reps = _as_int(self._min_repetitions, 2)
 
         if not content or len(content) < min_len * 2:
             return LoopDetectionResult(has_loop=False)

--- a/src/core/services/request_processor_service.py
+++ b/src/core/services/request_processor_service.py
@@ -159,7 +159,7 @@ class RequestProcessor(IRequestProcessor):
                     if md is None:
                         continue
                     # Accept either a ModelDefaults instance or a plain dict-like
-                    if isinstance(md, (ModelDefaults, dict)):
+                    if isinstance(md, ModelDefaults | dict):
                         model_defaults = md
                         break
 


### PR DESCRIPTION
## Summary
- rework the loop detector service to build on the shared InternalLoopDetector implementation
- delegate streaming helpers (process_chunk, reset, history/state access) to the configured detector and reuse configuration updates

## Testing
- `python - <<'PY' ...` *(fails: missing optional dependency `json_repair` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8feb69b883339da2e28ee43b7de9