### PR TITLE
Fix token counter fallback for empty text

### DIFF
--- a/src/core/utils/token_count.py
+++ b/src/core/utils/token_count.py
@@ -30,6 +30,8 @@ def count_tokens(text: str, model: str | None = None) -> int:
         return len(enc.encode(text))
     except Exception as e:
         logger.debug("Token counting fallback engaged: %s", e)
+        if not text:
+            return 0
         return max(1, len(text) // 4)
 
 

--- a/tests/unit/utils/test_token_count.py
+++ b/tests/unit/utils/test_token_count.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+
+@pytest.fixture(autouse=False)
+def disable_tiktoken_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def _raise_for_tiktoken(
+        name: str,
+        globals_: dict | None = None,
+        locals_: dict | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "tiktoken":
+            raise ModuleNotFoundError("No module named 'tiktoken'")
+        return original_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _raise_for_tiktoken)
+
+
+def test_count_tokens_returns_zero_for_empty_text_when_tiktoken_missing(
+    disable_tiktoken_import: None,
+) -> None:
+    from src.core.utils.token_count import count_tokens
+
+    assert count_tokens("") == 0


### PR DESCRIPTION
## Summary
- ensure the token counting fallback returns zero when the input text is empty
- add a regression test that simulates the absence of tiktoken to cover the fallback path

## Testing
- pytest tests/unit/utils/test_token_count.py -q -o addopts=""
- pytest -q -o addopts="" *(fails: missing optional test dependencies such as pytest-asyncio, respx, hypothesis, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e1043362f88333af179558701ad904