### PR TITLE
Fix exception mapping union handling

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -42,7 +42,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- prevent `isinstance` from raising `TypeError` when mapping configuration or invalid request errors by using a tuple argument

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df90b5ef1083338b51cc471285d867