### PR TITLE
Fix ResponseParser tool call content fallback

### DIFF
--- a/src/core/services/response_parser_service.py
+++ b/src/core/services/response_parser_service.py
@@ -58,6 +58,14 @@ class ResponseParser(IResponseParser):
                         metadata["tool_calls"] = [
                             tc.model_dump() for tc in choice.message.tool_calls
                         ]
+                        if not content:
+                            try:
+                                content = json.dumps(metadata["tool_calls"])
+                            except Exception:
+                                logger.debug(
+                                    "Failed to serialize tool_calls; leaving content empty",
+                                    exc_info=True,
+                                )
             if raw_response.usage:
                 usage = raw_response.usage
 


### PR DESCRIPTION
## Summary
- ensure `ResponseParser` populates `content` with serialized tool call data when chat responses omit message text
- add debug logging to aid diagnosing serialization issues when tool call payloads cannot be converted

## Testing
- `PYTHONPATH=/tmp/stubs:stubs pytest -c /tmp/pytest.ini tests/unit/test_response_parser_service.py -q` *(fails: missing optional third-party dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df916e6d6c83339bb46ea7fd2b89b1