### PR TITLE
Handle empty OpenAI choice lists in Anthropic converter

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -91,12 +91,12 @@ def _normalize_openai_response_to_dict(openai_response: Any) -> dict[str, Any]:
             "model": getattr(openai_response, "model", "unknown"),
             "choices": [],
             "usage": {
-                "prompt_tokens": getattr(usage_obj, "prompt_tokens", 0)
-                if usage_obj
-                else 0,
-                "completion_tokens": getattr(usage_obj, "completion_tokens", 0)
-                if usage_obj
-                else 0,
+                "prompt_tokens": (
+                    getattr(usage_obj, "prompt_tokens", 0) if usage_obj else 0
+                ),
+                "completion_tokens": (
+                    getattr(usage_obj, "completion_tokens", 0) if usage_obj else 0
+                ),
             },
         }
 

--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -83,7 +83,24 @@ def _normalize_openai_response_to_dict(openai_response: Any) -> dict[str, Any]:
     if isinstance(openai_response, dict):
         return openai_response
     # pydantic-like model path
-    first_choice = openai_response.choices[0]
+    choices_attr = getattr(openai_response, "choices", None)
+    if not choices_attr:
+        usage_obj = getattr(openai_response, "usage", None)
+        return {
+            "id": getattr(openai_response, "id", "msg_unk"),
+            "model": getattr(openai_response, "model", "unknown"),
+            "choices": [],
+            "usage": {
+                "prompt_tokens": getattr(usage_obj, "prompt_tokens", 0)
+                if usage_obj
+                else 0,
+                "completion_tokens": getattr(usage_obj, "completion_tokens", 0)
+                if usage_obj
+                else 0,
+            },
+        }
+
+    first_choice = choices_attr[0]
     msg_obj: dict[str, Any] = {
         "role": first_choice.message.role,
         "content": first_choice.message.content,

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
@@ -131,6 +131,26 @@ class TestAnthropicConverters:
         assert anthropic_response["usage"]["input_tokens"] == 10
         assert anthropic_response["usage"]["output_tokens"] == 15
 
+    def test_openai_response_without_choices(self) -> None:
+        """Ensure empty OpenAI choices produce a minimal Anthropic response."""
+        mock_usage = Mock()
+        mock_usage.prompt_tokens = 7
+        mock_usage.completion_tokens = 0
+
+        openai_response = Mock()
+        openai_response.id = "chatcmpl-empty"
+        openai_response.model = "gpt-4"
+        openai_response.choices = []
+        openai_response.usage = mock_usage
+
+        anthropic_response = openai_to_anthropic_response(openai_response)
+
+        assert anthropic_response["id"] == "chatcmpl-empty"
+        assert anthropic_response["model"] == "gpt-4"
+        assert anthropic_response["content"] == [{"type": "text", "text": ""}]
+        assert anthropic_response["usage"]["input_tokens"] == 7
+        assert anthropic_response["usage"]["output_tokens"] == 0
+
     def test_openai_stream_to_anthropic_stream_start(self) -> None:
         """Test OpenAI stream chunk to Anthropic stream conversion - start."""
         openai_chunk = 'data: {"id": "chatcmpl-123", "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {"role": "assistant"}}]}'


### PR DESCRIPTION
## Summary
- guard `_normalize_openai_response_to_dict` so OpenAI SDK objects with empty `choices` return a minimal Anthropic-compatible payload instead of raising
- add regression coverage ensuring the Anthropic converter yields an empty text block and preserves usage counters for these responses

## Testing
- pytest --override-ini=addopts="" tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
- pytest --override-ini=addopts="" *(fails: environment is missing pytest_asyncio, respx, pytest_httpx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e024c44a5483339ac2dc091b4fafaa