### PR TITLE
Fix metadata loss in streaming accumulator

### DIFF
--- a/src/core/services/streaming/content_accumulation_processor.py
+++ b/src/core/services/streaming/content_accumulation_processor.py
@@ -18,7 +18,16 @@ class ContentAccumulationProcessor(IStreamProcessor):
 
     async def process(self, content: StreamingContent) -> StreamingContent:
         if content.is_empty and not content.is_done:
-            return StreamingContent(content="")
+            # Preserve metadata/usage even when the chunk has no text so downstream
+            # processors (e.g., usage accounting) still receive the updated values.
+            return StreamingContent(
+                content="",
+                is_done=False,
+                is_cancellation=content.is_cancellation,
+                metadata=content.metadata,
+                usage=content.usage,
+                raw_data=content.raw_data,
+            )
 
         self._buffer += content.content
 

--- a/tests/unit/core/services/streaming/test_content_accumulation_processor.py
+++ b/tests/unit/core/services/streaming/test_content_accumulation_processor.py
@@ -81,6 +81,19 @@ async def test_content_accumulation_processor_handles_empty_chunks(
 
 
 @pytest.mark.asyncio
+async def test_content_accumulation_processor_preserves_metadata_for_empty_chunks(
+    content_accumulation_processor,
+):
+    chunk = StreamingContent(content="", metadata={"id": "chunk-1"})
+
+    processed_chunk = await content_accumulation_processor.process(chunk)
+
+    assert processed_chunk.metadata == {"id": "chunk-1"}
+    assert processed_chunk.content == ""
+    assert processed_chunk.is_done is False
+
+
+@pytest.mark.asyncio
 async def test_content_accumulation_processor_resets_buffer_after_emission(
     content_accumulation_processor,
 ):


### PR DESCRIPTION
## Summary
- ensure the streaming ContentAccumulationProcessor preserves metadata and usage when empty chunks are encountered
- add a regression test that reproduces the lost metadata scenario for empty streaming chunks

## Testing
- `./.venv/Scripts/python.exe -m pytest tests/unit/core/services/streaming/test_content_accumulation_processor.py` *(fails: No module named pytest in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e024aaa5fc8333ba5fb46e957c9aad