### PR TITLE
Fix missing CLI capture limit arguments

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -101,6 +101,27 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Write raw LLM requests and replies to FILE (disabled if omitted)",
     )
     parser.add_argument(
+        "--capture-max-bytes",
+        dest="capture_max_bytes",
+        type=int,
+        metavar="N",
+        help="Maximum size of capture file in bytes before rotation (env: CAPTURE_MAX_BYTES)",
+    )
+    parser.add_argument(
+        "--capture-truncate-bytes",
+        dest="capture_truncate_bytes",
+        type=int,
+        metavar="N",
+        help="Truncate captures to N bytes per entry (env: CAPTURE_TRUNCATE_BYTES)",
+    )
+    parser.add_argument(
+        "--capture-max-files",
+        dest="capture_max_files",
+        type=int,
+        metavar="N",
+        help="Maximum number of capture files to retain (env: CAPTURE_MAX_FILES)",
+    )
+    parser.add_argument(
         "--capture-rotate-interval",
         dest="capture_rotate_interval_seconds",
         type=int,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -181,3 +181,27 @@ def test_cli_pytest_compression_flags() -> None:
         # but we enable it with the flag
         config_override = apply_cli_args(args_enable)
         assert config_override.session.pytest_compression_enabled is True
+
+
+def test_cli_capture_limits_arguments() -> None:
+    """Ensure CLI options for capture limits are parsed and applied."""
+    with patch("src.core.cli.load_config", return_value=AppConfig()):
+        args = parse_cli_args(
+            [
+                "--capture-max-bytes",
+                "1024",
+                "--capture-truncate-bytes",
+                "256",
+                "--capture-max-files",
+                "3",
+            ]
+        )
+
+        assert args.capture_max_bytes == 1024
+        assert args.capture_truncate_bytes == 256
+        assert args.capture_max_files == 3
+
+        config = apply_cli_args(args)
+        assert config.logging.capture_max_bytes == 1024
+        assert config.logging.capture_truncate_bytes == 256
+        assert config.logging.capture_max_files == 3


### PR DESCRIPTION
## Summary
- restore the capture size/rotation flags to the v2 CLI to match the original runner
- add a regression test to ensure the capture limit arguments are parsed and applied

## Testing
- python -m pytest -c /tmp/pytest-min.ini tests/unit/test_cli.py::test_cli_capture_limits_arguments
- python -m pytest -c /tmp/pytest-min.ini *(fails: missing optional test dependencies such as pytest-asyncio, respx, pytest-httpx, pytest-mock, and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e04da762ec8333bdfa2407359f7208