### PR TITLE
Fix pytest command detection for compression

### DIFF
--- a/src/core/services/response_manager_service.py
+++ b/src/core/services/response_manager_service.py
@@ -251,7 +251,7 @@ class AgentResponseFormatter(IAgentResponseFormatter):
             pass
 
         looks_like_pytest = (
-            self._is_pytest_command(command_name)
+            self._is_pytest_command(command_name, message)
             or "test session starts" in message
             or "short test summary info" in message
         )


### PR DESCRIPTION
## Summary
- ensure pytest command detection considers the command output so shell-executed pytest runs trigger compression

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_PLUGINS=tests.k_asyncio_plugin python -m pytest --override-ini addopts="" tests/unit/core/services/test_pytest_compression_service.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_PLUGINS=tests.k_asyncio_plugin python -m pytest --override-ini addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68e04d29dff48333bb830ace269d4546