### PR TITLE
Fix OAuth backend model discovery

### DIFF
--- a/src/core/app/controllers/models_controller.py
+++ b/src/core/app/controllers/models_controller.py
@@ -300,9 +300,7 @@ async def _list_models_impl(
                 # Add models to the list with proper formatting
                 for model in models:
                     model_id: str = (
-                        f"{backend_type}:{model}"
-                        if backend_type != "openai"
-                        else model
+                        f"{backend_type}:{model}" if backend_type != "openai" else model
                     )
 
                     # Avoid duplicates

--- a/src/core/app/controllers/models_controller.py
+++ b/src/core/app/controllers/models_controller.py
@@ -235,6 +235,14 @@ async def _list_models_impl(
         # Ensure backend service is at least resolved for DI side effects
         _ = backend_service
 
+        try:
+            functional_backends = set(config.backends.functional_backends)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.debug(
+                "Unable to determine functional backends: %s", exc, exc_info=True
+            )
+            functional_backends = set()
+
         # Iterate through dynamically discovered backend types from the registry
         for backend_type in backend_registry.get_registered_backends():
             backend_config: Any | None = None
@@ -242,49 +250,79 @@ async def _list_models_impl(
                 # Access backend config dynamically using getattr
                 backend_config = getattr(config.backends, backend_type, None)
 
-            if backend_config and backend_config.api_key:
-                try:
-                    # Create backend instance
-                    backend_instance: Any = backend_factory.create_backend(
-                        backend_type, config
-                    )
-
-                    # Get available models from the backend. Prefer async helper when available.
-                    models: list[str]
-                    get_models_async = getattr(
-                        backend_instance, "get_available_models_async", None
-                    )
-                    if callable(get_models_async):
-                        models = await get_models_async()  # type: ignore[misc]
-                    else:
-                        models = await backend_instance.get_available_models()  # type: ignore[misc]
-
-                    # Add models to the list with proper formatting
-                    for model in models:
-                        model_id: str = (
-                            f"{backend_type}:{model}"
-                            if backend_type != "openai"
-                            else model
+            has_credentials = False
+            if isinstance(backend_config, dict):
+                has_credentials = bool(backend_config.get("api_key"))
+            elif backend_config is not None:
+                api_key_value = getattr(backend_config, "api_key", None)
+                has_credentials = bool(api_key_value)
+                if not has_credentials:
+                    identity = getattr(backend_config, "identity", None)
+                    extra = getattr(backend_config, "extra", None)
+                    if identity is not None:
+                        has_credentials = True
+                    elif isinstance(extra, dict):
+                        credential_hints = {
+                            "credentials_path",
+                            "oauth_credentials_path",
+                            "token_path",
+                            "service_account_file",
+                        }
+                        has_credentials = any(
+                            bool(extra.get(hint)) for hint in credential_hints
                         )
 
-                        # Avoid duplicates
-                        if model_id not in discovered_models:
-                            discovered_models.add(model_id)
-                            all_models.append(
-                                {
-                                    "id": model_id,
-                                    "object": "model",
-                                    "owned_by": str(backend_type).lower(),
-                                }
-                            )
-                    logger.debug(f"Discovered {len(models)} models from {backend_type}")
+            should_try_backend = backend_type in functional_backends or has_credentials
 
-                except Exception as e:  # type: ignore[misc]
-                    logger.warning(
-                        f"Failed to get models from {backend_type}: {e}",
-                        exc_info=True,
+            if not should_try_backend:
+                logger.debug(
+                    "Skipping backend %s during model discovery: no credentials detected",
+                    backend_type,
+                )
+                continue
+
+            try:
+                # Create backend instance
+                backend_instance: Any = backend_factory.create_backend(
+                    backend_type, config
+                )
+
+                # Get available models from the backend. Prefer async helper when available.
+                models: list[str]
+                get_models_async = getattr(
+                    backend_instance, "get_available_models_async", None
+                )
+                if callable(get_models_async):
+                    models = await get_models_async()  # type: ignore[misc]
+                else:
+                    models = await backend_instance.get_available_models()  # type: ignore[misc]
+
+                # Add models to the list with proper formatting
+                for model in models:
+                    model_id: str = (
+                        f"{backend_type}:{model}"
+                        if backend_type != "openai"
+                        else model
                     )
-                    continue
+
+                    # Avoid duplicates
+                    if model_id not in discovered_models:
+                        discovered_models.add(model_id)
+                        all_models.append(
+                            {
+                                "id": model_id,
+                                "object": "model",
+                                "owned_by": str(backend_type).lower(),
+                            }
+                        )
+                logger.debug(f"Discovered {len(models)} models from {backend_type}")
+
+            except Exception as e:  # type: ignore[misc]
+                logger.warning(
+                    f"Failed to get models from {backend_type}: {e}",
+                    exc_info=True,
+                )
+                continue
 
         # If no models were discovered, provide default fallback models
         if not all_models:

--- a/tests/unit/test_models_endpoint.py
+++ b/tests/unit/test_models_endpoint.py
@@ -29,3 +29,42 @@ import pytest
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
+
+
+def test_model_listing_includes_oauth_backends(monkeypatch) -> None:
+    import asyncio
+
+    from src.core.app.controllers import models_controller
+    from src.core.app.controllers.models_controller import _list_models_impl
+    from src.core.config.app_config import AppConfig
+
+    monkeypatch.setattr(
+        models_controller.backend_registry,
+        "get_registered_backends",
+        lambda: ["gemini-cli-oauth-personal"],
+    )
+
+    config = AppConfig()
+
+    created_backends: list[str] = []
+
+    class DummyBackend:
+        async def get_available_models(self) -> list[str]:
+            return ["gemini-2.5-pro"]
+
+    class DummyFactory:
+        def create_backend(self, backend_type: str, config_obj: AppConfig) -> DummyBackend:
+            created_backends.append(backend_type)
+            return DummyBackend()
+
+    result = asyncio.run(
+        _list_models_impl(
+            backend_service=object(),
+            config=config,
+            backend_factory=DummyFactory(),
+        )
+    )
+
+    model_ids = {model["id"] for model in result["data"]}
+    assert "gemini-cli-oauth-personal:gemini-2.5-pro" in model_ids
+    assert created_backends == ["gemini-cli-oauth-personal"]

--- a/tests/unit/test_models_endpoint.py
+++ b/tests/unit/test_models_endpoint.py
@@ -53,7 +53,9 @@ def test_model_listing_includes_oauth_backends(monkeypatch) -> None:
             return ["gemini-2.5-pro"]
 
     class DummyFactory:
-        def create_backend(self, backend_type: str, config_obj: AppConfig) -> DummyBackend:
+        def create_backend(
+            self, backend_type: str, config_obj: AppConfig
+        ) -> DummyBackend:
             created_backends.append(backend_type)
             return DummyBackend()
 


### PR DESCRIPTION
## Summary
- allow the models controller to discover OAuth-based backends by checking functional backends and credential hints instead of requiring API keys
- add a regression test that exercises `_list_models_impl` with a gemini CLI OAuth backend stub

## Testing
- python -m pytest -o addopts='' tests/unit/test_models_endpoint.py
- python -m pytest -o addopts=''
  - fails: missing optional test dependencies (pytest-asyncio, respx, pytest_httpx, pytest-mock, hypothesis)


------
https://chatgpt.com/codex/tasks/task_e_68e0470b16a483338706838abba40fc3