### PR TITLE
Fix Gemini converter tool call handling

### DIFF
--- a/src/gemini_converters.py
+++ b/src/gemini_converters.py
@@ -158,13 +158,19 @@ def openai_to_gemini_response(openai_response: ChatResponse) -> GenerateContentR
         content = None
 
         if choice.message:
-            # Properly map OpenAI tool_calls to Gemini functionCall part
+            parts: list[Part] = []
+
+            # Properly map OpenAI tool_calls to Gemini functionCall parts
             if choice.message.tool_calls:
-                part = _tool_call_to_function_call(choice.message.tool_calls[0])
-                content = Content(parts=[part], role="model")
-            elif choice.message.content:
-                part = Part(text=choice.message.content)  # type: ignore[call-arg]
-                content = Content(parts=[part], role="model")
+                for tool_call in choice.message.tool_calls:
+                    parts.append(_tool_call_to_function_call(tool_call))
+
+            # Include any assistant message content if present
+            if choice.message.content:
+                parts.append(Part(text=choice.message.content))  # type: ignore[call-arg]
+
+            if parts:
+                content = Content(parts=parts, role="model")
 
         # Map finish reason
         finish_reason = None

--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -5,10 +5,18 @@ Tests the conversion logic between Gemini and OpenAI formats.
 
 import json
 
-from src.core.domain.chat import ChatMessage
+from src.core.domain.chat import (
+    ChatCompletionChoice,
+    ChatCompletionChoiceMessage,
+    ChatMessage,
+    ChatResponse,
+    FunctionCall,
+    ToolCall,
+)
 from src.gemini_converters import (
     gemini_to_openai_messages,
     openai_to_gemini_contents,
+    openai_to_gemini_response,
     openai_to_gemini_stream_chunk,
 )
 from src.gemini_models import (
@@ -114,3 +122,42 @@ class TestMessageConversion:
         data = json.loads(payload)
 
         assert data["candidates"][0]["content"]["parts"][0]["text"] == "Hello"
+
+    def test_openai_to_gemini_response_multiple_tool_calls(self) -> None:
+        """Tool calls should be preserved when multiple are present."""
+        message = ChatCompletionChoiceMessage(
+            role="assistant",
+            tool_calls=[
+                ToolCall(
+                    id="call_1",
+                    function=FunctionCall(name="first", arguments="{\"a\": 1}"),
+                ),
+                ToolCall(
+                    id="call_2",
+                    function=FunctionCall(name="second", arguments="{\"b\": 2}"),
+                ),
+            ],
+        )
+        response = ChatResponse(
+            id="resp_1",
+            created=123,
+            model="gpt-test",
+            choices=[
+                ChatCompletionChoice(index=0, message=message, finish_reason="tool_calls"),
+            ],
+        )
+
+        gemini_response = openai_to_gemini_response(response)
+
+        assert gemini_response.candidates is not None
+        candidate = gemini_response.candidates[0]
+        assert candidate.content is not None
+        assert candidate.content.parts is not None
+        assert len(candidate.content.parts) == 2
+        for part, expected_name in zip(
+            candidate.content.parts,
+            ["first", "second"],
+            strict=False,
+        ):
+            assert part.function_call is not None
+            assert part.function_call["name"] == expected_name


### PR DESCRIPTION
## Summary
- ensure Gemini response conversion preserves every tool call emitted by OpenAI responses
- add regression coverage for multi-tool-call conversions

## Testing
- `./.venv/Scripts/python.exe -m pytest -o addopts="" tests/unit/test_gemini_converters.py`
- `./.venv/Scripts/python.exe -m pytest -o addopts=""` *(fails: missing optional test dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1045c7e30833395ba5b3fecdfaef7