### PR TITLE
Fix streaming JSON repair fallback when repair fails

### DIFF
--- a/src/core/services/streaming/json_repair_processor.py
+++ b/src/core/services/streaming/json_repair_processor.py
@@ -141,7 +141,7 @@ class JsonRepairProcessor(IStreamProcessor):
                 schema=self._schema,
                 strict=self._strict_mode,
             )
-            success = True
+            success = repaired is not None
         except Exception as e:  # pragma: no cover - strict mode rethrow
             if self._strict_mode:
                 raise JSONParsingError(

--- a/tests/unit/json_repair_processor_test.py
+++ b/tests/unit/json_repair_processor_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.core.domain.streaming_content import StreamingContent
+from src.core.services.json_repair_service import JsonRepairService
+from src.core.services.streaming.json_repair_processor import JsonRepairProcessor
+
+
+class FailingJsonRepairService(JsonRepairService):
+    """Test double that simulates a repair failure without raising."""
+
+    def repair_and_validate_json(
+        self,
+        json_string: str,
+        schema: dict[str, Any] | None = None,
+        strict: bool = False,
+    ) -> dict[str, Any] | None:
+        return None
+
+
+def test_json_repair_processor_flushes_raw_buffer_when_repair_returns_none() -> None:
+    processor = JsonRepairProcessor(
+        repair_service=FailingJsonRepairService(),
+        buffer_cap_bytes=1024,
+        strict_mode=False,
+    )
+
+    chunk = StreamingContent(content='{"foo": "bar"}', is_done=False)
+
+    result = asyncio.run(processor.process(chunk))
+
+    assert result.content == '{"foo": "bar"}'


### PR DESCRIPTION
## Summary
- ensure `JsonRepairProcessor` treats failed repairs as failures so buffered JSON is emitted unchanged instead of `null`
- add a regression test covering the non-strict repair failure path

## Testing
- python -m pytest -o addopts='' tests/unit/json_repair_processor_test.py

------
https://chatgpt.com/codex/tasks/task_e_68de8fd670788333ab840e16d73e5c48