### PR TITLE
Fix backend interface BackendError alias mismatch

### DIFF
--- a/src/core/interfaces/backend_service.py
+++ b/src/core/interfaces/backend_service.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from src.core.common.exceptions import BackendError
 from src.core.domain.chat import ChatRequest
 from src.core.domain.request_context import RequestContext
-from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
-
-
-class BackendError(Exception):
-    """Exception raised when a backend operation fails."""
+from src.core.domain.responses import (
+    ResponseEnvelope,
+    StreamingResponseEnvelope,
+)
 
 
 class IBackendService(ABC):


### PR DESCRIPTION
## Summary
- ensure the backend service interface re-exports the canonical `BackendError` from the shared exceptions module
- keep the response envelope imports grouped while switching to the shared exception class

## Testing
- python -m pytest --override-ini "addopts=--asyncio-mode=auto" tests/unit/core/test_backend_service_enhanced.py::TestBackendServiceValidation::test_validate_backend_and_model_valid *(fails: async plugin missing in environment)*
- python -m pytest --override-ini "addopts=--asyncio-mode=auto" *(fails: pytest-asyncio plugin is unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0472c405c8333bfb5287fe0a58ee0