### PR TITLE
Preserve HTTPException detail payloads

### DIFF
--- a/src/core/adapters/exception_adapters.py
+++ b/src/core/adapters/exception_adapters.py
@@ -46,9 +46,21 @@ def create_exception_handler() -> (
 
         # FastAPI HTTPExceptions - pass through
         if isinstance(exc, HTTPException):
+            detail = exc.detail
+
+            if isinstance(detail, dict):
+                content = detail
+            else:
+                content = {
+                    "error": {
+                        "message": str(detail),
+                        "type": "http_error",
+                    }
+                }
+
             return JSONResponse(
                 status_code=exc.status_code,
-                content={"error": {"message": str(exc.detail), "type": "http_error"}},
+                content=content,
                 headers=getattr(exc, "headers", None),
             )
 

--- a/tests/unit/core/adapters/test_exception_adapters.py
+++ b/tests/unit/core/adapters/test_exception_adapters.py
@@ -4,6 +4,7 @@ Tests for Exception Adapters module.
 This module tests the exception handling and conversion functions.
 """
 
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -196,6 +197,20 @@ class TestCreateExceptionHandler:
         assert response.status_code == 404
         content = response.body.decode()
         assert "Not found" in content
+
+    @pytest.mark.asyncio
+    async def test_handle_fastapi_http_exception_with_dict_detail(
+        self, mock_request: Mock, exception_handler
+    ) -> None:
+        """Ensure dictionary details from HTTPException are preserved."""
+        detail = {"error": {"message": "Detailed", "code": "X123"}}
+        error = StarletteHTTPException(status_code=418, detail=detail)
+
+        response = await exception_handler(mock_request, error)
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 418
+        assert json.loads(response.body) == detail
 
     @pytest.mark.asyncio
     async def test_handle_generic_exception(


### PR DESCRIPTION
## Summary
- ensure the FastAPI exception handler preserves dictionary details from HTTPException instances instead of stringifying them
- add regression coverage verifying dict payloads are returned unchanged

## Testing
- python -m pytest -o addopts="" tests/unit/core/adapters/test_exception_adapters.py -k dict_detail *(fails: async plugin missing in environment)*
- python -m pytest -o addopts="" *(fails: multiple missing test dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e0482bc3548333a1c0dff7794781e5