### PR TITLE
Fix whitespace handling in ProjectCommand

### DIFF
--- a/src/core/domain/commands/project_command.py
+++ b/src/core/domain/commands/project_command.py
@@ -1,5 +1,4 @@
-"""
-Project command implementation.
+"""Project command implementation.
 
 This module provides a domain command for setting the project name.
 """
@@ -55,7 +54,22 @@ class ProjectCommand(StatelessCommandBase, BaseCommand):
         Returns:
             CommandResult indicating success or failure
         """
-        project_name = args.get("name")
+        raw_project_value = args.get("name")
+
+        if raw_project_value is None:
+            return CommandResult(
+                success=False, message="Project name must be specified", name=self.name
+            )
+
+        if isinstance(raw_project_value, str):
+            project_name = raw_project_value.strip()
+        else:
+            logger.debug(
+                "Coercing non-string project name argument to string",
+                extra={"type": type(raw_project_value)},
+            )
+            project_name = str(raw_project_value).strip()
+
         if not project_name:
             return CommandResult(
                 success=False, message="Project name must be specified", name=self.name

--- a/tests/unit/commands/test_unit_project_command.py
+++ b/tests/unit/commands/test_unit_project_command.py
@@ -1,0 +1,42 @@
+"""Unit tests for ProjectCommand."""
+
+from __future__ import annotations
+
+import pytest
+from src.core.domain.commands.project_command import ProjectCommand
+from src.core.domain.session import SessionState
+
+
+class _Session:
+    """Lightweight session stub for testing."""
+
+    def __init__(self) -> None:
+        self.state = SessionState()
+
+
+@pytest.mark.asyncio
+async def test_project_command_rejects_whitespace_name() -> None:
+    """Project command should reject whitespace-only project names."""
+
+    command = ProjectCommand()
+    session = _Session()
+
+    result = await command.execute({"name": "   "}, session)
+
+    assert result.success is False
+    assert result.message == "Project name must be specified"
+
+
+@pytest.mark.asyncio
+async def test_project_command_trims_project_name() -> None:
+    """Project command should trim and persist the provided project name."""
+
+    command = ProjectCommand()
+    session = _Session()
+
+    result = await command.execute({"name": "  demo-project  "}, session)
+
+    assert result.success is True
+    assert result.data == {"project": "demo-project"}
+    assert result.new_state is not None
+    assert result.new_state.project == "demo-project"


### PR DESCRIPTION
## Summary
- trim and validate project names in `ProjectCommand` before updating session state
- log when non-string project arguments are coerced to strings
- add unit coverage for whitespace rejection and trimming behavior

## Testing
- python -m pytest tests/unit/commands/test_unit_project_command.py
- python -m pytest *(fails: numerous pre-existing failures including test_test_quality and DI-dependent command tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e104a4c92883339c498f2a5c9f5566