### PR TITLE
Fix OpenAI SSE chunk translation to canonical stream format

### DIFF
--- a/src/core/services/translation_service.py
+++ b/src/core/services/translation_service.py
@@ -209,7 +209,7 @@ class TranslationService:
             # or minimally processed to match the expected stream format.
             # We will convert it to a canonical stream chunk format if needed later.
             return chunk
-        elif source_format == "openai":
+        elif source_format in {"openai", "openai-responses"}:
             return Translation.openai_to_domain_stream_chunk(chunk)
         elif source_format == "anthropic":
             return Translation.anthropic_to_domain_stream_chunk(chunk)

--- a/tests/unit/core/services/test_translation_service_responses_api.py
+++ b/tests/unit/core/services/test_translation_service_responses_api.py
@@ -147,6 +147,34 @@ class TestResponsesApiTranslation:
         assert domain_request.model == "gpt-4"
         assert len(domain_request.messages) == 1
 
+    def test_to_domain_stream_chunk_responses_sse_input(self):
+        """Test translating SSE-formatted Responses API streaming chunks."""
+
+        sse_chunk = (
+            'data: {"id": "resp-123", "object": "response.chunk", '
+            '"choices": [{"delta": {"content": "partial"}}]}\n\n'
+        )
+
+        domain_chunk = self.service.to_domain_stream_chunk(
+            sse_chunk, "openai-responses"
+        )
+
+        assert isinstance(domain_chunk, dict)
+        assert domain_chunk["choices"][0]["delta"]["content"] == "partial"
+
+    def test_to_domain_stream_chunk_responses_done_marker(self):
+        """Test translating the [DONE] marker from Responses API streaming."""
+
+        done_chunk = "data: [DONE]\n\n"
+
+        domain_chunk = self.service.to_domain_stream_chunk(
+            done_chunk, "openai-responses"
+        )
+
+        assert isinstance(domain_chunk, dict)
+        assert domain_chunk["choices"][0]["finish_reason"] == "stop"
+        assert domain_chunk["choices"][0]["delta"] == {}
+
     def test_from_domain_to_responses_response_basic(self):
         """Test converting a ChatResponse to Responses API response format."""
         # Create a sample ChatResponse


### PR DESCRIPTION
## Summary
- parse string-based SSE chunks (including `[DONE]` and heartbeats) before converting them to canonical OpenAI stream chunks
- allow the translation service to treat `openai-responses` streaming data the same way as OpenAI chat completions
- add regression tests covering SSE conversion for the Responses API

## Testing
- python -m pytest --override-ini="addopts=" tests/unit/core/services/test_translation_service_responses_api.py


------
https://chatgpt.com/codex/tasks/task_e_68e047fc6b048333b11e8a2864487ea3