### PR TITLE
Fix env var parsing for tool loop config

### DIFF
--- a/src/tool_call_loop/config.py
+++ b/src/tool_call_loop/config.py
@@ -61,8 +61,14 @@ class ToolCallLoopConfig(InternalDTO):
         config = cls()
 
         if "TOOL_LOOP_DETECTION_ENABLED" in env_vars:
-            value = env_vars["TOOL_LOOP_DETECTION_ENABLED"].lower()
-            config.enabled = value in ("true", "1", "yes")
+            value = env_vars["TOOL_LOOP_DETECTION_ENABLED"].strip().lower()
+            truthy_values = {"true", "1", "yes", "on"}
+            falsy_values = {"false", "0", "no", "off", ""}
+
+            if value in truthy_values:
+                config.enabled = True
+            elif value in falsy_values:
+                config.enabled = False
 
         if "TOOL_LOOP_MAX_REPEATS" in env_vars:
             with contextlib.suppress(ValueError):
@@ -95,7 +101,16 @@ class ToolCallLoopConfig(InternalDTO):
         config = cls()
 
         if "enabled" in config_dict:
-            config.enabled = bool(config_dict["enabled"])
+            enabled_value = config_dict["enabled"]
+            if isinstance(enabled_value, str):
+                config.enabled = enabled_value.strip().lower() in {
+                    "true",
+                    "1",
+                    "yes",
+                    "on",
+                }
+            else:
+                config.enabled = bool(enabled_value)
 
         if "max_repeats" in config_dict:
             with contextlib.suppress(ValueError):

--- a/tests/unit/loop_detection/test_tool_call_tracker.py
+++ b/tests/unit/loop_detection/test_tool_call_tracker.py
@@ -398,3 +398,52 @@ class TestToolCallTracker:
         # Check that the consecutive count was reset
         full_sig = tracker.signatures[0].get_full_signature()
         assert tracker.consecutive_repeats[full_sig] == 1
+
+
+class TestToolCallLoopConfig:
+    """Tests for the ToolCallLoopConfig helper methods."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("true", True),
+            ("TrUe", True),
+            ("1", True),
+            ("yes", True),
+            ("on", True),
+            ("false", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+            ("", False),
+        ],
+    )
+    def test_from_dict_parses_string_booleans(self, value: str, expected: bool) -> None:
+        """Ensure string boolean values are parsed correctly."""
+
+        config = ToolCallLoopConfig.from_dict({"enabled": value})
+
+        assert config.enabled is expected
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("true", True),
+            ("FALSE", False),
+            ("On", True),
+            ("off", False),
+            ("  yes  ", True),
+            (" 0 ", False),
+            ("", False),
+        ],
+    )
+    def test_from_env_vars_parses_string_booleans(
+        self, value: str, expected: bool
+    ) -> None:
+        """Ensure environment variable boolean values are parsed correctly."""
+
+        config = ToolCallLoopConfig.from_env_vars(
+            {"TOOL_LOOP_DETECTION_ENABLED": value}
+        )
+
+        assert config.enabled is expected


### PR DESCRIPTION
## Summary
- ensure `ToolCallLoopConfig.from_env_vars` interprets common string boolean values when enabling or disabling loop detection
- extend tool call loop configuration tests to cover string boolean parsing from dicts and environment variables

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/loop_detection/test_tool_call_tracker.py
- ./.venv/Scripts/python.exe -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68df916e6d6c83339bb46ea7fd2b89b1