### PR TITLE
Enhance loop detection command exports and tests

### DIFF
--- a/src/core/domain/commands/loop_detection_commands/__init__.py
+++ b/src/core/domain/commands/loop_detection_commands/__init__.py
@@ -1,8 +1,8 @@
-"""
-Loop detection commands module.
+"""Loop detection command exports and helpers."""
 
-This module provides domain commands for loop detection functionality.
-"""
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from .loop_detection_command import LoopDetectionCommand
 from .tool_loop_detection_command import ToolLoopDetectionCommand
@@ -10,10 +10,27 @@ from .tool_loop_max_repeats_command import ToolLoopMaxRepeatsCommand
 from .tool_loop_mode_command import ToolLoopModeCommand
 from .tool_loop_ttl_command import ToolLoopTTLCommand
 
-__all__ = [
-    "LoopDetectionCommand",
-    "ToolLoopDetectionCommand",
-    "ToolLoopMaxRepeatsCommand",
-    "ToolLoopModeCommand",
-    "ToolLoopTTLCommand",
-]
+_LOOP_DETECTION_COMMANDS: dict[str, type[Any]] = {
+    "LoopDetectionCommand": LoopDetectionCommand,
+    "ToolLoopDetectionCommand": ToolLoopDetectionCommand,
+    "ToolLoopMaxRepeatsCommand": ToolLoopMaxRepeatsCommand,
+    "ToolLoopModeCommand": ToolLoopModeCommand,
+    "ToolLoopTTLCommand": ToolLoopTTLCommand,
+}
+
+__all__ = list(_LOOP_DETECTION_COMMANDS)
+
+
+def get_loop_detection_command(name: str) -> type[Any]:
+    """Return a loop detection command class by ``name``."""
+
+    try:
+        return _LOOP_DETECTION_COMMANDS[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown loop detection command: {name}") from exc
+
+
+def get_loop_detection_commands() -> Mapping[str, type[Any]]:
+    """Return a copy of the registered loop detection commands."""
+
+    return dict(_LOOP_DETECTION_COMMANDS)

--- a/src/core/domain/commands/loop_detection_commands/__init__.py
+++ b/src/core/domain/commands/loop_detection_commands/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from .loop_detection_command import LoopDetectionCommand
 from .tool_loop_detection_command import ToolLoopDetectionCommand

--- a/tests/unit/core/domain/test_loop_detection_commands_module.py
+++ b/tests/unit/core/domain/test_loop_detection_commands_module.py
@@ -1,49 +1,77 @@
 """Tests for the loop detection commands module exports."""
 
 from importlib import import_module, reload
+from types import ModuleType
+
+import pytest
 
 MODULE_PATH = "src.core.domain.commands.loop_detection_commands"
+
+EXPORT_MODULE_MAP = {
+    "LoopDetectionCommand": "loop_detection_command",
+    "ToolLoopDetectionCommand": "tool_loop_detection_command",
+    "ToolLoopMaxRepeatsCommand": "tool_loop_max_repeats_command",
+    "ToolLoopModeCommand": "tool_loop_mode_command",
+    "ToolLoopTTLCommand": "tool_loop_ttl_command",
+}
+
+
+def _reload_module() -> ModuleType:
+    return reload(import_module(MODULE_PATH))
+
+
+def _import_command_class(name: str) -> type[object]:
+    module = import_module(f"{MODULE_PATH}.{EXPORT_MODULE_MAP[name]}")
+    return getattr(module, name)
 
 
 def test_loop_detection_commands_module_exports_expected_classes() -> None:
     """Verify that the module exposes the documented command classes."""
 
-    module = reload(import_module(MODULE_PATH))
+    module = _reload_module()
 
-    expected_exports = [
-        "LoopDetectionCommand",
-        "ToolLoopDetectionCommand",
-        "ToolLoopMaxRepeatsCommand",
-        "ToolLoopModeCommand",
-        "ToolLoopTTLCommand",
-    ]
+    expected_exports = list(EXPORT_MODULE_MAP)
 
     assert module.__all__ == expected_exports
 
-    loop_detection_command = import_module(
-        f"{MODULE_PATH}.loop_detection_command"
-    ).LoopDetectionCommand
-    tool_loop_detection_command = import_module(
-        f"{MODULE_PATH}.tool_loop_detection_command"
-    ).ToolLoopDetectionCommand
-    tool_loop_max_repeats_command = import_module(
-        f"{MODULE_PATH}.tool_loop_max_repeats_command"
-    ).ToolLoopMaxRepeatsCommand
-    tool_loop_mode_command = import_module(
-        f"{MODULE_PATH}.tool_loop_mode_command"
-    ).ToolLoopModeCommand
-    tool_loop_ttl_command = import_module(
-        f"{MODULE_PATH}.tool_loop_ttl_command"
-    ).ToolLoopTTLCommand
-
-    assert module.LoopDetectionCommand is loop_detection_command
-    assert module.ToolLoopDetectionCommand is tool_loop_detection_command
-    assert module.ToolLoopMaxRepeatsCommand is tool_loop_max_repeats_command
-    assert module.ToolLoopModeCommand is tool_loop_mode_command
-    assert module.ToolLoopTTLCommand is tool_loop_ttl_command
+    for export_name in expected_exports:
+        assert getattr(module, export_name) is _import_command_class(export_name)
 
     namespace: dict[str, object] = {}
     exec(f"from {MODULE_PATH} import *", namespace)
 
     for export_name in expected_exports:
         assert namespace[export_name] is getattr(module, export_name)
+
+
+def test_get_loop_detection_command_returns_expected_class() -> None:
+    module = _reload_module()
+
+    command = module.get_loop_detection_command("ToolLoopTTLCommand")
+
+    assert command is _import_command_class("ToolLoopTTLCommand")
+
+
+def test_get_loop_detection_command_rejects_unknown_command_name() -> None:
+    module = _reload_module()
+
+    with pytest.raises(ValueError, match="Unknown loop detection command: unknown"):
+        module.get_loop_detection_command("unknown")
+
+
+def test_get_loop_detection_commands_returns_isolated_copy() -> None:
+    module = _reload_module()
+
+    commands = module.get_loop_detection_commands()
+
+    assert list(commands) == list(EXPORT_MODULE_MAP)
+    assert commands["LoopDetectionCommand"] is _import_command_class(
+        "LoopDetectionCommand"
+    )
+
+    commands["LoopDetectionCommand"] = object
+
+    refreshed_commands = module.get_loop_detection_commands()
+    assert refreshed_commands["LoopDetectionCommand"] is _import_command_class(
+        "LoopDetectionCommand"
+    )


### PR DESCRIPTION
## Summary
- add helper functions that expose loop detection command registrations through the package initializer
- tighten the unit tests to validate module exports and exercise the new helper functions

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/domain/test_loop_detection_commands_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e024f92ba083339dbf8afdf23a7dac