### PR TITLE
Handle non-text payloads in content rewriting middleware

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -78,7 +78,10 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                 is_rewritten = False
                 if "choices" in data and isinstance(data["choices"], list):
                     for choice in data["choices"]:
-                        if "message" not in choice or "content" not in choice["message"]:
+                        if (
+                            "message" not in choice
+                            or "content" not in choice["message"]
+                        ):
                             continue
 
                         original_content = choice["message"]["content"]

--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -24,15 +24,20 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                 is_rewritten = False
                 if "messages" in data and isinstance(data["messages"], list):
                     for message in data["messages"]:
-                        if "role" in message and "content" in message:
-                            role = message["role"]
-                            original_content = message["content"]
-                            rewritten_content = self.rewriter.rewrite_prompt(
-                                original_content, role
-                            )
-                            if original_content != rewritten_content:
-                                message["content"] = rewritten_content
-                                is_rewritten = True
+                        if "role" not in message or "content" not in message:
+                            continue
+
+                        original_content = message["content"]
+                        if not isinstance(original_content, str):
+                            continue
+
+                        role = message["role"]
+                        rewritten_content = self.rewriter.rewrite_prompt(
+                            original_content, role
+                        )
+                        if original_content != rewritten_content:
+                            message["content"] = rewritten_content
+                            is_rewritten = True
 
                 if is_rewritten:
                     body_bytes = json.dumps(data).encode("utf-8")
@@ -73,14 +78,19 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                 is_rewritten = False
                 if "choices" in data and isinstance(data["choices"], list):
                     for choice in data["choices"]:
-                        if "message" in choice and "content" in choice["message"]:
-                            original_content = choice["message"]["content"]
-                            rewritten_content = self.rewriter.rewrite_reply(
-                                original_content
-                            )
-                            if original_content != rewritten_content:
-                                choice["message"]["content"] = rewritten_content
-                                is_rewritten = True
+                        if "message" not in choice or "content" not in choice["message"]:
+                            continue
+
+                        original_content = choice["message"]["content"]
+                        if not isinstance(original_content, str):
+                            continue
+
+                        rewritten_content = self.rewriter.rewrite_reply(
+                            original_content
+                        )
+                        if original_content != rewritten_content:
+                            choice["message"]["content"] = rewritten_content
+                            is_rewritten = True
 
                 if is_rewritten:
                     new_body = json.dumps(data).encode("utf-8")

--- a/src/core/services/rate_limiter.py
+++ b/src/core/services/rate_limiter.py
@@ -223,9 +223,7 @@ class ConfigurableRateLimiter(IRateLimiter):
         """Apply configuration to the rate limiter."""
         rate_limits = self._config.get("rate_limits", {})
         if not isinstance(rate_limits, dict):
-            logger.warning(
-                "Rate limit configuration is not a mapping: %r", rate_limits
-            )
+            logger.warning("Rate limit configuration is not a mapping: %r", rate_limits)
             return
 
         default_limit = getattr(self._limiter, "_default_limit", 60)

--- a/tests/integration/test_content_rewriting_middleware.py
+++ b/tests/integration/test_content_rewriting_middleware.py
@@ -102,6 +102,74 @@ class TestContentRewritingMiddleware(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_inbound_reply_rewriting_ignores_non_string_content(self):
+        """Ensure non-string replies are forwarded unchanged."""
+
+        os.makedirs(os.path.join(self.test_config_dir, "replies", "001"), exist_ok=True)
+        with open(
+            os.path.join(self.test_config_dir, "replies", "001", "SEARCH.txt"), "w"
+        ) as f:
+            f.write("original reply")
+        with open(
+            os.path.join(self.test_config_dir, "replies", "001", "REPLACE.txt"), "w"
+        ) as f:
+            f.write("rewritten reply")
+
+        rewriter = ContentRewriterService(config_path=self.test_config_dir)
+        middleware = ContentRewritingMiddleware(app=None, rewriter=rewriter)
+
+        response_payload = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "This is an original reply."}
+                        ],
+                    }
+                }
+            ]
+        }
+
+        async def call_next(request):
+            return Response(
+                content=json.dumps(response_payload), media_type="application/json"
+            )
+
+        async def receive():
+            return {"type": "http.request", "body": b""}
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "headers": Headers({"content-type": "application/json"}).raw,
+                "http_version": "1.1",
+                "server": ("testserver", 80),
+                "client": ("testclient", 123),
+                "scheme": "http",
+                "root_path": "",
+                "path": "/test",
+                "raw_path": b"/test",
+                "query_string": b"",
+            },
+            receive=receive,
+        )
+
+        async def run_test():
+            response = await middleware.dispatch(request, call_next)
+            new_body = json.loads(response.body)
+            self.assertEqual(
+                new_body["choices"][0]["message"]["content"],
+                [
+                    {"type": "text", "text": "This is an original reply."}
+                ],
+            )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
     def test_outbound_prompt_rewriting(self):
         """Verify that outbound prompts are rewritten correctly."""
 
