### PR TITLE
Add coverage tests for loop detection command registry

### DIFF
--- a/src/core/domain/commands/loop_detection_commands/__init__.py
+++ b/src/core/domain/commands/loop_detection_commands/__init__.py
@@ -31,7 +31,7 @@ def get_loop_detection_command(name: str) -> type[Any]:
         raise ValueError(f"Unknown loop detection command: {name}") from exc
 
 
-def get_loop_detection_commands() -> Mapping[str, type[Any]]:
+def get_loop_detection_commands() -> dict[str, type[Any]]:
     """Return a copy of the registered loop detection commands."""
 
     return dict(_LOOP_DETECTION_COMMANDS)

--- a/tests/unit/core/domain/test_loop_detection_commands_registry.py
+++ b/tests/unit/core/domain/test_loop_detection_commands_registry.py
@@ -43,6 +43,4 @@ def test_get_loop_detection_commands_returns_isolated_copy() -> None:
     commands["LoopDetectionCommand"] = object
 
     refreshed_commands = loop_detection_commands.get_loop_detection_commands()
-    assert refreshed_commands["LoopDetectionCommand"] is getattr(
-        loop_detection_commands, "LoopDetectionCommand"
-    )
+    assert refreshed_commands["LoopDetectionCommand"] is loop_detection_commands.LoopDetectionCommand

--- a/tests/unit/core/domain/test_loop_detection_commands_registry.py
+++ b/tests/unit/core/domain/test_loop_detection_commands_registry.py
@@ -1,0 +1,48 @@
+"""Tests for the loop detection command registry helpers."""
+
+from __future__ import annotations
+
+from importlib import reload
+
+import pytest
+
+import src.core.domain.commands.loop_detection_commands as loop_detection_commands
+
+
+@pytest.fixture(autouse=True)
+def reload_commands_module():
+    """Ensure the registry module is freshly imported for each test."""
+
+    yield
+    reload(loop_detection_commands)
+
+
+def test_get_loop_detection_command_returns_registered_class() -> None:
+    """Every exported command name should resolve to the exported class."""
+
+    for command_name in loop_detection_commands.__all__:
+        command_class = loop_detection_commands.get_loop_detection_command(command_name)
+        exported_class = getattr(loop_detection_commands, command_name)
+        assert command_class is exported_class
+
+
+def test_get_loop_detection_command_raises_for_unknown_name() -> None:
+    """The registry should raise ``ValueError`` for unknown command names."""
+
+    with pytest.raises(ValueError, match="^Unknown loop detection command: missing$"):
+        loop_detection_commands.get_loop_detection_command("missing")
+
+
+def test_get_loop_detection_commands_returns_isolated_copy() -> None:
+    """Mutating the returned mapping must not affect the registry's state."""
+
+    commands = loop_detection_commands.get_loop_detection_commands()
+
+    assert set(commands) == set(loop_detection_commands.__all__)
+
+    commands["LoopDetectionCommand"] = object
+
+    refreshed_commands = loop_detection_commands.get_loop_detection_commands()
+    assert refreshed_commands["LoopDetectionCommand"] is getattr(
+        loop_detection_commands, "LoopDetectionCommand"
+    )


### PR DESCRIPTION
## Summary
- add focused unit tests that exercise the loop detection command registry helpers
- verify that exported command names resolve to the registered classes and that returned mappings stay isolated from mutations

## Testing
- python - <<'PY'
import pytest
import tempfile
import os

with tempfile.NamedTemporaryFile('w', suffix='.ini', delete=False) as tmp:
    tmp.write('[pytest]\n')
    config_path = tmp.name

try:
    pytest.main(['-c', config_path, 'tests/unit/core/domain/test_loop_detection_commands_registry.py'])
finally:
    os.remove(config_path)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e42f7f6d588333ab9c767a0d352be4