### PR TITLE
Fix API key redaction for overlapping secrets

### DIFF
--- a/src/security.py
+++ b/src/security.py
@@ -9,14 +9,14 @@ class APIKeyRedactor:
     """Redact known API keys from user provided prompts."""
 
     def __init__(self, api_keys: Iterable[str] | None = None) -> None:
-        # filter out falsy values
-        self.api_keys = [k for k in (api_keys or []) if k]
+        # Filter out falsy values and sort by length so longer keys are redacted first
+        unique_keys = {k for k in (api_keys or []) if k}
+        self.api_keys = sorted(unique_keys, key=len, reverse=True)
         # Pre-compile regex patterns for better performance
-        self._key_patterns = {}
+        self._key_patterns: dict[str, re.Pattern[str]] = {}
         for key in self.api_keys:
-            if key:
-                # Escape special regex characters and compile pattern
-                self._key_patterns[key] = re.compile(re.escape(key))
+            # Escape special regex characters and compile pattern
+            self._key_patterns[key] = re.compile(re.escape(key))
 
     def _redact_cached(self, text: str) -> str:
         """Cached version of redact for frequently processed content."""

--- a/tests/unit/test_prompt_redaction.py
+++ b/tests/unit/test_prompt_redaction.py
@@ -10,3 +10,17 @@ def test_redactor_replaces_keys_and_logs(caplog: Any) -> None:
         result = redactor.redact("my SECRET key")
     assert result == "my (API_KEY_HAS_BEEN_REDACTED) key"
     assert any("API key detected" in rec.message for rec in caplog.records)
+
+
+def test_redactor_prioritizes_longer_keys() -> None:
+    short = "sk-short"
+    long = f"{short}-extra"
+    # Provide keys in order that would previously leak the suffix of the longer key
+    redactor = APIKeyRedactor([short, long])
+
+    text = f"My key is {long}"
+    result = redactor.redact(text)
+
+    assert result == "My key is (API_KEY_HAS_BEEN_REDACTED)"
+    assert short not in result
+    assert long not in result


### PR DESCRIPTION
## Summary
- ensure `APIKeyRedactor` sorts unique API keys by length so longer secrets are redacted before their prefixes
- add a regression test proving overlapping keys are fully redacted without leaking suffix fragments

## Testing
- python -m pytest --override-ini="addopts=" tests/unit/test_prompt_redaction.py
- python -m pytest --override-ini="addopts=" *(fails: missing dev dependencies such as pytest-asyncio/respx in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0478abf888333a70b8f38cd5990f4