### PR TITLE
Fix Anthropic server DI setup

### DIFF
--- a/src/anthropic_server.py
+++ b/src/anthropic_server.py
@@ -19,7 +19,7 @@ def create_anthropic_app(config: AppConfig) -> FastAPI:
     """
     Create a lightweight FastAPI application with only Anthropic routes.
     """
-    _, app_config = build_app_with_config(config)
+    built_app, app_config = build_app_with_config(config)
 
     app = FastAPI(
         title="Anthropic LLM Interactive Proxy",
@@ -27,6 +27,12 @@ def create_anthropic_app(config: AppConfig) -> FastAPI:
         version="0.1.0",
         lifespan=None,
     )
+
+    service_provider = getattr(built_app.state, "service_provider", None)
+    if service_provider is not None:
+        app.state.service_provider = service_provider
+    else:
+        logger.warning("Service provider missing from built app; Anthropic routes may fail")
 
     _register_anthropic_endpoints(app, prefix="")
 

--- a/src/anthropic_server.py
+++ b/src/anthropic_server.py
@@ -32,7 +32,9 @@ def create_anthropic_app(config: AppConfig) -> FastAPI:
     if service_provider is not None:
         app.state.service_provider = service_provider
     else:
-        logger.warning("Service provider missing from built app; Anthropic routes may fail")
+        logger.warning(
+            "Service provider missing from built app; Anthropic routes may fail"
+        )
 
     _register_anthropic_endpoints(app, prefix="")
 

--- a/tests/unit/test_anthropic_server.py
+++ b/tests/unit/test_anthropic_server.py
@@ -15,6 +15,7 @@ def test_create_anthropic_app_registers_endpoints() -> None:
     # App should be created and configured
     assert app is not None
     assert hasattr(app.state, "app_config")
+    assert getattr(app.state, "service_provider", None) is not None
 
     # Ensure key Anthropic endpoints exist without prefix
     paths = {route.path for route in app.router.routes}  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- propagate the DI service provider from the full application build into the Anthropic-only FastAPI app so its endpoints can resolve dependencies
- extend the Anthropic server unit test to verify that the service provider is attached to the app state

## Testing
- python -m pytest tests/unit/test_anthropic_server.py *(fails: ModuleNotFoundError: No module named 'json_repair')*


------
https://chatgpt.com/codex/tasks/task_e_68debadf05588333a7641eae47283ce5