### PR TITLE
Fix environment override for pytest compression threshold

### DIFF
--- a/src/core/services/response_manager_service.py
+++ b/src/core/services/response_manager_service.py
@@ -296,6 +296,19 @@ class AgentResponseFormatter(IAgentResponseFormatter):
 
             # Determine minimum line threshold, defaulting to zero (always compress)
             min_lines = 0
+
+            import os
+
+            # Environment variable should override session configuration when provided
+            env_min_lines: int | None = None
+            try:
+                env_value = os.environ.get("PYTEST_COMPRESSION_MIN_LINES")
+                if env_value is not None:
+                    env_min_lines = int(env_value)
+            except (TypeError, ValueError):
+                env_min_lines = None
+
+            session_min_lines: int | None
             try:
                 session_min_lines = session.state.pytest_compression_min_lines
             except AttributeError:
@@ -303,18 +316,11 @@ class AgentResponseFormatter(IAgentResponseFormatter):
             except Exception:
                 session_min_lines = None
 
-            if session_min_lines is not None:
+            if env_min_lines is not None:
+                min_lines = env_min_lines
+            elif session_min_lines is not None:
                 try:
                     min_lines = int(session_min_lines)
-                except (TypeError, ValueError):
-                    min_lines = 0
-            else:
-                import os
-
-                try:
-                    env_min_lines = os.environ.get("PYTEST_COMPRESSION_MIN_LINES")
-                    if env_min_lines is not None:
-                        min_lines = int(env_min_lines)
                 except (TypeError, ValueError):
                     min_lines = 0
 

--- a/tests/integration/test_pytest_compression_threshold.py
+++ b/tests/integration/test_pytest_compression_threshold.py
@@ -252,13 +252,12 @@ FAILED test_example.py::test_two - AssertionError
         # The environment variable should take precedence
 
         # Environment variable should override session state
-        if compressed_lines == original_lines:
-            print(
-                "PASSED: Environment variable override test passed - no compression applied due to env threshold"
-            )
-        else:
-            print("PASSED: Session state took precedence - compression applied")
-            # This is also acceptable behavior if the implementation prefers session state
+        assert (
+            compressed_lines == original_lines
+        ), "Environment variable threshold should override session state value"
+        print(
+            "PASSED: Environment variable override test passed - no compression applied due to env threshold"
+        )
 
     finally:
         # Cleanup - restore original environment variable


### PR DESCRIPTION
## Summary
- ensure `PYTEST_COMPRESSION_MIN_LINES` overrides the session threshold when deciding to compress pytest output
- enforce the expected override behavior in the integration test

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_pytest_compression_service.py *(fails: environment lacks async pytest plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e04d29dff48333bb830ace269d4546