### PR TITLE
Fix Gemini Code Assist response normalization

### DIFF
--- a/src/connectors/gemini_cloud_project.py
+++ b/src/connectors/gemini_cloud_project.py
@@ -1156,10 +1156,12 @@ class GeminiCloudProjectConnector(GeminiBackend):
             # Convert to OpenAI-compatible format using the translation service
             if not domain_response:
                 raise BackendError("Failed to parse a valid response from the backend.")
-            openai_response = self.translation_service.from_domain_response(
-                response=domain_response,
-                target_format="openai",
-            ).model_dump(exclude_unset=True)
+            openai_response = self._normalize_openai_response(
+                self.translation_service.from_domain_response(
+                    response=domain_response,
+                    target_format="openai",
+                )
+            )
 
             if logger.isEnabledFor(logging.INFO):
                 logger.info(
@@ -1175,6 +1177,34 @@ class GeminiCloudProjectConnector(GeminiBackend):
             if logger.isEnabledFor(logging.ERROR):
                 logger.error(f"Unexpected error during API call: {e}", exc_info=True)
             raise BackendError(f"Unexpected error during API call: {e}")
+
+    def _normalize_openai_response(self, response: Any) -> dict[str, Any]:
+        """Normalize a translation output into an OpenAI-compatible dictionary."""
+        if isinstance(response, dict):
+            return response
+
+        model_dump = getattr(response, "model_dump", None)
+        if callable(model_dump):
+            try:
+                candidate = model_dump(exclude_unset=True)
+            except TypeError:
+                candidate = model_dump()
+            if isinstance(candidate, dict):
+                return candidate
+
+        as_dict = getattr(response, "dict", None)
+        if callable(as_dict):
+            candidate = as_dict()
+            if isinstance(candidate, dict):
+                return candidate
+
+        raise BackendError(
+            message=(
+                "TranslationService returned an unexpected response payload type: "
+                f"{type(response).__name__}"
+            ),
+            code="invalid_openai_response",
+        )
 
     async def _chat_completions_streaming(
         self,

--- a/tests/unit/connectors/test_gemini_cloud_project_translation.py
+++ b/tests/unit/connectors/test_gemini_cloud_project_translation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+import httpx
+
+from src.connectors.gemini_cloud_project import GeminiCloudProjectConnector
+from src.core.common.exceptions import BackendError
+from src.core.config.app_config import AppConfig
+from src.core.services.translation_service import TranslationService
+
+
+def _make_connector() -> GeminiCloudProjectConnector:
+    client = Mock(spec=httpx.AsyncClient)
+    config = AppConfig()
+    return GeminiCloudProjectConnector(
+        client,
+        config,
+        translation_service=TranslationService(),
+        gcp_project_id="test-project",
+    )
+
+
+def test_normalize_openai_response_accepts_dict() -> None:
+    connector = _make_connector()
+    payload = {"object": "chat.completion"}
+
+    result = connector._normalize_openai_response(payload)
+
+    assert result is payload
+
+
+def test_normalize_openai_response_uses_model_dump() -> None:
+    connector = _make_connector()
+
+    class DummyResponse:
+        def model_dump(self, exclude_unset: bool = True) -> dict[str, str]:
+            return {"object": "chat.completion"}
+
+    result = connector._normalize_openai_response(DummyResponse())
+
+    assert result == {"object": "chat.completion"}
+
+
+def test_normalize_openai_response_rejects_unknown_type() -> None:
+    connector = _make_connector()
+
+    with pytest.raises(BackendError):
+        connector._normalize_openai_response(object())
+


### PR DESCRIPTION
## Summary
- ensure the Gemini Cloud Project connector normalizes TranslationService output before returning an OpenAI-style payload
- add unit coverage for the normalization helper to verify dict handling, model_dump usage, and error conditions

## Testing
- python -m pytest -c /tmp/pytest.ini tests/unit/connectors/test_gemini_cloud_project_translation.py
- python -m pytest -c /tmp/pytest.ini # fails: missing optional test dependencies (pytest_asyncio, respx, pytest_httpx, hypothesis, pytest_mock)


------
https://chatgpt.com/codex/tasks/task_e_68e047fc6b048333b11e8a2864487ea3