### PR TITLE
Fix loop detection enabled env flag parsing

### DIFF
--- a/src/loop_detection/config.py
+++ b/src/loop_detection/config.py
@@ -200,12 +200,7 @@ class LoopDetectionConfig(InternalDTO):
         config = cls()
 
         if "LOOP_DETECTION_ENABLED" in env_dict:
-            config.enabled = env_dict["LOOP_DETECTION_ENABLED"].lower() in (
-                "true",
-                "1",
-                "yes",
-                "on",
-            )
+            config.enabled = _coerce_to_bool(env_dict["LOOP_DETECTION_ENABLED"])
 
         if "LOOP_DETECTION_BUFFER_SIZE" in env_dict:
             config.buffer_size = int(env_dict["LOOP_DETECTION_BUFFER_SIZE"])

--- a/tests/unit/loop_detection/test_config_parsing.py
+++ b/tests/unit/loop_detection/test_config_parsing.py
@@ -23,3 +23,16 @@ class TestLoopDetectionConfigParsing:
 
         config_one = LoopDetectionConfig.from_dict({"enabled": 1})
         assert config_one.enabled is True
+
+    def test_from_env_vars_handles_whitespace_booleans(self) -> None:
+        """Environment flags should ignore surrounding whitespace."""
+
+        config_true = LoopDetectionConfig.from_env_vars(
+            {"LOOP_DETECTION_ENABLED": "  true  "}
+        )
+        assert config_true.enabled is True
+
+        config_false = LoopDetectionConfig.from_env_vars(
+            {"LOOP_DETECTION_ENABLED": "  off  "}
+        )
+        assert config_false.enabled is False


### PR DESCRIPTION
## Summary
- use the shared boolean coercion helper when parsing LOOP_DETECTION_ENABLED from environment variables
- add a regression test ensuring whitespace around the env flag is handled correctly

## Testing
- python -m pytest -o addopts="" tests/unit/loop_detection/test_config_parsing.py
- python -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e1047ac8dc8333997b66e0dae90377