### PR TITLE
Improve exception handling in Anthropic converters and CLI privilege check

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -376,8 +376,12 @@ def _check_privileges() -> None:
                 and ctypes.windll.shell32.IsUserAnAdmin() != 0
             ):
                 raise SystemExit("Refusing to run with administrative privileges")
-        except Exception:
-            pass
+        except (AttributeError, OSError, ValueError) as privilege_error:
+            logging.getLogger(__name__).debug(
+                "Unable to confirm Windows privilege level: %s",
+                privilege_error,
+                exc_info=True,
+            )
 
 
 def _daemonize() -> None:


### PR DESCRIPTION
## Summary
- add targeted exception handling and debug logging to Anthropic conversion utilities to avoid swallowing unexpected errors
- narrow the Windows privilege detection exception handler in the CLI and log diagnostic details instead of silently ignoring failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb127ab308333a86392eaba01edac