### PR TITLE
Fix tool call reactor wiring test wait strategy

### DIFF
--- a/tests/integration/test_tool_call_reactor_wiring.py
+++ b/tests/integration/test_tool_call_reactor_wiring.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 
 import pytest
 from src.core.app.application_builder import ApplicationBuilder
@@ -18,7 +18,7 @@ async def test_tool_call_reactor_handlers_are_wired_up():
 
     # Act
     app = await builder.build(config)
-    time.sleep(0.1)  # Allow time for handlers to register
+    await asyncio.sleep(0.1)  # Allow time for handlers to register
     service_provider = app.state.service_provider
     reactor_middleware = service_provider.get_required_service(
         ToolCallReactorMiddleware


### PR DESCRIPTION
## Summary
- replace blocking sleep with awaitable sleep in the tool call reactor wiring integration test to avoid unused import
- remove the unused time import now that the async sleep is used

## Testing
- python -m pytest tests/integration/test_tool_call_reactor_wiring.py

------
https://chatgpt.com/codex/tasks/task_e_68e0e1c7514083338aabd6981e30297d