### PR TITLE
Ensure loop detection chunk config validates positive values

### DIFF
--- a/src/loop_detection/config.py
+++ b/src/loop_detection/config.py
@@ -283,6 +283,15 @@ class LoopDetectionConfig(InternalDTO):
         if self.max_pattern_length <= 0:
             errors.append("max_pattern_length must be positive")
 
+        if self.content_chunk_size <= 0:
+            errors.append("content_chunk_size must be positive")
+
+        if self.content_loop_threshold <= 0:
+            errors.append("content_loop_threshold must be positive")
+
+        if self.max_history_length <= 0:
+            errors.append("max_history_length must be positive")
+
         # Allow pattern length to exceed buffer - the detector will handle
         # clipping automatically when the buffer is smaller than the maximum
         # pattern size requested by configuration/testing scenarios.

--- a/tests/unit/loop_detection/test_config.py
+++ b/tests/unit/loop_detection/test_config.py
@@ -93,3 +93,17 @@ class TestLoopDetectionConfig:
         assert isinstance(semantic_thresholds, PatternThresholds)
         assert semantic_thresholds.min_repetitions == 4
         assert semantic_thresholds.min_total_length == 200
+
+    def test_validate_catches_non_positive_chunk_settings(self) -> None:
+        """Validate rejects non-positive chunk configuration values."""
+        config = LoopDetectionConfig(
+            content_chunk_size=0,
+            content_loop_threshold=-2,
+            max_history_length=0,
+        )
+
+        errors = config.validate()
+
+        assert "content_chunk_size must be positive" in errors
+        assert "content_loop_threshold must be positive" in errors
+        assert "max_history_length must be positive" in errors

--- a/tests/unit/loop_detection/test_detector.py
+++ b/tests/unit/loop_detection/test_detector.py
@@ -146,6 +146,18 @@ class TestLoopDetector:
             config = LoopDetectionConfig(enabled=True, max_pattern_length=0)
             LoopDetector(config=config)
 
+        with pytest.raises(ValueError):
+            config = LoopDetectionConfig(enabled=True, content_chunk_size=0)
+            LoopDetector(config=config)
+
+        with pytest.raises(ValueError):
+            config = LoopDetectionConfig(enabled=True, content_loop_threshold=0)
+            LoopDetector(config=config)
+
+        with pytest.raises(ValueError):
+            config = LoopDetectionConfig(enabled=True, max_history_length=0)
+            LoopDetector(config=config)
+
     @pytest.mark.asyncio
     async def test_check_for_loops_does_not_mutate_streaming_state(self) -> None:
         """check_for_loops should not modify the streaming analyzer state."""


### PR DESCRIPTION
## Summary
- ensure `LoopDetectionConfig.validate()` rejects non-positive chunk-size, loop-threshold, and history-length settings
- cover the stricter validation with focused tests for both the config object and `LoopDetector`

## Testing
- PYTHONPATH=src pytest -c /tmp/pytest-min.ini tests/unit/loop_detection/test_config.py::TestLoopDetectionConfig::test_validate_catches_non_positive_chunk_settings
- PYTHONPATH=src pytest -c /tmp/pytest-min.ini tests/unit/loop_detection/test_detector.py::TestLoopDetector::test_config_validation
- PYTHONPATH=src pytest -c /tmp/pytest-min.ini *(fails: missing dev dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e02489206483339b5d3151c0ae24d5