### PR TITLE
Improve default backend error handling

### DIFF
--- a/src/core/services/application_state_service.py
+++ b/src/core/services/application_state_service.py
@@ -121,13 +121,23 @@ class ApplicationStateService(IApplicationState):
 
     def get_functional_backends(self) -> list[str]:
         """Get list of functional backends."""
+
+        def _normalize_backends(value: Any) -> list[str]:
+            if isinstance(value, list):
+                return value
+            if isinstance(value, set):
+                return list(value)
+            if isinstance(value, tuple):
+                return list(value)
+            return []
+
         if self._state_provider and hasattr(
             self._state_provider, "functional_backends"
         ):
             backends = self._state_provider.functional_backends
-            return backends if isinstance(backends, list) else []
+            return _normalize_backends(backends)
         local_backends = self._local_state.get("functional_backends", [])
-        return local_backends if isinstance(local_backends, list) else []
+        return _normalize_backends(local_backends)
 
     def set_functional_backends(self, backends: list[str]) -> None:
         """Set list of functional backends."""

--- a/tests/unit/test_qwen_oauth_interactive_commands.py
+++ b/tests/unit/test_qwen_oauth_interactive_commands.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 import pytest
 
+from src.core.common.exceptions import ConfigurationError
+
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
@@ -121,7 +123,7 @@ class TestQwenOAuthConfigurationMethods:
             # This should not raise an error
             try:
                 config_manager._apply_default_backend("qwen-oauth")
-            except ValueError as e:
+            except (ValueError, ConfigurationError) as e:
                 if "not in functional_backends" in str(e):
                     # Expected if qwen-oauth is not actually functional
                     pass


### PR DESCRIPTION
## Summary
- raise `ConfigurationError` with structured details when persisted default backends are not functional
- normalize functional backend collections in the application state service to avoid false negatives for set inputs
- add a regression test for the new error handling path and adjust the qwen OAuth persistence test expectations

## Testing
- `pytest --override-ini addopts="" -p tests.k_asyncio_plugin tests/unit/test_config_persistence.py::test_apply_default_backend_invalid_backend_raises_configuration_error`
- `pytest --override-ini addopts="" -p tests.k_asyncio_plugin tests/unit/test_qwen_oauth_interactive_commands.py::TestQwenOAuthConfigurationMethods::test_config_file_backend_persistence`
- `pytest --override-ini addopts="" -p tests.k_asyncio_plugin`


------
https://chatgpt.com/codex/tasks/task_e_68e0482bc3548333a1c0dff7794781e5