### PR TITLE
Document required pytest plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This project is a swiss-army knife for anyone working with language models and a
 - [Example Config (minimal)](#example-config-minimal)
 - [Popular Scenarios](#popular-scenarios)
 - [Errors and Troubleshooting](#errors-and-troubleshooting)
+- [Running Tests](#running-tests)
 - [Support](#support)
 - [License](#license)
 - [Changelog](#changelog)
@@ -628,6 +629,17 @@ models:
 - Enable wire capture for tricky issues: `--capture-file wire.jsonl`
 - Use in-chat `!/backend(...)` and `!/model(...)` to isolate provider/model problems
 - Check environment variables are set for the back-end you selected
+
+## Running Tests
+
+The pytest configuration in [`pyproject.toml`](pyproject.toml) enables async and parallel execution via `--asyncio-mode=auto` and `-n`. Those flags rely on plugins (`pytest-asyncio`, `pytest-xdist`) that are declared in the `dev` optional dependency group, so they are not installed by a plain `pip install -e .`. Install the development extras before running the suite:
+
+```bash
+python -m pip install -e .[dev]
+python -m pytest
+```
+
+The commands above work on Linux, macOS, and Windows as long as they are executed from the virtual environment you created for the project (for example `.venv/bin/python` on Unix-like systems or `.venv\Scripts\python.exe` on Windows).
 
 ## Support
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,20 @@
+# Running Tests Locally
+
+This project relies on several pytest plugins (``pytest-asyncio`` and ``pytest-xdist``) that are only declared inside the ``dev`` optional dependency group in ``pyproject.toml``. The default ``pip install -e .`` command does **not** install those extras, so the pytest configuration defined in ``[tool.pytest.ini_options]`` ends up passing ``--asyncio-mode`` and ``-n`` arguments without the plugins that provide them. As a result ``pytest`` aborts with an "unrecognized arguments" error before running any tests.
+
+To make sure the required plugins are present:
+
+1. Create a virtual environment (the path or tooling does not matter, it just needs to be active when installing packages).
+2. Install the project together with the development extras:
+   ```bash
+   python -m pip install -e .[dev]
+   ```
+   Installing the ``dev`` extra pulls in ``pytest``, ``pytest-asyncio``, ``pytest-xdist`` and the other tools that the test suite expects.
+3. Once the installation finishes, run the test suite:
+   ```bash
+   python -m pytest
+   ```
+
+If you are running inside a non-Windows container, make sure the commands use the Python interpreter from the virtual environment you created (for example ``.venv/bin/python``). The project documentation previously referenced a Windows-specific interpreter path (``.venv/Scripts/python.exe``); the cross-platform ``python`` entry point from the active environment works everywhere and still satisfies local developer workflows on Windows.
+
+Following the steps above allows the test suite to execute in an automated container without hitting missing dependency errors.


### PR DESCRIPTION
## Summary
- add documentation describing the pytest plugin requirements and installation steps
- update the README with cross-platform instructions for installing the dev extras before running pytest

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e043ae06448333870de52706896cd9