### PR TITLE
Fix OpenAI OAuth auth error handling

### DIFF
--- a/src/connectors/openai_oauth.py
+++ b/src/connectors/openai_oauth.py
@@ -487,7 +487,7 @@ class OpenAIOAuthConnector(OpenAIConnector):
         except Exception as e:
             # Check if it's an auth-related error and degrade accordingly
             if (
-                isinstance(e, AuthenticationError | HTTPException)
+                isinstance(e, (AuthenticationError, HTTPException))
                 and hasattr(e, "status_code")
                 and e.status_code in (401, 403)
             ):

--- a/tests/unit/openai_connector_tests/test_openai_oauth.py
+++ b/tests/unit/openai_connector_tests/test_openai_oauth.py
@@ -1,0 +1,50 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from src.connectors.openai import OpenAIConnector
+from src.connectors.openai_oauth import OpenAIOAuthConnector
+from src.core.config.app_config import AppConfig
+
+
+def test_openai_oauth_degrades_on_http_auth_error(monkeypatch):
+    client = AsyncMock()
+    config = AppConfig()
+    connector = OpenAIOAuthConnector(client=client, config=config)
+    connector.is_functional = True
+    connector.api_key = "token"
+    connector._auth_credentials = {"tokens": {"access_token": "token"}}
+
+    def fake_validate_runtime_credentials(self: OpenAIOAuthConnector):
+        return True, []
+
+    async def fake_load_auth(self: OpenAIOAuthConnector) -> bool:
+        return True
+
+    async def fake_super_chat_completions(
+        self: OpenAIConnector,
+        request_data,
+        processed_messages,
+        effective_model,
+        identity=None,
+        **kwargs,
+    ):
+        raise HTTPException(status_code=401, detail="invalid token")
+
+    monkeypatch.setattr(
+        OpenAIOAuthConnector,
+        "_validate_runtime_credentials",
+        fake_validate_runtime_credentials,
+    )
+    monkeypatch.setattr(OpenAIOAuthConnector, "_load_auth", fake_load_auth)
+    monkeypatch.setattr(OpenAIConnector, "chat_completions", fake_super_chat_completions)
+
+    async def invoke_chat_completion() -> None:
+        with pytest.raises(HTTPException):
+            await connector.chat_completions({}, [], "gpt-test")
+
+    asyncio.run(invoke_chat_completion())
+
+    assert connector.is_functional is False


### PR DESCRIPTION
## Summary
- fix the OpenAI OAuth connector's authentication error handling to avoid raising a TypeError when inspecting exceptions
- add a regression test that exercises the degradation path when the parent connector raises an HTTPException

## Testing
- python -m pytest --override-ini addopts="" tests/unit/openai_connector_tests/test_openai_oauth.py
- python -m pytest --override-ini addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e0243dec0c83338b0867dc3c9cf4fc