### PR TITLE
Fix tool call middleware JSON type detection

### DIFF
--- a/src/core/services/tool_call_loop_middleware.py
+++ b/src/core/services/tool_call_loop_middleware.py
@@ -146,7 +146,7 @@ class ToolCallLoopDetectionMiddleware(IResponseMiddleware):
             data = content
         else:
             # Otherwise try to parse common JSON container types
-            if isinstance(content, str | bytes | bytearray):
+            if isinstance(content, (str, bytes, bytearray)):
                 try:
                     data = json.loads(content)
                 except (json.JSONDecodeError, TypeError, ValueError):


### PR DESCRIPTION
## Summary
- fix the tool call loop middleware to use a tuple when checking for string/bytes content types
- prevent `_extract_tool_calls` from raising `TypeError` when middleware receives byte payloads

## Testing
- python -m pytest tests/unit/test_tool_call_loop_middleware.py --override-ini="addopts=" *(fails: pytest-asyncio plugin missing in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68e024aaa5fc8333ba5fb46e957c9aad