### PR TITLE
Handle OpenAI Responses output translation

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -593,7 +593,7 @@ class OpenAIConnector(LLMBackend):
         # Convert to domain response first, then back to ensure consistency
         # We'll treat the Responses API response as a special case of OpenAI response
         domain_response = self.translation_service.to_domain_response(
-            response_data, "openai"
+            response_data, "openai-responses"
         )
 
         # Convert back to Responses API format for the final response

--- a/src/core/services/translation_service.py
+++ b/src/core/services/translation_service.py
@@ -33,6 +33,7 @@ class TranslationService:
             "response": {
                 "gemini": Translation.gemini_to_domain_response,
                 "openai": Translation.openai_to_domain_response,
+                "openai-responses": Translation.responses_to_domain_response,
                 "anthropic": Translation.anthropic_to_domain_response,
                 "code_assist": Translation.code_assist_to_domain_response,
                 "raw_text": Translation.raw_text_to_domain_response,
@@ -160,8 +161,7 @@ class TranslationService:
         elif source_format == "openai":
             return Translation.openai_to_domain_response(response)
         elif source_format == "openai-responses":
-            # OpenAI Responses API responses can be treated as OpenAI responses for domain conversion
-            return Translation.openai_to_domain_response(response)
+            return Translation.responses_to_domain_response(response)
         elif source_format == "anthropic":
             return Translation.anthropic_to_domain_response(response)
         elif source_format == "code_assist":


### PR DESCRIPTION
## Summary
- add a dedicated Responses API response converter that normalizes output blocks and tool calls into canonical chat choices
- wire the new converter into the translation service and OpenAI connector so Responses payloads are parsed correctly
- extend translation unit tests to cover Responses output scenarios

## Testing
- python -m pytest -o addopts='' tests/unit/core/domain/test_translation_responses.py tests/unit/core/services/test_translation_service.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e047fc6b048333b11e8a2864487ea3