### PR TITLE
Fix API key redaction for hyphenated tokens

### DIFF
--- a/tests/unit/core/common/test_logging_utils.py
+++ b/tests/unit/core/common/test_logging_utils.py
@@ -238,6 +238,11 @@ class TestRedactText:
         result = redact_text("API key: sk_test_1234567890abcdefg")
         assert "sk_test_1234567890abcdefg" not in result
 
+        # Test with modern hyphenated API key
+        modern_key = "sk-proj-1234567890abcdef1234567890"
+        result = redact_text(f"Leaked key: {modern_key}")
+        assert modern_key not in result
+
         # Test with Bearer token
         result = redact_text("Authorization: Bearer abcdefghijklmnopqrst")
         assert "Bearer abcdefghijklmnopqrst" not in result

--- a/tests/unit/core/test_logging_utils.py
+++ b/tests/unit/core/test_logging_utils.py
@@ -87,6 +87,12 @@ class TestRedaction:
         # Just verify it's not the same as the original (redaction happened)
         assert result != text_with_api_key
 
+        # Ensure hyphenated keys are redacted
+        modern_key = "sk-proj-1234567890abcdef1234567890"
+        modern_result = redact_text(modern_key)
+        assert modern_result != modern_key
+        assert "sk-proj" not in modern_result
+
 
 class TestLogging:
     """Test logging functions."""


### PR DESCRIPTION
## Summary
- expand the log redaction regex to cover modern hyphenated API keys (e.g. sk-proj-*)
- reuse the shared regexes inside `redact_text` so bearer tokens and API keys are consistently masked
- add unit coverage proving that hyphenated keys are now redacted in both helper modules

## Testing
- `python -m pytest -o addopts='' tests/unit/core/common/test_logging_utils.py::TestRedactText::test_redact_text tests/unit/core/test_logging_utils.py::TestRedaction::test_redact_text_with_secrets -q`
- `python -m pytest -o addopts='' -q` *(fails: missing optional dev dependencies such as pytest-asyncio, pytest-httpx, respx, hypothesis, pytest-mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e0478abf888333a70b8f38cd5990f4