### PR TITLE
Handle backend errors during validation

### DIFF
--- a/src/core/services/backend_service.py
+++ b/src/core/services/backend_service.py
@@ -512,7 +512,7 @@ class BackendService(IBackendService):
                 return True, None
 
             return False, f"Model {model} not available on backend {backend}"
-        except (TypeError, ValueError, AttributeError) as e:
+        except (BackendError, TypeError, ValueError, AttributeError) as e:
             logger.warning(
                 f"Backend validation failed for {backend}: {e!s}", exc_info=True
             )

--- a/tests/unit/core/test_backend_service_enhanced.py
+++ b/tests/unit/core/test_backend_service_enhanced.py
@@ -616,6 +616,27 @@ class TestBackendServiceValidation:
             assert "Backend validation failed" in error
             assert "Backend error" in error
 
+    @pytest.mark.asyncio
+    async def test_validate_backend_and_model_backend_error_object(
+        self, backend_service
+    ):
+        """Test validating when backend creation raises BackendError."""
+        backend_error = BackendError(message="boom", backend_name="test")
+
+        with patch.object(
+            backend_service,
+            "_get_or_create_backend",
+            side_effect=backend_error,
+        ):
+            valid, error = await backend_service.validate_backend_and_model(
+                BackendType.OPENAI, "model"
+            )
+
+        assert valid is False
+        assert error is not None
+        assert "Backend validation failed" in error
+        assert "boom" in error
+
 
 class TestBackendServiceFailover:
     """Tests for the BackendService's failover capabilities."""


### PR DESCRIPTION
## Summary
- ensure backend validation gracefully handles BackendError raised during backend creation
- add regression test verifying validate_backend_and_model returns a failure tuple when BackendError occurs

## Testing
- python -m pytest tests/unit/core/test_backend_service_enhanced.py -k test_validate_backend_and_model
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e104d0d17c833391a7029052c21949