### PR TITLE
Fix DI provider exposure for Anthropic server

### DIFF
--- a/src/anthropic_server.py
+++ b/src/anthropic_server.py
@@ -19,7 +19,7 @@ def create_anthropic_app(config: AppConfig) -> FastAPI:
     """
     Create a lightweight FastAPI application with only Anthropic routes.
     """
-    _, app_config = build_app_with_config(config)
+    full_app, app_config = build_app_with_config(config)
 
     app = FastAPI(
         title="Anthropic LLM Interactive Proxy",
@@ -27,6 +27,12 @@ def create_anthropic_app(config: AppConfig) -> FastAPI:
         version="0.1.0",
         lifespan=None,
     )
+
+    service_provider = getattr(full_app.state, "service_provider", None)
+    if service_provider is None and logger.isEnabledFor(logging.WARNING):
+        logger.warning("Service provider missing from Anthropic app state.")
+    elif service_provider is not None:
+        app.state.service_provider = service_provider
 
     _register_anthropic_endpoints(app, prefix="")
 

--- a/tests/unit/test_anthropic_server.py
+++ b/tests/unit/test_anthropic_server.py
@@ -15,6 +15,8 @@ def test_create_anthropic_app_registers_endpoints() -> None:
     # App should be created and configured
     assert app is not None
     assert hasattr(app.state, "app_config")
+    assert hasattr(app.state, "service_provider")
+    assert app.state.service_provider is not None
 
     # Ensure key Anthropic endpoints exist without prefix
     paths = {route.path for route in app.router.routes}  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- ensure the Anthropic-only FastAPI application copies the DI service provider from the staged app build
- extend the Anthropic server unit test to assert the service provider is available on the app state

## Testing
- python -m pytest tests/unit/test_anthropic_server.py *(fails: ModuleNotFoundError: No module named 'json_repair')*

------
https://chatgpt.com/codex/tasks/task_e_68debadf05588333a7641eae47283ce5