### PR TITLE
Fix OpenAI connector leaking API key in logs

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -90,7 +90,11 @@ class OpenAIConnector(LLMBackend):
 
     async def initialize(self, **kwargs: Any) -> None:
         self.api_key = kwargs.get("api_key")
-        logger.info(f"OpenAIConnector initialize called. api_key: {self.api_key}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "OpenAIConnector initialize called. api_key provided: %s",
+                bool(self.api_key),
+            )
         if "api_base_url" in kwargs:
             self.api_base_url = kwargs["api_base_url"]
 


### PR DESCRIPTION
## Summary
- avoid logging the raw OpenAI API key during connector initialization to keep secrets out of log files

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/openai_connector_tests *(fails: required pytest plugins such as pytest-asyncio are not installed in the environment)*
- python -m pytest --override-ini=addopts="" *(fails: required pytest plugins and dependencies like pytest-asyncio, respx, pytest_httpx, pytest_mock are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e048af8b3483338e7bafadaceac220