### PR TITLE
Fix pytest alias detection in compression service

### DIFF
--- a/src/core/services/pytest_compression_service.py
+++ b/src/core/services/pytest_compression_service.py
@@ -22,8 +22,8 @@ class PytestCompressionService:
             "container.exec",
         ]
 
-        # Pattern to detect pytest in command arguments
-        self.pytest_pattern = re.compile(r"pytest")
+        # Pattern to detect pytest in command arguments (supports pytest and py.test aliases)
+        self.pytest_pattern = re.compile(r"\bpy\.?test\b", re.IGNORECASE)
 
     def scan_tool_call_for_pytest(self, tool_call: ToolCall) -> tuple[bool, str] | None:
         """


### PR DESCRIPTION
## Summary
- update the pytest command detection regex so the compression service also matches the `py.test` alias
- add regression tests that cover direct alias detection and ToolCall payloads for py.test commands

## Testing
- pytest --override-ini addopts="" -k TestPytestCompressionServiceDetection tests/unit/core/services/test_pytest_compression_service.py
- pytest --override-ini addopts="" *(fails: missing optional plugins such as pytest-asyncio, pytest_httpx, respx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e04d29dff48333bb830ace269d4546