### PR TITLE
Fix backend config iteration for dict backends

### DIFF
--- a/src/core/services/backend_config_provider.py
+++ b/src/core/services/backend_config_provider.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 from src.core.config.app_config import AppConfig, BackendConfig
 from src.core.domain.chat import ChatRequest
@@ -113,11 +113,19 @@ class BackendConfigProvider(IBackendConfigProvider):
         # Include both registered backends and any backends explicitly configured
         registered = set(backend_registry.get_registered_backends())
 
+        backends_config = self._app_config.backends
+
         # Add any backends that are explicitly configured
         try:
+            # Handle dictionary-style configurations (e.g. when loading from YAML)
+            if isinstance(backends_config, Mapping):
+                for key in backends_config.keys():
+                    if isinstance(key, str) and key != "default_backend":
+                        registered.add(key)
+
             # Check if backends has __dict__ attribute (BackendSettings does)
-            if hasattr(self._app_config.backends, "__dict__"):
-                for key in self._app_config.backends.__dict__:
+            elif hasattr(backends_config, "__dict__"):
+                for key in backends_config.__dict__:
                     # Skip default_backend and non-backend attributes
                     if key != "default_backend" and not key.startswith("_"):
                         registered.add(key)
@@ -125,7 +133,7 @@ class BackendConfigProvider(IBackendConfigProvider):
             import logging
 
             logging.getLogger(__name__).debug(
-                "iter_backend_names failed while inspecting __dict__: %s",
+                "iter_backend_names failed while inspecting backend configuration: %s",
                 e,
                 exc_info=True,
             )

--- a/tests/unit/core/test_backend_config_provider.py
+++ b/tests/unit/core/test_backend_config_provider.py
@@ -97,6 +97,22 @@ class TestBackendConfigProvider:
         assert "test_backend1" in backend_names
         assert "test_backend2" in backend_names
 
+    def test_iter_backend_names_includes_dict_backends(self) -> None:
+        """Configured dictionary backends should be included in iteration."""
+        # Arrange
+        app_config = AppConfig()
+        app_config.backends = {
+            "custom-backend": {"api_key": ["test-key"]},
+            "default_backend": "openai",
+        }  # type: ignore[assignment]
+        provider = BackendConfigProvider(app_config)
+
+        # Act
+        backend_names = provider.iter_backend_names()
+
+        # Assert
+        assert "custom-backend" in backend_names
+
     def test_get_default_backend(self) -> None:
         """Test getting the default backend."""
         # Arrange


### PR DESCRIPTION
## Summary
- update `BackendConfigProvider.iter_backend_names` to include keys from dictionary-style backend configs
- add a regression test ensuring dictionary-configured backends are surfaced during iteration

## Testing
- pytest -o addopts= tests/unit/core/test_backend_config_provider.py -q
- pytest -o addopts= *(fails: missing optional dev dependencies such as pytest-asyncio, pytest-httpx, respx, pytest-mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e104d0d17c833391a7029052c21949