### PR TITLE
Fix JSON repair middleware truthiness handling

### DIFF
--- a/src/core/app/middleware/json_repair_middleware.py
+++ b/src/core/app/middleware/json_repair_middleware.py
@@ -74,22 +74,21 @@ class JsonRepairMiddleware(IResponseMiddleware):
                     schema=self.config.session.json_repair_schema,
                     strict=strict_effective,
                 )
-                if repaired_json:
-                    metrics.inc(
-                        "json_repair.non_streaming.strict_success"
-                        if strict_effective
-                        else "json_repair.non_streaming.best_effort_success"
-                    )
-                else:
-                    metrics.inc(
-                        "json_repair.non_streaming.strict_fail"
-                        if strict_effective
-                        else "json_repair.non_streaming.best_effort_fail"
-                    )
+                success_metric = (
+                    "json_repair.non_streaming.strict_success"
+                    if strict_effective
+                    else "json_repair.non_streaming.best_effort_success"
+                )
+                failure_metric = (
+                    "json_repair.non_streaming.strict_fail"
+                    if strict_effective
+                    else "json_repair.non_streaming.best_effort_fail"
+                )
+                metrics.inc(success_metric if repaired_json is not None else failure_metric)
             except Exception:
                 metrics.inc("json_repair.non_streaming.strict_fail")
                 raise
-            if repaired_json:
+            if repaired_json is not None:
                 if logger.isEnabledFor(logging.INFO):
                     logger.info(f"JSON detected and repaired for session {session_id}")
                 response.content = json.dumps(repaired_json)


### PR DESCRIPTION
## Summary
- ensure JsonRepairMiddleware treats repaired JSON objects consistently by using explicit None checks and consistent metrics updates
- add regression coverage for empty-object repairs and run middleware processing via asyncio.run in tests

## Testing
- `python -m pytest -o addopts='' tests/unit/core/services/test_json_repair_middleware.py`
- `python -m pytest -o addopts=''` *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e0245f0630833380cb472c3ed0239b