### PR TITLE
Fix models endpoint to respect injected configuration

### DIFF
--- a/tests/unit/test_models_endpoint.py
+++ b/tests/unit/test_models_endpoint.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi.testclient import TestClient
 from src.core.app.test_builder import build_test_app
 
@@ -70,3 +72,57 @@ def test_model_listing_includes_oauth_backends(monkeypatch) -> None:
     model_ids = {model["id"] for model in result["data"]}
     assert "gemini-cli-oauth-personal:gemini-2.5-pro" in model_ids
     assert created_backends == ["gemini-cli-oauth-personal"]
+
+
+def test_list_models_uses_injected_config(monkeypatch) -> None:
+    import asyncio
+    from types import SimpleNamespace
+
+    from src.core.app.controllers import models_controller
+    from src.core.app.controllers.models_controller import _list_models_impl
+    from src.core.interfaces.configuration_interface import IConfig
+
+    class DummyConfig(IConfig):
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {}
+            self.backends = SimpleNamespace(
+                functional_backends=["custom"],
+                custom=SimpleNamespace(api_key="super-secret"),
+            )
+
+        def get(self, key: str, default: Any = None) -> Any:
+            return self._store.get(key, default)
+
+        def set(self, key: str, value: Any) -> None:
+            self._store[key] = value
+
+    dummy_config = DummyConfig()
+
+    monkeypatch.setattr(
+        models_controller.backend_registry,
+        "get_registered_backends",
+        lambda: ["custom"],
+    )
+
+    created_backends: list[tuple[str, DummyConfig]] = []
+
+    class DummyBackend:
+        async def get_available_models(self) -> list[str]:
+            return ["my-special-model"]
+
+    class DummyFactory:
+        def create_backend(self, backend_type: str, config_obj: DummyConfig) -> DummyBackend:
+            created_backends.append((backend_type, config_obj))
+            return DummyBackend()
+
+    result = asyncio.run(
+        _list_models_impl(
+            backend_service=object(),
+            config=dummy_config,
+            backend_factory=DummyFactory(),
+        )
+    )
+
+    model_ids = {model["id"] for model in result["data"]}
+    assert "custom:my-special-model" in model_ids
+    assert created_backends == [("custom", dummy_config)]


### PR DESCRIPTION
## Summary
- keep the injected configuration when discovering models so custom backend settings remain available
- add a regression test covering a non-AppConfig implementation to ensure discovery uses the provided config

## Testing
- python -m pytest -o addopts='' tests/unit/test_models_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e104e6c1c88333beb52672b53217a0