### PR TITLE
Fix newline handling for content rewrite rules

### DIFF
--- a/src/core/services/content_rewriter_service.py
+++ b/src/core/services/content_rewriter_service.py
@@ -67,8 +67,7 @@ class ContentRewriterService:
             mode_file_name = found_modes[0]
             mode_file_path = mode_files[mode_file_name]
 
-            with open(search_file, encoding="utf-8") as f:
-                search_text = f.read()
+            search_text = self._read_rule_file(search_file)
 
             if len(search_text) < 8:
                 logger.warning(
@@ -77,8 +76,7 @@ class ContentRewriterService:
                 )
                 continue
 
-            with open(mode_file_path, encoding="utf-8") as f:
-                action_text = f.read()
+            action_text = self._read_rule_file(mode_file_path)
 
             if not search_text:
                 continue
@@ -109,6 +107,18 @@ class ContentRewriterService:
                 )
 
         return rules
+
+    def _read_rule_file(self, path: str) -> str:
+        """Read a rule file, normalizing trailing newline characters."""
+
+        with open(path, encoding="utf-8") as file:
+            text = file.read()
+
+        if text.endswith("\r\n"):
+            return text[:-2]
+        if text.endswith("\n") or text.endswith("\r"):
+            return text[:-1]
+        return text
 
     def _apply_rules(self, content: str, rules: list[ReplacementRule]) -> str:
         """Applies a list of replacement rules to a string."""

--- a/tests/unit/core/services/test_content_rewriter_service.py
+++ b/tests/unit/core/services/test_content_rewriter_service.py
@@ -190,6 +190,53 @@ class TestContentRewriterService(unittest.TestCase):
         rewritten = service.rewrite_reply(reply)
         self.assertEqual(rewritten, "This is an rewritten reply.")
 
+    def test_rules_ignore_trailing_newlines_in_files(self):
+        """Ensure rule files ending with newlines are applied correctly."""
+
+        os.makedirs(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "user",
+                "003_newline",
+            ),
+            exist_ok=True,
+        )
+
+        with open(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "user",
+                "003_newline",
+                "SEARCH.txt",
+            ),
+            "w",
+        ) as file:
+            file.write("newline marker\n")
+
+        with open(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "user",
+                "003_newline",
+                "REPLACE.txt",
+            ),
+            "w",
+        ) as file:
+            file.write("updated marker\n")
+
+        service = ContentRewriterService(config_path=self.test_config_dir)
+
+        prompt = "The newline marker should be replaced."
+        rewritten_prompt = service.rewrite_prompt(prompt, "user")
+
+        self.assertEqual(
+            rewritten_prompt,
+            "The updated marker should be replaced.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize trailing newline characters when loading replacement rule files so replacements work even when files end with newlines
- add a regression test that covers newline-terminated search and replace files

## Testing
- python -m pytest -o addopts= tests/unit/core/services/test_content_rewriter_service.py
- python -m pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e04d85ab88833386e0814f85e93bbc