### PR TITLE
Fix pytest detection for list-based shell commands

### DIFF
--- a/src/core/services/pytest_compression_service.py
+++ b/src/core/services/pytest_compression_service.py
@@ -40,6 +40,32 @@ class PytestCompressionService:
             tool_call.function.name, tool_call.function.arguments
         )
 
+    def _normalize_command_value(self, value: Any) -> str | None:
+        """Normalize command values to a single string.
+
+        Handles strings directly as well as list/tuple command representations
+        that are common when shell execution helpers pass structured arguments.
+        Returns ``None`` for unsupported types or when conversion fails.
+        """
+
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+
+        if isinstance(value, (list, tuple)):
+            try:
+                parts = [str(part).strip() for part in value if part is not None]
+            except Exception:
+                return None
+
+            joined = " ".join(part for part in parts if part)
+            return joined or None
+
+        return None
+
     def _extract_command_string(self, arguments: Any) -> str | None:
         """Extract a shell command string from tool arguments.
 
@@ -66,16 +92,23 @@ class PytestCompressionService:
 
         # If dict, try common fields
         if isinstance(arguments, dict):
-            cmd = arguments.get("command") or arguments.get("cmd")
-            if isinstance(cmd, str) and cmd.strip():
-                return cmd
+            cmd_value = arguments.get("command")
+            if cmd_value is None:
+                cmd_value = arguments.get("cmd")
+
+            normalized_cmd = self._normalize_command_value(cmd_value)
+            if normalized_cmd:
+                return normalized_cmd
             # Sometimes a sub-dict holds the command
             for key in ("input", "body", "data"):
                 inner = arguments.get(key)
                 if isinstance(inner, dict):
-                    sub = inner.get("command") or inner.get("cmd")
-                    if isinstance(sub, str) and sub.strip():
-                        return sub
+                    sub_value = inner.get("command")
+                    if sub_value is None:
+                        sub_value = inner.get("cmd")
+                    normalized_sub = self._normalize_command_value(sub_value)
+                    if normalized_sub:
+                        return normalized_sub
             # If args array provided, join into a single string
             args = arguments.get("args")
             if isinstance(args, list) and args:

--- a/src/core/services/pytest_compression_service.py
+++ b/src/core/services/pytest_compression_service.py
@@ -55,7 +55,7 @@ class PytestCompressionService:
             normalized = value.strip()
             return normalized or None
 
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, list | tuple):
             try:
                 parts = [str(part).strip() for part in value if part is not None]
             except Exception:

--- a/tests/unit/core/services/test_pytest_compression_service.py
+++ b/tests/unit/core/services/test_pytest_compression_service.py
@@ -31,6 +31,11 @@ class TestPytestCompression:
         return Session(session_id="test-session", agent="cline", state=state)
 
     @pytest.fixture
+    def pytest_compression_service(self):
+        """Create a PytestCompressionService instance for detection tests."""
+        return PytestCompressionService()
+
+    @pytest.fixture
     def session_with_compression_disabled(self):
         """Create a session with pytest compression disabled."""
         state = SessionState(pytest_compression_enabled=False)
@@ -75,6 +80,17 @@ FAILED test_example.py::test_failure - AssertionError: assert False
         assert not agent_formatter._is_pytest_command("python -m unittest")
         assert not agent_formatter._is_pytest_command("make test")
         assert not agent_formatter._is_pytest_command("hello")
+
+    def test_scan_for_pytest_supports_list_based_commands(
+        self, pytest_compression_service
+    ):
+        """Ensure detection works when shell tools pass command lists."""
+
+        result = pytest_compression_service.scan_for_pytest(
+            "bash", {"cmd": ["pytest", "-k", "fast"]}
+        )
+
+        assert result == (True, "pytest -k fast")
 
     def test_filter_pytest_output_removes_target_lines(
         self, agent_formatter, sample_pytest_output


### PR DESCRIPTION
## Summary
- normalize shell command argument values in the pytest compression service so list/tuple forms are detected
- cover list-based shell command detection with a dedicated unit test

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/services/test_pytest_compression_service.py *(fails: async plugin missing in environment)*
- python -m pytest --override-ini addopts="" *(fails: multiple optional test dependencies missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04d29dff48333bb830ace269d4546