### PR TITLE
Fix Gemini stop sequence handling in translation service

### DIFF
--- a/src/core/domain/translation.py
+++ b/src/core/domain/translation.py
@@ -552,7 +552,12 @@ class Translation:
         if request.max_tokens is not None:
             config["maxOutputTokens"] = request.max_tokens
         if request.stop:
-            config["stopSequences"] = request.stop
+            stop_sequences = (
+                request.stop
+                if isinstance(request.stop, list)
+                else [request.stop]
+            )
+            config["stopSequences"] = stop_sequences
         # Check for CLI override first (--thinking-budget flag)
         import os
 

--- a/tests/unit/core/domain/test_translation_stop_sequences.py
+++ b/tests/unit/core/domain/test_translation_stop_sequences.py
@@ -1,0 +1,18 @@
+"""Regression tests for Gemini stop sequence handling."""
+
+from src.core.domain.chat import CanonicalChatRequest, ChatMessage
+from src.core.domain.translation import Translation
+
+
+def test_stop_sequence_string_is_wrapped_in_list() -> None:
+    """Ensure Gemini translation wraps single stop strings in a list."""
+
+    request = CanonicalChatRequest(
+        model="gemini-1.5-pro",
+        messages=[ChatMessage(role="user", content="Hello")],
+        stop="FINISH",
+    )
+
+    gemini_request = Translation.from_domain_to_gemini_request(request)
+
+    assert gemini_request["generationConfig"]["stopSequences"] == ["FINISH"]


### PR DESCRIPTION
## Summary
- ensure `Translation.from_domain_to_gemini_request` wraps single string stop sequences in a list before building Gemini payloads
- add a regression test covering string stop sequences for the Gemini translator

## Testing
- `pytest tests/unit/core/domain/test_translation_stop_sequences.py --override-ini=addopts="" -q`
- `pytest --override-ini=addopts="" -q` *(fails: missing optional dependencies such as watchdog, respx, pytest_asyncio, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68df916e6d6c83339bb46ea7fd2b89b1