### PR TITLE
Allow storing session ID through secure state proxy

### DIFF
--- a/src/core/services/secure_state_service.py
+++ b/src/core/services/secure_state_service.py
@@ -153,6 +153,7 @@ class StateAccessProxy:
         "api_key_redaction_enabled",
         "rate_limits",
         "session_manager",
+        "session_id",
         "client_api_key",
         "disable_auth",
         "httpx_client",

--- a/tests/unit/core/services/test_secure_state_service.py
+++ b/tests/unit/core/services/test_secure_state_service.py
@@ -6,8 +6,6 @@ from src.core.services.secure_state_service import StateAccessProxy
 class _DummyState:
     """Simple stand-in for FastAPI app.state."""
 
-    pass
-
 
 def test_state_access_proxy_allows_session_id_attribute() -> None:
     """Setting session_id should be allowed for middleware compatibility."""

--- a/tests/unit/core/services/test_secure_state_service.py
+++ b/tests/unit/core/services/test_secure_state_service.py
@@ -1,0 +1,18 @@
+"""Tests for secure state service utilities."""
+
+from src.core.services.secure_state_service import StateAccessProxy
+
+
+class _DummyState:
+    """Simple stand-in for FastAPI app.state."""
+
+    pass
+
+
+def test_state_access_proxy_allows_session_id_attribute() -> None:
+    """Setting session_id should be allowed for middleware compatibility."""
+    proxy = StateAccessProxy(_DummyState(), [])
+
+    proxy.session_id = "abc123"
+
+    assert proxy.session_id == "abc123"


### PR DESCRIPTION
## Summary
- allow the secure state proxy to treat `session_id` as an always-allowed attribute so header middleware can persist it
- add a regression test ensuring `session_id` can be set on the proxy without raising

## Testing
- python -m pytest tests/unit/core/services/test_secure_state_service.py -o addopts="" --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68df909ef3dc833396ebe28418a307c5