### PR TITLE
Fix set command handler parameter support

### DIFF
--- a/src/core/commands/handlers/set_command_handler.py
+++ b/src/core/commands/handlers/set_command_handler.py
@@ -1,21 +1,38 @@
 from __future__ import annotations
 
-import contextlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from src.core.commands.command import Command
 from src.core.commands.handler import ICommandHandler
+from src.core.commands.handlers.base_handler import BaseCommandHandler
+from src.core.commands.handlers.loop_detection_handlers import (
+    LoopDetectionHandler,
+    ToolLoopDetectionHandler,
+    ToolLoopMaxRepeatsHandler,
+    ToolLoopModeHandler,
+    ToolLoopTTLHandler,
+)
+from src.core.commands.handlers.project_dir_handler import ProjectDirCommandHandler
+from src.core.commands.handlers.reasoning_handlers import (
+    GeminiGenerationConfigHandler,
+    ReasoningEffortHandler,
+    ThinkingBudgetHandler,
+)
 from src.core.commands.registry import command
 from src.core.domain.command_results import CommandResult
 from src.core.domain.session import Session
 
 if TYPE_CHECKING:
-    pass
+    from collections.abc import Mapping
 
 
 @command("set")
 class SetCommandHandler(ICommandHandler):
     """Handler for the 'set' command."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parameter_handlers = self._build_parameter_handlers()
 
     @property
     def command_name(self) -> str:
@@ -36,18 +53,193 @@ class SetCommandHandler(ICommandHandler):
     async def handle(self, command: Command, session: Session) -> CommandResult:
         """Handle set command by updating session state for supported keys."""
         if not command.args:
-            return CommandResult(success=False, message="No arguments provided.")
+            return CommandResult(
+                success=False,
+                message="No arguments provided.",
+                name=self.command_name,
+            )
 
-        # Update backend provider and/or model when specified
-        backend = command.args.get("backend")
-        model = command.args.get("model")
+        handled_any = False
+        processed_params: set[str] = set()
 
-        if isinstance(backend, str) and backend:
-            with contextlib.suppress(Exception):
-                session.set_provider(backend)
+        backend_result = self._apply_backend_argument(command.args, session)
+        if backend_result is not None:
+            return backend_result
+        if self._has_parameter(command.args, "backend"):
+            handled_any = True
+            processed_params.add("backend")
 
-        if isinstance(model, str) and model:
-            with contextlib.suppress(Exception):
-                session.set_model(model)
+        model_result = self._apply_model_argument(command.args, session)
+        if model_result is not None:
+            return model_result
+        if self._has_parameter(command.args, "model"):
+            handled_any = True
+            processed_params.add("model")
 
-        return CommandResult(success=True, message="Settings updated")
+        for raw_key, value in command.args.items():
+            normalized = self._normalize_param(raw_key)
+            if normalized in processed_params:
+                continue
+
+            if normalized == "temperature":
+                temperature_result = self._apply_temperature(value, session)
+                if temperature_result is not None:
+                    return temperature_result
+                handled_any = True
+                processed_params.add(normalized)
+                continue
+
+            if normalized == "project":
+                project_result = self._apply_project(value, session)
+                if project_result is not None:
+                    return project_result
+                handled_any = True
+                processed_params.add(normalized)
+                continue
+
+            handler = self._parameter_handlers.get(normalized)
+            if handler is not None:
+                handler_result = handler.handle(value, session.state)
+                if not handler_result.success:
+                    return CommandResult(
+                        success=False,
+                        message=handler_result.message,
+                        name=self.command_name,
+                    )
+                if handler_result.new_state is not None:
+                    session.state = handler_result.new_state
+                handled_any = True
+                processed_params.add(normalized)
+                continue
+
+            return CommandResult(
+                success=False,
+                message=f"Unknown parameter: {raw_key}",
+                name=self.command_name,
+            )
+
+        if not handled_any:
+            return CommandResult(
+                success=False,
+                message="No valid parameters provided.",
+                name=self.command_name,
+            )
+
+        return CommandResult(
+            success=True,
+            message="Settings updated",
+            name=self.command_name,
+            new_state=session.state,
+        )
+
+    def _apply_backend_argument(
+        self, args: Mapping[str, Any], session: Session
+    ) -> CommandResult | None:
+        for key, value in args.items():
+            if self._normalize_param(key) != "backend":
+                continue
+            if not isinstance(value, str):
+                return CommandResult(
+                    success=False,
+                    message="Backend name must be a string",
+                    name=self.command_name,
+                )
+            new_backend_config = session.state.backend_config.with_backend(value)
+            session.state = session.state.with_backend_config(new_backend_config)
+            return None
+        return None
+
+    def _apply_model_argument(
+        self, args: Mapping[str, Any], session: Session
+    ) -> CommandResult | None:
+        for key, value in args.items():
+            if self._normalize_param(key) != "model":
+                continue
+            if value is None:
+                new_backend_config = session.state.backend_config.with_model(None)
+                session.state = session.state.with_backend_config(new_backend_config)
+                return None
+            if not isinstance(value, str):
+                return CommandResult(
+                    success=False,
+                    message="Model name must be a string",
+                    name=self.command_name,
+                )
+            model_value = value
+            if ":" in model_value:
+                backend_part, model_part = model_value.split(":", 1)
+                backend_error = self._apply_backend_argument(
+                    {"backend": backend_part}, session
+                )
+                if backend_error is not None:
+                    return backend_error
+                model_value = model_part
+            new_backend_config = session.state.backend_config.with_model(model_value)
+            session.state = session.state.with_backend_config(new_backend_config)
+            return None
+        return None
+
+    def _apply_temperature(
+        self, value: Any, session: Session
+    ) -> CommandResult | None:
+        if value is None:
+            return CommandResult(
+                success=False,
+                message="Temperature value must be specified",
+                name=self.command_name,
+            )
+        try:
+            temperature = float(value)
+        except (TypeError, ValueError):
+            return CommandResult(
+                success=False,
+                message="Temperature must be a valid number",
+                name=self.command_name,
+            )
+        if not 0.0 <= temperature <= 1.0:
+            return CommandResult(
+                success=False,
+                message="Temperature must be between 0.0 and 1.0",
+                name=self.command_name,
+            )
+        reasoning_config = session.state.reasoning_config.with_temperature(temperature)
+        session.state = session.state.with_reasoning_config(reasoning_config)
+        return None
+
+    def _apply_project(self, value: Any, session: Session) -> CommandResult | None:
+        if not isinstance(value, str) or not value:
+            return CommandResult(
+                success=False,
+                message="Project name must be a non-empty string",
+                name=self.command_name,
+            )
+        session.state = session.state.with_project(value)
+        return None
+
+    def _build_parameter_handlers(self) -> dict[str, BaseCommandHandler]:
+        handlers: list[BaseCommandHandler] = [
+            ProjectDirCommandHandler(),
+            LoopDetectionHandler(),
+            ToolLoopDetectionHandler(),
+            ToolLoopMaxRepeatsHandler(),
+            ToolLoopModeHandler(),
+            ToolLoopTTLHandler(),
+            ReasoningEffortHandler(),
+            ThinkingBudgetHandler(),
+            GeminiGenerationConfigHandler(),
+        ]
+        handler_map: dict[str, BaseCommandHandler] = {}
+        for handler in handlers:
+            names = [handler.name, *handler.aliases]
+            for name in names:
+                handler_map[self._normalize_param(name)] = handler
+        return handler_map
+
+    def _normalize_param(self, param_name: str) -> str:
+        return param_name.lower().replace("_", "-").replace(" ", "-")
+
+    def _has_parameter(self, args: Mapping[str, Any], name: str) -> bool:
+        normalized_name = self._normalize_param(name)
+        return any(
+            self._normalize_param(arg_name) == normalized_name for arg_name in args.keys()
+        )

--- a/tests/unit/commands/test_set_command_handler.py
+++ b/tests/unit/commands/test_set_command_handler.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from src.core.commands.command import Command
+from src.core.commands.handlers.set_command_handler import SetCommandHandler
+from src.core.domain.configuration.reasoning_config import ReasoningConfiguration
+from src.core.domain.session import Session, SessionState
+
+
+def test_set_command_handler_updates_temperature() -> None:
+    handler = SetCommandHandler()
+    state = SessionState(
+        reasoning_config=ReasoningConfiguration(temperature=0.2)
+    )
+    session = Session(session_id="test", state=state)
+    command = Command(name="set", args={"temperature": "0.8"})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is True
+    assert result.message == "Settings updated"
+    assert session.state.reasoning_config.temperature == pytest.approx(0.8)
+
+
+def test_set_command_handler_updates_project_dir(tmp_path: Path) -> None:
+    handler = SetCommandHandler()
+    session = Session(session_id="test", state=SessionState())
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    command = Command(name="set", args={"project-dir": str(project_dir)})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is True
+    assert session.state.project_dir == str(project_dir)
+
+
+def test_set_command_handler_rejects_unknown_parameter() -> None:
+    handler = SetCommandHandler()
+    session = Session(session_id="test", state=SessionState())
+    command = Command(name="set", args={"unsupported": "value"})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is False
+    assert result.message == "Unknown parameter: unsupported"
+
+
+def test_set_command_handler_validates_temperature_range() -> None:
+    handler = SetCommandHandler()
+    session = Session(
+        session_id="test",
+        state=SessionState(reasoning_config=ReasoningConfiguration()),
+    )
+    command = Command(name="set", args={"temperature": "2.5"})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is False
+    assert result.message == "Temperature must be between 0.0 and 1.0"


### PR DESCRIPTION
## Summary
- route the `/set` interactive command through the dedicated parameter handlers so temperature, project, and loop-detection settings are applied to the session state
- add input validation for backend/model updates and reuse helper methods when parsing combined backend:model overrides
- cover the handler with unit tests for success and error scenarios

## Testing
- pytest -o addopts="" tests/unit/commands/test_set_command_handler.py
- pytest -o addopts="" *(fails: missing pytest_asyncio, respx, pytest_httpx, pytest_mock dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e047b54b54833397c8d1cd4658bf08