### PR TITLE
Add middleware to prevent backend request loops

### DIFF
--- a/src/connectors/anthropic.py
+++ b/src/connectors/anthropic.py
@@ -23,6 +23,7 @@ from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelop
 from src.core.interfaces.configuration_interface import IAppIdentityConfig
 from src.core.interfaces.model_bases import DomainModel, InternalDTO
 from src.core.interfaces.response_processor_interface import ProcessedResponse
+from src.core.security.loop_prevention import ensure_loop_guard_header
 from src.core.services.backend_registry import backend_registry
 from src.core.services.translation_service import TranslationService
 
@@ -169,6 +170,8 @@ class AnthropicBackend(LLMBackend):
         }
         if identity:
             request_headers.update(identity.get_resolved_headers(None))
+
+        request_headers = ensure_loop_guard_header(request_headers)
 
         if logger.isEnabledFor(logging.INFO):
             logger.info(
@@ -325,6 +328,7 @@ class AnthropicBackend(LLMBackend):
     async def _handle_non_streaming_response(
         self, url: str, payload: dict, headers: dict, original_model: str
     ) -> ResponseEnvelope:
+        headers = ensure_loop_guard_header(headers)
         try:
             if logger.isEnabledFor(logging.INFO):
                 logger.info(
@@ -360,6 +364,7 @@ class AnthropicBackend(LLMBackend):
         self, url: str, payload: dict, headers: dict, model: str
     ) -> AsyncIterator[ProcessedResponse]:
         """Handle a streaming response from Anthropic and return an async iterator of ProcessedResponse objects."""
+        headers = ensure_loop_guard_header(headers)
         request = self.client.build_request("POST", url, json=payload, headers=headers)
         try:
             response = await self.client.send(request, stream=True)
@@ -433,10 +438,12 @@ class AnthropicBackend(LLMBackend):
             )
 
         url = f"{base.rstrip('/')}/models"
