### PR TITLE
Close OpenAI streaming responses on error

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import suppress
 
 logger = logging.getLogger(__name__)
 
@@ -434,6 +435,9 @@ class OpenAIConnector(LLMBackend):
                 body = (await response.aread()).decode("utf-8")
             except Exception:
                 body = getattr(response, "text", "")
+            finally:
+                with suppress(Exception):
+                    await response.aclose()
             raise HTTPException(
                 status_code=status_code,
                 detail={


### PR DESCRIPTION
## Summary
- ensure OpenAI streaming responses are properly closed before raising HTTP errors to avoid leaking connections
- add defensive cleanup for error paths by suppressing close exceptions

## Testing
- python -m pytest tests/unit/openai_connector_tests/test_streaming_response.py *(fails: missing pytest-mock fixture in environment)*
- python -m pytest *(fails: missing pytest_asyncio, pytest_httpx, respx, pytest_mock dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e048af8b3483338e7bafadaceac220