### PR TITLE
Handle trailing newlines in replacement rules

### DIFF
--- a/tests/unit/core/services/test_content_rewriter_service.py
+++ b/tests/unit/core/services/test_content_rewriter_service.py
@@ -190,6 +190,43 @@ class TestContentRewriterService(unittest.TestCase):
         rewritten = service.rewrite_reply(reply)
         self.assertEqual(rewritten, "This is an rewritten reply.")
 
+    def test_rule_files_trim_trailing_newlines(self):
+        """Rules with trailing newlines in files should still apply correctly."""
+
+        os.makedirs(
+            os.path.join(self.test_config_dir, "prompts", "user", "003_newline"),
+            exist_ok=True,
+        )
+        with open(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "user",
+                "003_newline",
+                "SEARCH.txt",
+            ),
+            "w",
+        ) as search_file:
+            search_file.write("target phrase\n")
+        with open(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "user",
+                "003_newline",
+                "REPLACE.txt",
+            ),
+            "w",
+        ) as replace_file:
+            replace_file.write("updated phrase\n")
+
+        service = ContentRewriterService(config_path=self.test_config_dir)
+
+        prompt = "This target phrase should be updated."
+        rewritten = service.rewrite_prompt(prompt, "user")
+
+        self.assertEqual(rewritten, "This updated phrase should be updated.")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize text loaded from SEARCH/REPLACE files so trailing newlines and BOMs do not break content rewrites
- add warnings for incomplete rule directories and reuse a helper for reading rule text
- cover the regression with a unit test that verifies newline-terminated rules apply successfully

## Testing
- python -m pytest -c /tmp/pytest_no_xdist.ini tests/unit/core/services/test_content_rewriter_service.py
- python -m pytest -c /tmp/pytest_no_xdist.ini tests/integration/test_content_rewriting_middleware.py
- python -m pytest -c /tmp/pytest_no_xdist.ini

------
https://chatgpt.com/codex/tasks/task_e_68e04d85ab88833386e0814f85e93bbc