### PR TITLE
Fix module docstring syntax in performance tracker

### DIFF
--- a/src/performance_tracker.py
+++ b/src/performance_tracker.py
@@ -1,6 +1,4 @@
-"""
-Performance tracking system for measuring execution times across the full request handling cycle.
-"""
+"""Performance tracking system for measuring execution times across the full request handling cycle."""
 
 import logging
 import time


### PR DESCRIPTION
## Summary
- correct the performance tracker module docstring so the file parses correctly

## Testing
- ./.venv/Scripts/python.exe -m pytest *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68e104a4c92883339c498f2a5c9f5566