### PR TITLE
Fix Retry-After header for rate limit errors

### DIFF
--- a/tests/unit/core/adapters/test_exception_adapters.py
+++ b/tests/unit/core/adapters/test_exception_adapters.py
@@ -63,12 +63,16 @@ class TestCreateExceptionHandler:
 
     @pytest.mark.asyncio
     async def test_handle_rate_limit_error_with_reset(
-        self, mock_request: Mock, exception_handler
+        self, mock_request: Mock, exception_handler, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test handling RateLimitExceededError with reset time."""
+        monkeypatch.setattr(
+            "src.core.adapters.exception_adapters.time.time",
+            lambda: 100.0,
+        )
         error = RateLimitExceededError(
             message="Rate limit exceeded",
-            reset_at=60,
+            reset_at=160.0,
         )
 
         response = await exception_handler(mock_request, error)


### PR DESCRIPTION
## Summary
- normalize Retry-After header computation for rate limit exceptions in the shared FastAPI adapters
- propagate the Retry-After header when mapping domain rate limit errors to HTTP exceptions
- update the unit tests to exercise the corrected Retry-After behaviour

## Testing
- ./.venv/Scripts/python.exe -m pytest -o addopts="" tests/unit/test_transport_adapters.py::TestExceptionAdapters::test_map_domain_exception_to_http_exception


------
https://chatgpt.com/codex/tasks/task_e_68e10552a4408333b68518ad708f4afd