### PR TITLE
Fix logging API key redaction for iterable args

### DIFF
--- a/src/core/common/logging_utils.py
+++ b/src/core/common/logging_utils.py
@@ -253,7 +253,7 @@ class ApiKeyRedactionFilter(logging.Filter):
             return s
         if isinstance(obj, dict):
             return {k: self._sanitize(v) for k, v in obj.items()}
-        if isinstance(obj, list | tuple):
+        if isinstance(obj, (list, tuple)):
             sanitized = [self._sanitize(v) for v in obj]
             return type(obj)(sanitized)
         return obj


### PR DESCRIPTION
## Summary
- update the API key redaction logging filter to handle iterable checks without relying on union types, restoring compatibility with Python 3.10
- extend the logging utilities test suite with coverage for tuple sanitization and tuple-based log record arguments

## Testing
- python -m pytest -o addopts='' tests/unit/core/common/test_logging_utils.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e0478abf888333a70b8f38cd5990f4