### PR TITLE
Fix interactive model command messaging

### DIFF
--- a/src/core/commands/handlers/model_command_handler.py
+++ b/src/core/commands/handlers/model_command_handler.py
@@ -1,16 +1,23 @@
-"""
-Command handler for setting/unsetting the active model (and optional backend).
-"""
+"""Command handler for the interactive ``!/model`` command."""
+
+from collections.abc import Mapping
+from typing import Any
 
 from src.core.commands.command import Command
 from src.core.commands.handler import ICommandHandler
 from src.core.commands.registry import command
 from src.core.domain.command_results import CommandResult
+from src.core.domain.commands.model_command import ModelCommand
 from src.core.domain.session import Session
 
 
 @command("model")
 class ModelCommandHandler(ICommandHandler):
+    """Interactive handler that delegates to the domain ``ModelCommand``."""
+
+    def __init__(self, model_command: ModelCommand | None = None) -> None:
+        self._model_command = model_command or ModelCommand()
+
     @property
     def command_name(self) -> str:
         return "model"
@@ -28,25 +35,5 @@ class ModelCommandHandler(ICommandHandler):
         return ["!/model(name=gpt-4)", "!/model(name=openrouter:claude-3-opus)"]
 
     async def handle(self, command: Command, session: Session) -> CommandResult:
-        name = command.args.get("name")
-        if name is None or (isinstance(name, str) and not name.strip()):
-            # Unset
-            new_state = session.state.with_backend_config(
-                session.state.backend_config.with_model(None)
-            )
-            return CommandResult(
-                success=True, message="Model command executed", new_state=new_state
-            )
-
-        # Set
-        backend_type = None
-        model = name
-        if ":" in name:
-            backend_type, model = name.split(":", 1)
-        new_backend_cfg = session.state.backend_config.with_model(model)
-        if backend_type:
-            new_backend_cfg = new_backend_cfg.with_backend(backend_type)
-        new_state = session.state.with_backend_config(new_backend_cfg)
-        return CommandResult(
-            success=True, message="Model command executed", new_state=new_state
-        )
+        args: Mapping[str, Any] = command.args
+        return await self._model_command.execute(args, session)

--- a/tests/unit/commands/test_unit_model_command_handler.py
+++ b/tests/unit/commands/test_unit_model_command_handler.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from src.core.commands.command import Command
+from src.core.commands.handlers.model_command_handler import ModelCommandHandler
+from src.core.domain.session import Session
+
+
+def test_model_command_handler_sets_model() -> None:
+    handler = ModelCommandHandler()
+    session = Session(session_id="test-session")
+    command = Command(name="model", args={"name": "gpt-4-turbo"})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is True
+    assert result.message == "Model changed to gpt-4-turbo"
+    assert result.new_state is not None
+    assert result.new_state.backend_config.model == "gpt-4-turbo"
+
+
+def test_model_command_handler_sets_backend_and_model() -> None:
+    handler = ModelCommandHandler()
+    session = Session(session_id="test-session")
+    command = Command(name="model", args={"name": "openrouter:claude-3-opus"})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is True
+    assert (
+        result.message
+        == "Backend changed to openrouter; Model changed to claude-3-opus"
+    )
+    assert result.new_state is not None
+    assert result.new_state.backend_config.backend_type == "openrouter"
+    assert result.new_state.backend_config.model == "claude-3-opus"
+
+
+def test_model_command_handler_unsets_model() -> None:
+    handler = ModelCommandHandler()
+    session = Session(session_id="test-session")
+    command = Command(name="model", args={"name": ""})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is True
+    assert result.message == "Model unset"
+    assert result.new_state is not None
+    assert result.new_state.backend_config.model is None


### PR DESCRIPTION
## Summary
- delegate the interactive `!/model` handler to the existing domain `ModelCommand` so responses match core command behaviour
- add unit tests covering model selection, backend override, and unset flows for the interactive handler

## Testing
- python -m pytest --override-ini addopts="" tests/unit/commands/test_unit_model_command_handler.py
- python -m pytest --override-ini addopts="" *(fails: missing optional test dependencies such as pytest-asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e047b54b54833397c8d1cd4658bf08