### PR TITLE
Fix performance tracker overhead reporting

### DIFF
--- a/src/performance_tracker.py
+++ b/src/performance_tracker.py
@@ -93,8 +93,8 @@ class PerformanceMetrics(InternalDTO):
             ]
             if t is not None
         )
-        if accounted_time and self.total_time:
-            overhead = self.total_time - accounted_time
+        if self.total_time is not None:
+            overhead = max(self.total_time - accounted_time, 0.0)
             summary_parts.append(f"overhead={overhead:.3f}s")
 
         if logger.isEnabledFor(logging.INFO):

--- a/tests/unit/test_performance_tracker.py
+++ b/tests/unit/test_performance_tracker.py
@@ -55,6 +55,29 @@ def test_log_summary_includes_breakdown_and_overhead(monkeypatch, caplog):
     assert "overhead=0.800s" in message
 
 
+def test_log_summary_includes_overhead_without_breakdown(monkeypatch, caplog):
+    import time as original_time
+
+    time_values = _time_sequence(101.0, 101.5)
+    monkeypatch.setattr(performance_tracker.time, "time", time_values)
+    monkeypatch.setattr(original_time, "time", time_values)
+
+    metrics = PerformanceMetrics(request_start=100.0)
+    metrics.session_id = "session-456"
+    metrics.backend_used = "backend-b"
+    metrics.model_used = "model-c"
+
+    metrics.finalize()
+
+    caplog.set_level(logging.INFO)
+    metrics.log_summary()
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].message
+    assert "breakdown=" not in message
+    assert "overhead=1.000s" in message
+
+
 def test_track_request_performance_finalizes(monkeypatch):
     calls: list[PerformanceMetrics] = []
 


### PR DESCRIPTION
## Summary
- ensure `PerformanceMetrics.log_summary` always reports overhead when a total duration is available, even if no individual phases were timed
- clamp the overhead value at zero to avoid negative output from minor floating-point skew
- add a regression test covering the "no phase breakdown" scenario to confirm the summary still logs overhead

## Testing
- `python -m pytest -o addopts='' tests/unit/test_performance_tracker.py`
- `python -m pytest -o addopts=''` *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e0243dec0c83338b0867dc3c9cf4fc