### PR TITLE
Fix runtime isinstance union bug in OpenAI connector

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -285,7 +285,7 @@ class OpenAIConnector(LLMBackend):
                     return getattr(message, key, None)
 
                 def _normalize_content(value: Any) -> Any:
-                    if isinstance(value, list | tuple):
+                    if isinstance(value, (list, tuple)):
                         normalized_parts: list[Any] = []
                         for part in value:
                             if hasattr(part, "model_dump") and callable(


### PR DESCRIPTION
## Summary
- replace the invalid isinstance check that used the Python 3.10 union operator so OpenAI payload normalization no longer raises at runtime

## Testing
- PYTHONPATH=. pytest -c pytest-noaddopts.ini -p tests.k_asyncio_plugin tests/unit/connectors/test_precision_payload_mapping.py -k openai_payload_contains_temperature_and_top_p
- PYTHONPATH=. pytest -c /tmp/pytest-noaddopts.ini -p tests.k_asyncio_plugin *(fails: missing optional dev dependencies such as pytest-asyncio, respx, pytest_httpx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e104a4c92883339c498f2a5c9f5566