### PR TITLE
Handle streaming request failures in OpenAI connector

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -427,7 +427,12 @@ class OpenAIConnector(LLMBackend):
             raise AuthenticationError(message="No auth credentials found")
 
         request = self.client.build_request("POST", url, json=payload, headers=headers)
-        response = await self.client.send(request, stream=True)
+        try:
+            response = await self.client.send(request, stream=True)
+        except httpx.RequestError as exc:
+            raise ServiceUnavailableError(
+                message=f"Could not connect to backend ({exc})"
+            ) from exc
 
         status_code = (
             int(response.status_code) if hasattr(response, "status_code") else 200


### PR DESCRIPTION
## Summary
- wrap OpenAIConnector streaming requests in a try/except so request errors surface as ServiceUnavailableError

## Testing
- python -m pytest --override-ini addopts="" tests/unit/openai_connector_tests/test_streaming_response.py *(fails: pytest-mock fixture unavailable in environment)*
- python -m pytest --override-ini addopts="" *(fails: pytest-asyncio, respx, pytest_httpx, and pytest-mock not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e048af8b3483338e7bafadaceac220