### PR TITLE
Fix usage tracking cost extraction

### DIFF
--- a/src/core/services/usage_tracking_service.py
+++ b/src/core/services/usage_tracking_service.py
@@ -7,6 +7,7 @@ This service integrates usage tracking with the new SOLID architecture.
 from __future__ import annotations
 
 import logging
+import math
 import time
 import uuid
 from collections.abc import AsyncGenerator
@@ -148,6 +149,7 @@ class UsageTrackingService(IUsageTrackingService):
                 self.cost = 0.0
                 self.remote_completion_id: str | None = None
                 self.usage_data: UsageData | None = None
+                self.cost_overridden = False
 
             def set_response(
                 self, response: dict[str, Any] | StreamingResponseLike
@@ -162,6 +164,7 @@ class UsageTrackingService(IUsageTrackingService):
             def set_cost(self, cost: float) -> None:
                 """Set the cost for this request."""
                 self.cost = cost
+                self.cost_overridden = True
 
             def set_completion_id(self, completion_id: str) -> None:
                 """Set the remote completion ID."""
@@ -193,7 +196,9 @@ class UsageTrackingService(IUsageTrackingService):
             prompt_tokens = None
             completion_tokens = None
             total_tokens = None
-            cost = tracker.cost
+            derived_cost: float | None = (
+                tracker.cost if tracker.cost_overridden else None
+            )
 
             # Extract from headers first if available
             if tracker.response_headers:
@@ -204,6 +209,10 @@ class UsageTrackingService(IUsageTrackingService):
                 prompt_tokens = prompt_tokens or u.get("prompt_tokens")
                 completion_tokens = completion_tokens or u.get("completion_tokens")
                 total_tokens = total_tokens or u.get("total_tokens")
+                if not tracker.cost_overridden:
+                    header_cost = self._parse_billing_cost(billing.get("cost"))
+                    if header_cost is not None:
+                        derived_cost = header_cost
 
             # Extract from response body
             if tracker.response is not None:
@@ -212,6 +221,18 @@ class UsageTrackingService(IUsageTrackingService):
                 prompt_tokens = prompt_tokens or u.get("prompt_tokens")
                 completion_tokens = completion_tokens or u.get("completion_tokens")
                 total_tokens = total_tokens or u.get("total_tokens")
+                if not tracker.cost_overridden:
+                    response_cost = self._parse_billing_cost(billing.get("cost"))
+                    if response_cost is not None:
+                        derived_cost = response_cost
+
+            cost = (
+                tracker.cost
+                if tracker.cost_overridden
+                else derived_cost if derived_cost is not None else tracker.cost
+            )
+            if not tracker.cost_overridden and derived_cost is not None:
+                tracker.cost = cost
 
             # Persist usage data
             usage_data = await self.track_usage(
@@ -227,6 +248,24 @@ class UsageTrackingService(IUsageTrackingService):
                 session_id=session_id,
             )
             tracker.set_usage_data(usage_data)
+
+    @staticmethod
+    def _parse_billing_cost(value: Any) -> float | None:
+        """Parse a billing cost value into a float if valid."""
+
+        if value is None:
+            return None
+        try:
+            candidate = float(value)
+        except (TypeError, ValueError):
+            logger.debug("Ignoring invalid billing cost value: %s", value, exc_info=True)
+            return None
+        if math.isnan(candidate) or math.isinf(candidate):
+            logger.debug(
+                "Ignoring non-finite billing cost value: %s", value, exc_info=True
+            )
+            return None
+        return candidate
 
     async def get_usage_stats(
         self, project: str | None = None, days: int = 30

--- a/tests/unit/core/services/usage_tracking_service_cost_test.py
+++ b/tests/unit/core/services/usage_tracking_service_cost_test.py
@@ -1,0 +1,82 @@
+"""Tests for usage tracking cost extraction logic."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.core.interfaces.repositories_interface import IUsageRepository
+from src.core.services.usage_tracking_service import UsageTrackingService
+
+
+@pytest.fixture
+def mock_repository() -> AsyncMock:
+    """Create a mock usage repository that returns the entity being added."""
+
+    repo = AsyncMock(spec=IUsageRepository)
+
+    async def _add(entity):
+        return entity
+
+    repo.add.side_effect = _add
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_track_request_uses_billing_cost(
+    mock_repository: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Track request should store billing-derived cost when available."""
+
+    service = UsageTrackingService(mock_repository)
+
+    monkeypatch.setattr(
+        "src.core.services.usage_tracking_service.extract_billing_info_from_headers",
+        lambda headers, backend: {"usage": {}, "cost": "1.25"},
+    )
+    monkeypatch.setattr(
+        "src.core.services.usage_tracking_service.extract_billing_info_from_response",
+        lambda response, backend: {"usage": {}, "cost": "2.5"},
+    )
+
+    async with service.track_request(
+        model="gpt-4", backend="openai", messages=[]
+    ) as tracker:
+        tracker.set_response_headers({"x-test": "value"})
+        tracker.set_response({"id": "resp"})
+
+    usage_data = mock_repository.add.await_args.args[0]
+    assert usage_data.cost == pytest.approx(2.5)
+    assert tracker.cost == pytest.approx(2.5)
+    assert tracker.usage_data is usage_data
+
+
+@pytest.mark.asyncio
+async def test_track_request_preserves_manual_cost(
+    mock_repository: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manual cost overrides billing-derived values."""
+
+    service = UsageTrackingService(mock_repository)
+
+    monkeypatch.setattr(
+        "src.core.services.usage_tracking_service.extract_billing_info_from_headers",
+        lambda headers, backend: {"usage": {}, "cost": "3.5"},
+    )
+    monkeypatch.setattr(
+        "src.core.services.usage_tracking_service.extract_billing_info_from_response",
+        lambda response, backend: {"usage": {}, "cost": "4.0"},
+    )
+
+    async with service.track_request(
+        model="gpt-4", backend="openai", messages=[]
+    ) as tracker:
+        tracker.set_cost(9.99)
+        tracker.set_response_headers({"x-test": "value"})
+        tracker.set_response({"id": "resp"})
+
+    usage_data = mock_repository.add.await_args.args[0]
+    assert usage_data.cost == pytest.approx(9.99)
+    assert tracker.cost == pytest.approx(9.99)
+    assert tracker.usage_data is usage_data


### PR DESCRIPTION
## Summary
- ensure the usage tracking service captures billing-derived cost data unless callers set a manual override
- add regression tests that verify billing costs are applied and that manual overrides remain untouched

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/core/services/usage_tracking_service_cost_test.py *(fails: `.venv/Scripts/python.exe` is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9028623883338fb4947e4bb331fb