### PR TITLE
Fix Anthropic text normalization for streaming responses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,34 @@ from src.core.interfaces.backend_service_interface import IBackendService
 from src.core.interfaces.session_service_interface import ISessionService
 
 
+def pytest_load_initial_conftests(
+    args: list[str], early_config: pytest.Config, parser: pytest.Parser
+) -> None:
+    """Strip xdist-specific CLI options that aren't available in this environment."""
+
+    ignored_prefixes = ("--dist", "--max-worker-restart")
+    cleaned_args: list[str] = []
+    skip_next = False
+
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+
+        if arg == "-n":
+            skip_next = True
+            continue
+
+        if any(arg.startswith(prefix) for prefix in ignored_prefixes):
+            if "=" not in arg:
+                skip_next = True
+            continue
+
+        cleaned_args.append(arg)
+
+    args[:] = cleaned_args
+
+
 # Provide env fixtures used by config tests
 @pytest.fixture
 def mock_env_vars(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- normalize OpenAI list-based content payloads before building Anthropic responses and stream events
- extend Anthropic converter unit tests to cover list-based streaming chunks
- strip unsupported pytest-xdist options during test invocation so the suite can run without optional plugins

## Testing
- pytest -o addopts='' tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
- pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e10416c5c08333867476cd711b6441