### PR TITLE
Fix loop detection config boolean parsing

### DIFF
--- a/src/loop_detection/config.py
+++ b/src/loop_detection/config.py
@@ -32,7 +32,7 @@ def _coerce_to_bool(value: Any) -> bool:
             )
         return True
 
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return bool(value)
 
     if isinstance(value, bool):
@@ -47,6 +47,7 @@ def _coerce_to_bool(value: Any) -> bool:
             type(value).__name__,
         )
     return True
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/loop_detection/config.py
+++ b/src/loop_detection/config.py
@@ -15,6 +15,39 @@ from typing import Any
 
 from src.core.interfaces.model_bases import InternalDTO
 
+
+def _coerce_to_bool(value: Any) -> bool:
+    """Convert a loosely-typed configuration value into a boolean."""
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off", ""}:
+            return False
+        if logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                "Unexpected boolean value '%s' in loop detection config; treating as truthy",
+                value,
+            )
+        return True
+
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    if isinstance(value, bool):
+        return value
+
+    if value is None:
+        return False
+
+    if logger.isEnabledFor(logging.WARNING):
+        logger.warning(
+            "Unexpected type %s for loop detection boolean config; treating as truthy",
+            type(value).__name__,
+        )
+    return True
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,7 +122,7 @@ class LoopDetectionConfig(InternalDTO):
         config = cls()
 
         if "enabled" in config_dict:
-            config.enabled = bool(config_dict["enabled"])
+            config.enabled = _coerce_to_bool(config_dict["enabled"])
 
         if "buffer_size" in config_dict:
             config.buffer_size = int(config_dict["buffer_size"])

--- a/tests/unit/loop_detection/test_config_parsing.py
+++ b/tests/unit/loop_detection/test_config_parsing.py
@@ -1,0 +1,25 @@
+"""Tests for loop detection config parsing helpers."""
+
+from src.loop_detection.config import LoopDetectionConfig
+
+
+class TestLoopDetectionConfigParsing:
+    """Ensure dictionary parsing handles loose boolean values."""
+
+    def test_from_dict_handles_string_booleans(self) -> None:
+        """String representations of booleans should be parsed predictably."""
+
+        config_false = LoopDetectionConfig.from_dict({"enabled": "false"})
+        assert config_false.enabled is False
+
+        config_true = LoopDetectionConfig.from_dict({"enabled": "TRUE"})
+        assert config_true.enabled is True
+
+    def test_from_dict_handles_numeric_booleans(self) -> None:
+        """Numeric values should follow standard truthiness rules."""
+
+        config_zero = LoopDetectionConfig.from_dict({"enabled": 0})
+        assert config_zero.enabled is False
+
+        config_one = LoopDetectionConfig.from_dict({"enabled": 1})
+        assert config_one.enabled is True


### PR DESCRIPTION
## Summary
- normalize boolean parsing in `LoopDetectionConfig.from_dict` so string and numeric values load reliably
- add focused unit coverage for the new coercion helper

## Testing
- python -m pytest -o addopts="" tests/unit/loop_detection/test_config_parsing.py
- python -m pytest -o addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68e02489206483339b5d3151c0ae24d5