### PR TITLE
Fix Anthropic streaming finish reason mapping

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -175,9 +175,10 @@ def openai_to_anthropic_stream_chunk(chunk_data: str, id: str, model: str) -> st
 
         # Finish reason delta
         if choice.get("finish_reason"):
+            anthropic_reason = _map_finish_reason(choice["finish_reason"])
             payload = {
                 "type": "message_delta",
-                "delta": {"stop_reason": choice["finish_reason"]},
+                "delta": {"stop_reason": anthropic_reason},
             }
             return f"event: message_delta\ndata: {json.dumps(payload)}\n\n"
     except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- ensure OpenAI streaming finish reasons are translated via `_map_finish_reason` when emitting Anthropic-compatible SSE chunks

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
- ./.venv/Scripts/python.exe -m pytest *(fails: formatting and json_repair_processor baseline issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e024c44a5483339ac2dc091b4fafaa