### PR TITLE
Fix overhead logging when no phase timings exist

### DIFF
--- a/src/performance_tracker.py
+++ b/src/performance_tracker.py
@@ -95,9 +95,10 @@ class PerformanceMetrics(InternalDTO):
             ]
             if t is not None
         )
-        if accounted_time and self.total_time:
+        if self.total_time is not None:
             overhead = self.total_time - accounted_time
-            summary_parts.append(f"overhead={overhead:.3f}s")
+            if overhead > 0:
+                summary_parts.append(f"overhead={overhead:.3f}s")
 
         if logger.isEnabledFor(logging.INFO):
             logger.info(" | ".join(summary_parts))

--- a/tests/unit/test_performance_tracker.py
+++ b/tests/unit/test_performance_tracker.py
@@ -55,6 +55,25 @@ def test_log_summary_includes_breakdown_and_overhead(monkeypatch, caplog):
     assert "overhead=0.800s" in message
 
 
+def test_log_summary_reports_overhead_without_phase_timings(monkeypatch, caplog):
+    import time as original_time
+
+    time_values = _time_sequence(51.0, 52.0)
+    monkeypatch.setattr(performance_tracker.time, "time", time_values)
+    monkeypatch.setattr(original_time, "time", time_values)
+
+    metrics = PerformanceMetrics(request_start=50.0)
+
+    caplog.set_level(logging.INFO)
+    metrics.log_summary()
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].message
+    assert "total=1.000s" in message
+    assert "breakdown=[" not in message
+    assert "overhead=1.000s" in message
+
+
 def test_track_request_performance_finalizes(monkeypatch):
     calls: list[PerformanceMetrics] = []
 


### PR DESCRIPTION
## Summary
- ensure performance tracker reports overhead even when no phase durations were captured
- add regression test covering overhead logging without phase timings

## Testing
- python -m pytest --override-ini addopts= tests/unit/test_performance_tracker.py
- python -m pytest --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e1043362f88333af179558701ad904