### PR TITLE
Fix translation service DI alias to reuse singleton instance

### DIFF
--- a/src/core/app/stages/backend.py
+++ b/src/core/app/stages/backend.py
@@ -140,13 +140,18 @@ class BackendStage(InitializationStage):
             )
             from src.core.services.translation_service import TranslationService
 
-            # Register concrete implementation
+            # Register concrete implementation once
             services.add_singleton(TranslationService)
 
-            # Register interface
+            # Ensure interface resolves to the same singleton instance via factory
+            def _translation_service_alias_factory(
+                provider: IServiceProvider,
+            ) -> TranslationService:
+                return provider.get_required_service(TranslationService)
+
             services.add_singleton(
                 cast(type, ITranslationService),
-                implementation_type=TranslationService,
+                implementation_factory=_translation_service_alias_factory,
             )
 
             if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
## Summary
- ensure the backend stage registers the translation service protocol via a factory that reuses the concrete singleton instance

## Testing
- python -m pytest tests/unit/core/services/test_backend_service_hypothesis.py -k translation_service --maxfail=1 *(fails: ModuleNotFoundError: No module named 'json_repair')*


------
https://chatgpt.com/codex/tasks/task_e_68debadf05588333a7641eae47283ce5