### PR TITLE
Fix content filter to handle dict responses

### DIFF
--- a/tests/unit/core/services/test_response_middleware.py
+++ b/tests/unit/core/services/test_response_middleware.py
@@ -1,5 +1,6 @@
 """Tests for response middleware functionality."""
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -95,6 +96,21 @@ class TestContentFilterMiddleware:
         result = await middleware.process(response, "session123", {})
 
         assert result == response
+
+    def test_process_handles_dictionary_response(self, middleware):
+        """Middleware should support plain dictionary responses."""
+        response = {
+            "content": "I'll help you with that. Sanitized answer.",
+            "usage": {"prompt_tokens": 1},
+            "metadata": {"source": "test"},
+        }
+
+        result = asyncio.run(middleware.process(response, "session123", {}))
+
+        assert result is not response
+        assert result["content"] == "Sanitized answer."
+        assert result["usage"] == response["usage"]
+        assert result["metadata"] == response["metadata"]
 
 
 class TestLoopDetectionMiddleware:


### PR DESCRIPTION
## Summary
- update ContentFilterMiddleware to gracefully handle dict responses and preserve metadata
- add a regression test covering dictionary responses to prevent crashes

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/test_response_middleware.py -k dictionary_response
- python -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e1043362f88333af179558701ad904