### PR TITLE
Handle dict responses in logging middleware

### DIFF
--- a/src/core/services/response_middleware.py
+++ b/src/core/services/response_middleware.py
@@ -29,12 +29,25 @@ class LoggingMiddleware(IResponseMiddleware):
             response_type = (
                 context.get("response_type", "unknown") if context else "unknown"
             )
-            usage_info = response.usage if response.usage else {}
+
+            if isinstance(response, dict):
+                raw_content = response.get("content")
+                usage_info = response.get("usage", {}) or {}
+            else:
+                raw_content = getattr(response, "content", None)
+                usage_info = getattr(response, "usage", {}) or {}
+
+            try:
+                content_length = len(raw_content) if raw_content else 0
+            except TypeError:
+                content_length = 0
 
             logger.debug(
-                f"Response processed for session {session_id} ({response_type}): "
-                f"content_len={len(response.content) if response.content else 0}, "
-                f"usage={usage_info}"
+                "Response processed for session %s (%s): content_len=%s, usage=%s",
+                session_id,
+                response_type,
+                content_length,
+                usage_info,
             )
 
         return response

--- a/tests/unit/core/services/test_response_middleware.py
+++ b/tests/unit/core/services/test_response_middleware.py
@@ -45,6 +45,15 @@ class TestLoggingMiddleware:
         result = await middleware.process(response, "session123", context)
         assert result == response
 
+    @pytest.mark.asyncio
+    async def test_process_handles_dict_response(self, middleware):
+        """Logging middleware should handle plain dictionary responses."""
+        response = {"content": "ok", "usage": {"tokens": 1}}
+
+        result = await middleware.process(response, "session123", {})
+
+        assert result is response
+
 
 class TestContentFilterMiddleware:
     """Test the ContentFilterMiddleware functionality."""


### PR DESCRIPTION
## Summary
- ensure `LoggingMiddleware` tolerates responses that expose their data as dictionaries by computing content length and usage defensively
- cover dictionary responses with a new unit test for the logging middleware

## Testing
- `python -m pytest tests/unit/core/services/test_response_middleware.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68df916e6d6c83339bb46ea7fd2b89b1