### PR TITLE
Fix Gemini model extraction with query params

### DIFF
--- a/src/gemini_converters.py
+++ b/src/gemini_converters.py
@@ -379,12 +379,20 @@ def openai_models_to_gemini_models(
 
 def extract_model_from_gemini_path(path: str) -> str:
     """Extract model name from Gemini API path like /v1beta/models/gemini-pro:generateContent."""
-    # Path format: /v1beta/models/{model}:generateContent or /v1beta/models/{model}:streamGenerateContent
+    # Path format examples:
+    #   /v1beta/models/{model}:generateContent
+    #   /v1beta/models/{model}:streamGenerateContent?alt=sse
     if "/models/" in path:
-        # Extract the part between /models/ and the next :
-        parts = path.split("/models/")[1]
-        model = parts.split(":")[0]
-        return model
+        # Extract the portion that starts at the model name
+        parts = path.split("/models/", 1)[1]
+
+        # Remove any path suffix (e.g. :generateContent) and query parameters
+        model_and_suffix = parts.split(":", 1)[0]
+        model = model_and_suffix.split("?", 1)[0]
+
+        # Defensive trim for stray slashes
+        return model.strip("/") or "gemini-pro"
+
     return "gemini-pro"  # Default fallback
 
 

--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -10,6 +10,7 @@ from src.gemini_converters import (
     gemini_to_openai_messages,
     openai_to_gemini_contents,
     openai_to_gemini_stream_chunk,
+    extract_model_from_gemini_path,
 )
 from src.gemini_models import (
     Blob,
@@ -114,3 +115,23 @@ class TestMessageConversion:
         data = json.loads(payload)
 
         assert data["candidates"][0]["content"]["parts"][0]["text"] == "Hello"
+
+
+class TestExtractModelFromGeminiPath:
+    """Tests for extract_model_from_gemini_path utility."""
+
+    def test_extracts_model_without_suffix(self) -> None:
+        path = "/v1beta/models/gemini-1.5-flash-latest:generateContent"
+        assert (
+            extract_model_from_gemini_path(path)
+            == "gemini-1.5-flash-latest"
+        )
+
+    def test_extracts_model_with_query_parameters(self) -> None:
+        path = (
+            "/v1beta/models/gemini-1.5-flash-latest:streamGenerateContent?alt=sse"
+        )
+        assert (
+            extract_model_from_gemini_path(path)
+            == "gemini-1.5-flash-latest"
+        )


### PR DESCRIPTION
## Summary
- strip colon and query suffixes when parsing Gemini model IDs from request paths
- add regression tests covering paths with and without query parameters

## Testing
- `python -m pytest -c /tmp/pytest-min.ini tests/unit/test_gemini_converters.py`
- `python -m pytest -c /tmp/pytest-min.ini`


------
https://chatgpt.com/codex/tasks/task_e_68e0249d56b08333acfbc205012811d8