### PR TITLE
Fix Gemini model extraction with query strings

### DIFF
--- a/src/gemini_converters.py
+++ b/src/gemini_converters.py
@@ -384,8 +384,10 @@ def extract_model_from_gemini_path(path: str) -> str:
     # Path format: /v1beta/models/{model}:generateContent or /v1beta/models/{model}:streamGenerateContent
     if "/models/" in path:
         # Extract the part between /models/ and the next :
-        parts = path.split("/models/")[1]
-        model = parts.split(":")[0]
+        parts = path.split("/models/", 1)[1]
+        model_section = parts.split(":", 1)[0]
+        # Strip query parameters or fragments appended to the model name
+        model = model_section.split("?", 1)[0].split("#", 1)[0]
         return model
     return "gemini-pro"  # Default fallback
 

--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -102,6 +102,16 @@ class TestMessageConversion:
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello!"
 
+    def test_extract_model_from_path_with_query_string(self) -> None:
+        """Model extraction should ignore query parameters."""
+        from src.gemini_converters import extract_model_from_gemini_path
+
+        path = "/v1beta/models/gemini-1.5-pro-latest:generateContent?key=secret"
+
+        model = extract_model_from_gemini_path(path)
+
+        assert model == "gemini-1.5-pro-latest"
+
     def test_openai_stream_chunk_with_structured_content(self) -> None:
         """Ensure streaming conversion handles list-based delta content."""
         chunk = (


### PR DESCRIPTION
## Summary
- strip query strings and fragments when extracting model names from Gemini API paths
- add regression coverage ensuring extract_model_from_gemini_path ignores query parameters

## Testing
- ./.venv/Scripts/python.exe -m pytest -c pytest.no_addopts.ini tests/unit/test_gemini_converters.py::TestMessageConversion::test_extract_model_from_path_with_query_string
- ./.venv/Scripts/python.exe -m pytest -c pytest.no_addopts.ini *(fails: missing optional dev dependencies such as pytest_asyncio, pytest_httpx, respx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68e1045c7e30833395ba5b3fecdfaef7