### PR TITLE
Handle invalid persisted backend selection gracefully

### DIFF
--- a/stubs/colorama/__init__.py
+++ b/stubs/colorama/__init__.py
@@ -1,0 +1,24 @@
+"""Minimal runtime stub for the colorama package used in tests."""
+
+from __future__ import annotations
+
+__all__ = ["init", "deinit", "Fore", "Back", "Style"]
+
+
+def init(*_args, **_kwargs) -> None:  # pragma: no cover - behaviorless stub
+    """No-op replacement for :func:`colorama.init`."""
+
+
+def deinit() -> None:  # pragma: no cover - behaviorless stub
+    """No-op replacement for :func:`colorama.deinit`."""
+
+
+class _ColorAttributes:
+    def __getattr__(self, _name: str) -> str:  # pragma: no cover - trivial return
+        return ""
+
+
+Fore = _ColorAttributes()
+Back = _ColorAttributes()
+Style = _ColorAttributes()
+Style.RESET_ALL = ""

--- a/stubs/json_repair/__init__.py
+++ b/stubs/json_repair/__init__.py
@@ -1,0 +1,29 @@
+"""Lightweight fallback implementation of the ``json_repair`` package."""
+
+from __future__ import annotations
+
+import ast
+import json
+from typing import Any
+
+
+def repair_json(json_string: str, **_: Any) -> str:
+    """Repair a JSON string by attempting tolerant parsing.
+
+    This fallback tries a normal ``json.loads`` first.  If parsing fails we
+    fall back to ``ast.literal_eval`` which tolerates trailing commas and
+    single-quoted keys/values.  The parsed object is then re-serialized to a
+    JSON string so the rest of the code-path can consume it normally.
+    """
+
+    try:
+        # Fast path for already-valid JSON.
+        json.loads(json_string)
+        return json_string
+    except json.JSONDecodeError:
+        try:
+            repaired_obj = ast.literal_eval(json_string)
+        except (SyntaxError, ValueError) as exc:  # pragma: no cover - mirrors library failure
+            raise exc
+
+    return json.dumps(repaired_obj)

--- a/stubs/pytz/__init__.py
+++ b/stubs/pytz/__init__.py
@@ -1,0 +1,14 @@
+"""Minimal pytz shim using zoneinfo for tests."""
+
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+__all__ = ["timezone"]
+
+
+def timezone(name: str) -> ZoneInfo:  # pragma: no cover - thin wrapper
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        return ZoneInfo("UTC")

--- a/stubs/watchdog/__init__.py
+++ b/stubs/watchdog/__init__.py
@@ -1,0 +1,7 @@
+"""Minimal watchdog stub for unit tests."""
+
+from __future__ import annotations
+
+from . import events, observers
+
+__all__ = ["events", "observers"]

--- a/stubs/watchdog/events.py
+++ b/stubs/watchdog/events.py
@@ -1,0 +1,19 @@
+"""Minimal subset of watchdog.events used in tests."""
+
+from __future__ import annotations
+
+__all__ = ["FileSystemEventHandler"]
+
+
+class FileSystemEventHandler:  # pragma: no cover - behaviorless stub
+    def on_any_event(self, _event) -> None:
+        pass
+
+    def on_created(self, _event) -> None:
+        pass
+
+    def on_modified(self, _event) -> None:
+        pass
+
+    def on_deleted(self, _event) -> None:
+        pass

--- a/stubs/watchdog/observers/__init__.py
+++ b/stubs/watchdog/observers/__init__.py
@@ -1,0 +1,37 @@
+"""Minimal watchdog.observers stub used during tests."""
+
+from __future__ import annotations
+
+__all__ = ["Observer", "api"]
+
+
+class Observer:  # pragma: no cover - behaviorless stub
+    def schedule(self, *_args, **_kwargs) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def join(self, *_args, **_kwargs) -> None:
+        pass
+
+
+class _BaseObserver:  # pragma: no cover - behaviorless stub
+    def schedule(self, *_args, **_kwargs) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def join(self, *_args, **_kwargs) -> None:
+        pass
+
+
+class api:  # pragma: no cover - behaviorless stub module
+    BaseObserver = _BaseObserver


### PR DESCRIPTION
## Summary
- ensure `ConfigManager` logs and retains a persisted default backend even when it is not currently functional
- add coverage that exercises the new behavior when a backend is unavailable
- supply lightweight stubs for optional third-party dependencies so tests can import without the real packages

## Testing
- `PYTHONPATH=stubs python -m pytest --override-ini=addopts="" tests/unit/test_config_persistence.py -k missing_backend -q`
- `PYTHONPATH=stubs python -m pytest --override-ini=addopts="" -q` *(fails: missing dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68df913863488333ba705a621cba26ed