### PR TITLE
Handle duration-style retryDelay metadata

### DIFF
--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -70,14 +70,32 @@ def _find_retry_delay_in_details(details_list: list[Any]) -> float | None:
         if not item.get("@type", "").endswith("RetryInfo"):
             continue
 
-        delay_str = item.get("retryDelay")
-        if not isinstance(delay_str, str) or not delay_str.endswith("s"):
-            continue
+        delay_value = item.get("retryDelay")
 
-        try:
-            return float(delay_str[:-1])
-        except ValueError:
-            pass  # Malformed delay string in this item, try next
+        if isinstance(delay_value, str):
+            if not delay_value.endswith("s"):
+                continue
+
+            try:
+                return float(delay_value[:-1])
+            except ValueError:
+                continue
+
+        if isinstance(delay_value, dict):
+            seconds_value = delay_value.get("seconds", 0)
+            nanos_value = delay_value.get("nanos", 0)
+
+            try:
+                seconds = float(seconds_value)
+            except (TypeError, ValueError):
+                continue
+
+            try:
+                nanos = float(nanos_value)
+            except (TypeError, ValueError):
+                nanos = 0.0
+
+            return seconds + nanos / 1_000_000_000
 
     return None
 

--- a/tests/unit/test_rate_limit_registry.py
+++ b/tests/unit/test_rate_limit_registry.py
@@ -323,6 +323,22 @@ class TestParseRetryDelay:
         result = parse_retry_delay(json_detail)
         assert result == 20.0
 
+    def test_parse_retry_delay_with_duration_object(self) -> None:
+        """Test parsing RetryInfo duration dictionaries."""
+        detail = {
+            "error": {
+                "details": [
+                    {
+                        "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                        "retryDelay": {"seconds": "12", "nanos": 500_000_000},
+                    }
+                ]
+            }
+        }
+
+        result = parse_retry_delay(detail)
+        assert result == pytest.approx(12.5)
+
     def test_parse_retry_delay_with_embedded_json(self) -> None:
         """Test parsing string with embedded JSON."""
         detail = 'prefix {"error": {"details": [{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "25s"}]}} suffix'


### PR DESCRIPTION
## Summary
- extend retry delay parsing to support google RetryInfo payloads that provide retryDelay as a seconds/nanos dictionary
- add coverage ensuring duration dictionaries are parsed correctly

## Testing
- `python -m pytest tests/unit/test_rate_limit_registry.py -k duration_object` *(fails: ModuleNotFoundError: No module named 'json_repair')*

------
https://chatgpt.com/codex/tasks/task_e_68de900e32c8833397eb9509d119dd23