### PR TITLE
Fix Gemini streaming conversion for structured deltas

### DIFF
--- a/src/gemini_converters.py
+++ b/src/gemini_converters.py
@@ -445,4 +445,21 @@ def _openai_delta_to_part(choice_fragment: dict[str, Any]) -> Part | None:
     content = delta.get("content")
     if not content:
         return None
-    return Part(text=content)  # type: ignore[call-arg]
+
+    if isinstance(content, str):
+        return Part(text=content)  # type: ignore[call-arg]
+
+    if isinstance(content, list):
+        text_segments: list[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type in {"text", "output_text"}:
+                text_value = item.get("text")
+                if isinstance(text_value, str) and text_value:
+                    text_segments.append(text_value)
+        if text_segments:
+            return Part(text="".join(text_segments))  # type: ignore[call-arg]
+
+    return None

--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -6,7 +6,6 @@ Tests the conversion logic between Gemini and OpenAI formats.
 import json
 
 from src.core.domain.chat import ChatMessage
-
 from src.gemini_converters import (
     gemini_to_openai_messages,
     openai_to_gemini_contents,
@@ -104,8 +103,8 @@ class TestMessageConversion:
     def test_openai_stream_chunk_with_structured_content(self) -> None:
         """Ensure streaming conversion handles list-based delta content."""
         chunk = (
-            "data: {\"choices\": [{\"index\": 0, \"delta\": {"
-            "\"content\": [{\"type\": \"text\", \"text\": \"Hello\"}]}}]}\n\n"
+            'data: {"choices": [{"index": 0, "delta": {'
+            '"content": [{"type": "text", "text": "Hello"}]}}]}\n\n'
         )
 
         gemini_chunk = openai_to_gemini_stream_chunk(chunk)

--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -3,10 +3,14 @@ Unit tests for Gemini API converter functions.
 Tests the conversion logic between Gemini and OpenAI formats.
 """
 
+import json
+
 from src.core.domain.chat import ChatMessage
+
 from src.gemini_converters import (
     gemini_to_openai_messages,
     openai_to_gemini_contents,
+    openai_to_gemini_stream_chunk,
 )
 from src.gemini_models import (
     Blob,
@@ -96,3 +100,18 @@ class TestMessageConversion:
         assert len(contents) == 1
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello!"
+
+    def test_openai_stream_chunk_with_structured_content(self) -> None:
+        """Ensure streaming conversion handles list-based delta content."""
+        chunk = (
+            "data: {\"choices\": [{\"index\": 0, \"delta\": {"
+            "\"content\": [{\"type\": \"text\", \"text\": \"Hello\"}]}}]}\n\n"
+        )
+
+        gemini_chunk = openai_to_gemini_stream_chunk(chunk)
+        assert gemini_chunk.startswith("data: ")
+
+        payload = gemini_chunk[6:].strip()
+        data = json.loads(payload)
+
+        assert data["candidates"][0]["content"]["parts"][0]["text"] == "Hello"


### PR DESCRIPTION
## Summary
- handle list-based delta content when converting OpenAI streaming chunks to Gemini format
- add a regression test that covers structured delta content from OpenAI streams

## Testing
- python -m pytest tests/unit/test_gemini_converters.py *(fails: repository pytest configuration requires plugins that are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df90b5ef1083338b51cc471285d867