### PR TITLE
Fix tool call loop detection for byte responses

### DIFF
--- a/src/core/services/tool_call_loop_middleware.py
+++ b/src/core/services/tool_call_loop_middleware.py
@@ -146,7 +146,7 @@ class ToolCallLoopDetectionMiddleware(IResponseMiddleware):
             data = content
         else:
             # Otherwise try to parse common JSON container types
-            if isinstance(content, (str, bytes, bytearray)):
+            if isinstance(content, str | bytes | bytearray):
                 try:
                     data = json.loads(content)
                 except (json.JSONDecodeError, TypeError, ValueError):

--- a/src/core/services/tool_call_loop_middleware.py
+++ b/src/core/services/tool_call_loop_middleware.py
@@ -145,11 +145,20 @@ class ToolCallLoopDetectionMiddleware(IResponseMiddleware):
         if isinstance(content, dict):
             data = content
         else:
-            # Otherwise try to parse as JSON string
-            try:
-                data = json.loads(content) if isinstance(content, str) else {}
-            except (json.JSONDecodeError, TypeError, ValueError):
-                # Not JSON or doesn't have the expected structure
+            # Otherwise try to parse common JSON container types
+            if isinstance(content, (str, bytes, bytearray)):
+                try:
+                    data = json.loads(content)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    # Not JSON or doesn't have the expected structure
+                    return []
+            else:
+                # Unsupported content type (e.g., streaming iterators)
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Unsupported response content type for tool call extraction: %s",
+                        type(content).__name__,
+                    )
                 return []
 
         # Check for OpenAI format

--- a/tests/unit/test_tool_call_loop_middleware.py
+++ b/tests/unit/test_tool_call_loop_middleware.py
@@ -165,9 +165,7 @@ async def test_process_tool_calls_from_bytes(
 
     # The next identical call should trigger loop protection
     with pytest.raises(ToolCallLoopError) as exc_info:
-        await middleware.process(
-            response, session_id, context={"config": loop_config}
-        )
+        await middleware.process(response, session_id, context={"config": loop_config})
 
     assert "Tool call loop detected" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary
- ensure the tool call loop middleware parses JSON payloads when FastAPI responses provide bytes
- add a regression test covering byte-encoded payloads to keep the behaviour in place

## Testing
- `pytest tests/unit/test_rate_limit_registry.py` *(fails: ModuleNotFoundError: No module named 'json_repair')*


------
https://chatgpt.com/codex/tasks/task_e_68de900e32c8833397eb9509d119dd23