@@ -153,6 +221,64 @@ class TestContentRewritingMiddleware(unittest.TestCase):
             self.assertEqual(
                 new_body["messages"][1]["content"], "This is a user prompt."
             )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
+    def test_outbound_prompt_rewriting_ignores_non_string_content(self):
+        """Ensure non-string prompt content is left untouched."""
+
+        async def run_test():
+            rewriter = ContentRewriterService(config_path=self.test_config_dir)
+            middleware = ContentRewritingMiddleware(app=None, rewriter=rewriter)
+
+            structured_content = [{"type": "text", "text": "Structured user payload."}]
+            payload = {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "This is an original system prompt.",
+                    },
+                    {"role": "user", "content": structured_content},
+                ]
+            }
+
+            async def get_body():
+                return json.dumps(payload).encode("utf-8")
+
+            request = Request(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "headers": Headers({"content-type": "application/json"}).raw,
+                    "http_version": "1.1",
+                    "server": ("testserver", 80),
+                    "client": ("testclient", 123),
+                    "scheme": "http",
+                    "root_path": "",
+                    "path": "/test",
+                    "raw_path": b"/test",
+                    "query_string": b"",
+                }
+            )
+            request._body = await get_body()
+
+            call_next = AsyncMock()
+            call_next.return_value = Response("OK")
+
+            await middleware.dispatch(request, call_next)
+
+            call_next.assert_called_once()
+            new_request = call_next.call_args[0][0]
+
+            new_body = await new_request.json()
+
+            self.assertEqual(
+                new_body["messages"][0]["content"],
+                "This is an rewritten system prompt.",
+            )
+            self.assertEqual(new_body["messages"][1]["content"], structured_content)
 
         import asyncio
 

--- a/tests/integration/test_content_rewriting_middleware.py
+++ b/tests/integration/test_content_rewriting_middleware.py
@@ -161,9 +161,7 @@ class TestContentRewritingMiddleware(unittest.TestCase):
             new_body = json.loads(response.body)
             self.assertEqual(
                 new_body["choices"][0]["message"]["content"],
-                [
-                    {"type": "text", "text": "This is an original reply."}
-                ],
+                [{"type": "text", "text": "This is an original reply."}],
             )
 
         import asyncio

--- a/tests/unit/core/testing/test_interfaces.py
+++ b/tests/unit/core/testing/test_interfaces.py
@@ -306,9 +306,7 @@ class TestTestStageValidator:
         # Should not raise any exception
         TestStageValidator.validate_stage_services(services)
 
-    def test_validate_stage_services_with_problematic_session_service(
-        self
-    ) -> None:
+    def test_validate_stage_services_with_problematic_session_service(self) -> None:
         """Test validation with problematic session service."""
         mock_service = AsyncMock(spec=ISessionService)
         services = {ISessionService: mock_service}

--- a/tests/unit/loop_detection/test_analyzer.py
+++ b/tests/unit/loop_detection/test_analyzer.py
@@ -139,7 +139,6 @@ def test_pattern_analyzer_total_length_excludes_noise(
     assert event.total_length == expected
 
 
-
 def test_pattern_analyzer_reset(analyzer: PatternAnalyzer) -> None:
     analyzer.analyze_chunk("some content", "some content")
     analyzer.analyze_chunk("```", "```")  # Enter code block and reset history


### PR DESCRIPTION
## Summary
- guard the content rewriting middleware so that request and response replacements only run on string payloads
- add integration tests that cover multimodal-style message content to ensure it is forwarded untouched

## Testing
- python -m pytest --override-ini addopts='' tests/integration/test_content_rewriting_middleware.py
- python -m pytest --override-ini addopts='' *(fails: missing optional pytest plugins such as pytest-asyncio, pytest-mock, respx, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e04d85ab88833386e0814f85e93bbc