-        headers = {
+        headers = ensure_loop_guard_header(
+            {
             self.auth_header_name: key_api,
             "anthropic-version": ANTHROPIC_VERSION_HEADER,
         }
+        )
         try:
             response = await self.client.get(url, headers=headers)
         except httpx.RequestError as e:

--- a/src/connectors/gemini_oauth_personal.py
+++ b/src/connectors/gemini_oauth_personal.py
@@ -102,6 +102,7 @@ from src.core.domain.responses import (
     ResponseEnvelope,
     StreamingResponseEnvelope,
 )
+from src.core.security.loop_prevention import LOOP_GUARD_HEADER, LOOP_GUARD_VALUE
 from src.core.services.backend_registry import backend_registry
 from src.core.services.translation_service import TranslationService
 
@@ -1157,6 +1158,8 @@ class GeminiOAuthPersonalConnector(GeminiBackend):
             auth_session = google.auth.transport.requests.AuthorizedSession(
                 _StaticTokenCreds(access_token)
             )
+            auth_session.headers.setdefault(LOOP_GUARD_HEADER, LOOP_GUARD_VALUE)
+            auth_session.headers.setdefault(LOOP_GUARD_HEADER, LOOP_GUARD_VALUE)
 
             # Discover project ID (required for Code Assist API)
             project_id = await self._discover_project_id(auth_session)

--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -21,6 +21,7 @@ from src.core.interfaces.response_processor_interface import (
     IResponseProcessor,
     ProcessedResponse,
 )
+from src.core.security.loop_prevention import ensure_loop_guard_header
 from src.core.services.backend_registry import backend_registry
 from src.core.services.translation_service import TranslationService
 
@@ -81,11 +82,11 @@ class OpenAIConnector(LLMBackend):
 
     def get_headers(self) -> dict[str, str]:
         if not self.api_key:
-            return {}
+            return ensure_loop_guard_header({})
         headers = {"Authorization": f"Bearer {self.api_key}"}
         if self.identity:
             headers.update(self.identity.get_resolved_headers(None))
-        return headers
+        return ensure_loop_guard_header(headers)
 
     async def initialize(self, **kwargs: Any) -> None:
         self.api_key = kwargs.get("api_key")
@@ -373,8 +374,12 @@ class OpenAIConnector(LLMBackend):
         if not headers or not headers.get("Authorization"):
             raise AuthenticationError(message="No auth credentials found")
 
+        guarded_headers = ensure_loop_guard_header(headers)
+
         try:
-            response = await self.client.post(url, json=payload, headers=headers)
+            response = await self.client.post(
+                url, json=payload, headers=guarded_headers
+            )
         except httpx.RequestError as e:
             raise ServiceUnavailableError(message=f"Could not connect to backend ({e})")
 
@@ -421,7 +426,11 @@ class OpenAIConnector(LLMBackend):
         if not headers or not headers.get("Authorization"):
             raise AuthenticationError(message="No auth credentials found")
 
-        request = self.client.build_request("POST", url, json=payload, headers=headers)
+        guarded_headers = ensure_loop_guard_header(headers)
+
+        request = self.client.build_request(
+            "POST", url, json=payload, headers=guarded_headers
+        )
         response = await self.client.send(request, stream=True)
 
         status_code = (
@@ -544,11 +553,13 @@ class OpenAIConnector(LLMBackend):
         api_base = kwargs.get("openai_url") or self.api_base_url
         url = f"{api_base.rstrip('/')}/responses"
 
+        guarded_headers = ensure_loop_guard_header(headers)
+
         if domain_request.stream:
             # Return a domain-level streaming envelope
             try:
                 content_iterator = await self._handle_streaming_response(
-                    url, payload, headers, domain_request.session_id or ""
+                    url, payload, guarded_headers, domain_request.session_id or ""
                 )
             except AuthenticationError as e:
                 raise HTTPException(status_code=401, detail=str(e))
@@ -560,7 +571,7 @@ class OpenAIConnector(LLMBackend):
         else:
             # Return a domain ResponseEnvelope for non-streaming
             return await self._handle_responses_non_streaming_response(
-                url, payload, headers, domain_request.session_id or ""
+                url, payload, guarded_headers, domain_request.session_id or ""
             )
 
     async def _handle_responses_non_streaming_response(
@@ -574,8 +585,12 @@ class OpenAIConnector(LLMBackend):
         if not headers or not headers.get("Authorization"):
             raise AuthenticationError(message="No auth credentials found")
 
+        guarded_headers = ensure_loop_guard_header(headers)
+
         try:
-            response = await self.client.post(url, json=payload, headers=headers)
+            response = await self.client.post(
+                url, json=payload, headers=guarded_headers
+            )
         except httpx.RequestError as e:
             raise ServiceUnavailableError(message=f"Could not connect to backend ({e})")
 

--- a/src/connectors/openrouter.py
+++ b/src/connectors/openrouter.py
@@ -16,6 +16,7 @@ from src.core.config.app_config import AppConfig
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.interfaces.configuration_interface import IAppIdentityConfig
 from src.core.interfaces.model_bases import DomainModel, InternalDTO
+from src.core.security.loop_prevention import ensure_loop_guard_header
 from src.core.services.backend_registry import backend_registry
 from src.core.services.translation_service import TranslationService
 
@@ -51,7 +52,7 @@ class OpenRouterBackend(OpenAIConnector):
         logger.info(
             f"OpenRouter headers: Authorization: Bearer {self.api_key[:20]}..., HTTP-Referer: {headers.get('HTTP-Referer', 'NOT_SET')}, X-Title: {headers.get('X-Title', 'NOT_SET')}"
         )
-        return headers
+        return ensure_loop_guard_header(headers)
 
     async def initialize(self, **kwargs: Any) -> None:
         """Fetch available models and cache them for later use."""

--- a/src/connectors/qwen_oauth.py
+++ b/src/connectors/qwen_oauth.py
@@ -29,6 +29,7 @@ from src.core.config.app_config import AppConfig
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.interfaces.configuration_interface import IAppIdentityConfig
 from src.core.interfaces.model_bases import DomainModel, InternalDTO
+from src.core.security.loop_prevention import ensure_loop_guard_header
 from src.core.services.backend_registry import backend_registry
 
 from .openai import OpenAIConnector
@@ -504,11 +505,13 @@ class QwenOAuthConnector(OpenAIConnector):
                 status_code=401,
                 detail="No valid Qwen OAuth access token available. Please authenticate.",
             )
-        return {
+        return ensure_loop_guard_header(
+            {
             "Authorization": f"Bearer {self._oauth_credentials['access_token']}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+        )
 
     async def _perform_health_check(self) -> bool:
         """Override parent health check to use Qwen-specific API endpoint."""

--- a/src/connectors/zai.py
+++ b/src/connectors/zai.py
@@ -12,6 +12,7 @@ from src.core.common.exceptions import AuthenticationError, ConfigurationError
 from src.core.config.app_config import AppConfig
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.interfaces.configuration_interface import IAppIdentityConfig
+from src.core.security.loop_prevention import ensure_loop_guard_header
 from src.core.services.backend_registry import backend_registry
 
 from .openai import OpenAIConnector
@@ -107,10 +108,12 @@ class ZAIConnector(OpenAIConnector):
             raise AuthenticationError(
                 message="ZAI API key is not set.", code="missing_api_key"
             )
-        return {
+        return ensure_loop_guard_header(
+            {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
+        )
 
     def get_available_models(self) -> list[str]:
         """

--- a/src/core/app/middleware/loop_prevention_middleware.py
+++ b/src/core/app/middleware/loop_prevention_middleware.py
@@ -1,0 +1,27 @@
+"""Middleware that prevents backend request loops."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+from src.core.security.loop_prevention import LOOP_GUARD_HEADER
+
+
+class LoopPreventionMiddleware(BaseHTTPMiddleware):
+    """Reject requests that originate from backend connectors."""
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if request.headers.get(LOOP_GUARD_HEADER):
+            return JSONResponse(
+                status_code=status.HTTP_508_LOOP_DETECTED,
+                content={"detail": "Request loop detected"},
+            )
+        return await call_next(request)

--- a/src/core/app/middleware_config.py
+++ b/src/core/app/middleware_config.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 from src.core.common.structlog_config import get_logger
+from src.core.app.middleware.loop_prevention_middleware import LoopPreventionMiddleware
 from src.core.security import APIKeyMiddleware, AuthMiddleware
 from src.request_middleware import CustomHeaderMiddleware
 from src.response_middleware import RetryAfterMiddleware
@@ -80,6 +81,9 @@ def configure_middleware(app: FastAPI, config: Any) -> None:
 
     # Custom header middleware
     app.add_middleware(CustomHeaderMiddleware)
+
+    # Loop prevention middleware (fast rejection path, minimal overhead)
+    app.add_middleware(LoopPreventionMiddleware)
 
     # Response retry-after middleware
     app.add_middleware(RetryAfterMiddleware)

--- a/src/core/security/__init__.py
+++ b/src/core/security/__init__.py
@@ -1,7 +1,16 @@
-"""
-Security package for authentication and authorization.
-"""
+"""Security package for authentication and authorization."""
 
+from src.core.security.loop_prevention import (
+    LOOP_GUARD_HEADER,
+    LOOP_GUARD_VALUE,
+    ensure_loop_guard_header,
+)
 from src.core.security.middleware import APIKeyMiddleware, AuthMiddleware
 
-__all__ = ["APIKeyMiddleware", "AuthMiddleware"]
+__all__ = [
+    "APIKeyMiddleware",
+    "AuthMiddleware",
+    "ensure_loop_guard_header",
+    "LOOP_GUARD_HEADER",
+    "LOOP_GUARD_VALUE",
+]

--- a/src/core/security/loop_prevention.py
+++ b/src/core/security/loop_prevention.py
@@ -1,0 +1,15 @@
+"""Utilities for preventing backend request loops."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+LOOP_GUARD_HEADER = "x-llmproxy-loop-guard"
+LOOP_GUARD_VALUE = "1"
+
+
+def ensure_loop_guard_header(headers: Mapping[str, str] | None) -> dict[str, str]:
+    """Return headers with the loop guard marker applied."""
+    result: dict[str, str] = dict(headers.items()) if headers else {}
+    result.setdefault(LOOP_GUARD_HEADER, LOOP_GUARD_VALUE)
+    return result

--- a/tests/unit/test_loop_prevention.py
+++ b/tests/unit/test_loop_prevention.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.app.middleware.loop_prevention_middleware import LoopPreventionMiddleware
+from src.core.security.loop_prevention import (
+    LOOP_GUARD_HEADER,
+    LOOP_GUARD_VALUE,
+    ensure_loop_guard_header,
+)
+
+
+def test_ensure_loop_guard_header_preserves_existing_headers() -> None:
+    source = {"Authorization": "Bearer token"}
+    guarded = ensure_loop_guard_header(source)
+    assert guarded is not source
+    assert guarded["Authorization"] == "Bearer token"
+    assert guarded[LOOP_GUARD_HEADER] == LOOP_GUARD_VALUE
+
+
+def test_loop_prevention_middleware_rejects_loop_requests() -> None:
+    app = FastAPI()
+    app.add_middleware(LoopPreventionMiddleware)
+
+    @app.get("/ping")
+    def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        response = client.get("/ping", headers={LOOP_GUARD_HEADER: LOOP_GUARD_VALUE})
+    assert response.status_code == 508
+    assert response.json()["detail"] == "Request loop detected"
+
+
+def test_loop_prevention_middleware_allows_regular_requests() -> None:
+    app = FastAPI()
+    app.add_middleware(LoopPreventionMiddleware)
+
+    @app.get("/ping")
+    def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- add a reusable loop guard header helper and expose it through the security package
- reject looped backend requests via a FastAPI middleware and wire it into the app configuration
- mark all outbound connector requests with the guard header so the middleware can break loops
- cover the helper and middleware behaviour with focused unit tests

## Testing
- `python -m pytest -o addopts="" tests/unit/test_loop_prevention.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0e2b4e7e48333b519ad9cfc9007d7