### PR TITLE
Fix hybrid loop detector pattern length reporting

### DIFF
--- a/src/loop_detection/hybrid_detector.py
+++ b/src/loop_detection/hybrid_detector.py
@@ -304,14 +304,18 @@ class HybridLoopDetector(ILoopDetector):
             if event is None:
                 return LoopDetectionResult(has_loop=False)
 
+            repetition_count = event.repetition_count
+            if repetition_count > 0 and event.total_length % repetition_count == 0:
+                pattern_length = event.total_length // repetition_count
+            else:
+                pattern_length = len(event.pattern)
+
             return LoopDetectionResult(
                 has_loop=True,
                 pattern=event.pattern,
-                repetitions=event.repetition_count,
+                repetitions=repetition_count,
                 details={
-                    "pattern_length": (
-                        len(event.pattern) if hasattr(event, "pattern") else 0
-                    ),
+                    "pattern_length": pattern_length,
                     "total_repeated_chars": event.total_length,
                     "detection_method": (
                         "short_pattern" if event.total_length < 500 else "long_pattern"

--- a/tests/unit/loop_detection/test_hybrid_loop_result_details.py
+++ b/tests/unit/loop_detection/test_hybrid_loop_result_details.py
@@ -1,0 +1,31 @@
+"""Hybrid loop detector result detail tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.loop_detection.hybrid_detector import HybridLoopDetector
+
+
+@pytest.mark.asyncio
+async def test_long_pattern_details_report_actual_length() -> None:
+    """Ensure long pattern detection reports the true repeated length."""
+    pattern = "".join(str(i % 10) for i in range(110))
+    content = pattern * 3
+
+    detector = HybridLoopDetector(
+        short_detector_config={"content_loop_threshold": 9999},
+        long_detector_config={
+            "min_pattern_length": len(pattern),
+            "min_repetitions": 3,
+            "max_history": len(content) + 50,
+        },
+    )
+
+    result = await detector.check_for_loops(content)
+
+    assert result.has_loop is True
+    assert result.details is not None
+    assert result.repetitions == 3
+    assert result.details["pattern_length"] == len(pattern)
+    assert result.details["total_repeated_chars"] == len(pattern) * result.repetitions


### PR DESCRIPTION
## Summary
- ensure the hybrid loop detector calculates pattern length from the actual repeated content instead of the preview string
- add a regression test covering long-pattern detection metadata

## Testing
- not run (json_repair dependency missing in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de8feb69b883339da2e28ee43b7de9