### PR TITLE
Fix usage tracking zero token fallback logic

### DIFF
--- a/src/core/services/usage_tracking_service.py
+++ b/src/core/services/usage_tracking_service.py
@@ -200,18 +200,38 @@ class UsageTrackingService(IUsageTrackingService):
                 billing = extract_billing_info_from_headers(
                     tracker.response_headers, backend
                 )
-                u = billing.get("usage", {})
-                prompt_tokens = prompt_tokens or u.get("prompt_tokens")
-                completion_tokens = completion_tokens or u.get("completion_tokens")
-                total_tokens = total_tokens or u.get("total_tokens")
+                usage_details = billing.get("usage", {})
+                header_prompt_tokens = usage_details.get("prompt_tokens")
+                header_completion_tokens = usage_details.get("completion_tokens")
+                header_total_tokens = usage_details.get("total_tokens")
+
+                if prompt_tokens is None and header_prompt_tokens is not None:
+                    prompt_tokens = header_prompt_tokens
+                if (
+                    completion_tokens is None
+                    and header_completion_tokens is not None
+                ):
+                    completion_tokens = header_completion_tokens
+                if total_tokens is None and header_total_tokens is not None:
+                    total_tokens = header_total_tokens
 
             # Extract from response body
             if tracker.response is not None:
                 billing = extract_billing_info_from_response(tracker.response, backend)
-                u = billing.get("usage", {})
-                prompt_tokens = prompt_tokens or u.get("prompt_tokens")
-                completion_tokens = completion_tokens or u.get("completion_tokens")
-                total_tokens = total_tokens or u.get("total_tokens")
+                usage_details = billing.get("usage", {})
+                response_prompt_tokens = usage_details.get("prompt_tokens")
+                response_completion_tokens = usage_details.get("completion_tokens")
+                response_total_tokens = usage_details.get("total_tokens")
+
+                if prompt_tokens is None and response_prompt_tokens is not None:
+                    prompt_tokens = response_prompt_tokens
+                if (
+                    completion_tokens is None
+                    and response_completion_tokens is not None
+                ):
+                    completion_tokens = response_completion_tokens
+                if total_tokens is None and response_total_tokens is not None:
+                    total_tokens = response_total_tokens
 
             # Persist usage data
             usage_data = await self.track_usage(

--- a/src/core/services/usage_tracking_service.py
+++ b/src/core/services/usage_tracking_service.py
@@ -207,10 +207,7 @@ class UsageTrackingService(IUsageTrackingService):
 
                 if prompt_tokens is None and header_prompt_tokens is not None:
                     prompt_tokens = header_prompt_tokens
-                if (
-                    completion_tokens is None
-                    and header_completion_tokens is not None
-                ):
+                if completion_tokens is None and header_completion_tokens is not None:
                     completion_tokens = header_completion_tokens
                 if total_tokens is None and header_total_tokens is not None:
                     total_tokens = header_total_tokens
@@ -225,10 +222,7 @@ class UsageTrackingService(IUsageTrackingService):
 
                 if prompt_tokens is None and response_prompt_tokens is not None:
                     prompt_tokens = response_prompt_tokens
-                if (
-                    completion_tokens is None
-                    and response_completion_tokens is not None
-                ):
+                if completion_tokens is None and response_completion_tokens is not None:
                     completion_tokens = response_completion_tokens
                 if total_tokens is None and response_total_tokens is not None:
                     total_tokens = response_total_tokens

--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -36,10 +36,15 @@ class RateLimitRegistry:
             keys = list(self._until.keys())
         else:
             combos_list = list(combos)
-            if not combos_list:  # Empty list should fall back to all entries (preserve original behavior)
+            if (
+                not combos_list
+            ):  # Empty list should fall back to all entries (preserve original behavior)
                 keys = list(self._until.keys())
             else:
-                keys = [(backend, model or "", key_name) for backend, model, key_name in combos_list]
+                keys = [
+                    (backend, model or "", key_name)
+                    for backend, model, key_name in combos_list
+                ]
         now = time.time()
         valid_times: list[float] = []
         expired_keys: list[tuple[str, str, str]] = []


### PR DESCRIPTION
## Summary
- ensure usage token values extracted from headers or responses are only overridden when missing
- preserve legitimate zero token counts when persisting usage data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9028623883338fb4947e4bb331fb