### PR TITLE
Handle negative lengths in ResponseBuffer.get_recent_content

### DIFF
--- a/src/loop_detection/buffer.py
+++ b/src/loop_detection/buffer.py
@@ -47,6 +47,9 @@ class ResponseBuffer:
 
     def get_recent_content(self, length: int) -> str:
         """Get the most recent content up to specified length."""
+        if length <= 0:
+            return ""
+
         content = self.get_content()
         return content[-length:] if len(content) > length else content
 


### PR DESCRIPTION
## Summary
- ensure `ResponseBuffer.get_recent_content` returns an empty string when given a non-positive length

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/loop_detection/test_buffer_comprehensive.py -k get_recent_content_edge_cases -vv *(fails: ModuleNotFoundError: No module named 'json_repair')*

------
https://chatgpt.com/codex/tasks/task_e_68df90d60f748333958d4b8612dfff2b