### PR TITLE
Fix Python 3.10 compatibility in FastAPI exception adapter

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -42,7 +42,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- replace the use of the PEP 604 union type with a tuple of classes when checking configuration and invalid request errors
- restore compatibility with Python 3.10 runtimes where isinstance does not accept union objects

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/test_transport_adapters.py *(fails: interpreter path not available in container)*
- python -m pytest tests/unit/test_transport_adapters.py *(fails: project-level addopts require plugins that are not installed in this environment)*
- python -m pytest -c /tmp/pytest.ini tests/unit/test_transport_adapters.py *(fails: async tests require pytest-asyncio which is unavailable in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68e0482bc3548333a1c0dff7794781e5