### PR TITLE
Fix JSON repair middleware metrics for best-effort failures

### DIFF
--- a/src/core/app/middleware/json_repair_middleware.py
+++ b/src/core/app/middleware/json_repair_middleware.py
@@ -87,7 +87,11 @@ class JsonRepairMiddleware(IResponseMiddleware):
                         else "json_repair.non_streaming.best_effort_fail"
                     )
             except Exception:
-                metrics.inc("json_repair.non_streaming.strict_fail")
+                metrics.inc(
+                    "json_repair.non_streaming.strict_fail"
+                    if strict_effective
+                    else "json_repair.non_streaming.best_effort_fail"
+                )
                 raise
             if repaired_json:
                 if logger.isEnabledFor(logging.INFO):

--- a/tests/unit/core/services/test_json_repair_middleware.py
+++ b/tests/unit/core/services/test_json_repair_middleware.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from src.core.app.middleware.json_repair_middleware import JsonRepairMiddleware
 from src.core.config.app_config import AppConfig, SessionConfig
@@ -29,6 +31,14 @@ def json_repair_middleware(
     return JsonRepairMiddleware(config, json_repair_service)
 
 
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
 async def test_process_response_valid(
     json_repair_middleware: JsonRepairMiddleware,
 ) -> None:
@@ -49,3 +59,35 @@ async def test_process_response_invalid(
     )
     assert processed_response.content == '{"a": 1}'
     assert processed_response.metadata.get("repaired")
+
+
+async def test_process_response_best_effort_failure_metrics(
+    json_repair_middleware: JsonRepairMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric_calls: list[str] = []
+
+    def fake_inc(metric_name: str) -> None:
+        metric_calls.append(metric_name)
+
+    monkeypatch.setattr(
+        "src.core.app.middleware.json_repair_middleware.metrics.inc",
+        fake_inc,
+    )
+
+    def fail_repair(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("repair boom")
+
+    monkeypatch.setattr(
+        json_repair_middleware.json_repair_service,
+        "repair_and_validate_json",
+        fail_repair,
+    )
+
+    response = ProcessedResponse(content="{'broken': true}")
+
+    with pytest.raises(RuntimeError):
+        await json_repair_middleware.process(response, "session_id", {})
+
+    assert metric_calls
+    assert metric_calls[-1] == "json_repair.non_streaming.best_effort_fail"


### PR DESCRIPTION
## Summary
- ensure JsonRepairMiddleware logs best-effort failure metrics when JSON repair raises
- add coverage for best-effort failure handling and pin async backend to asyncio for the middleware tests

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_json_repair_middleware.py
- python -m pytest -o addopts='' *(fails: missing pytest_asyncio, respx, pytest_httpx, pytest_mock dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1048db8f48333adf3963b032f50be