### PR TITLE
Trim trailing newline from rewrite search patterns

### DIFF
--- a/src/core/services/content_rewriter_service.py
+++ b/src/core/services/content_rewriter_service.py
@@ -77,6 +77,11 @@ class ContentRewriterService:
             with open(search_file, encoding="utf-8") as f:
                 search_text = f.read()
 
+            # Trim trailing newlines that editors often append automatically.
+            # Without this, the newline becomes part of the search string and
+            # prevents matches in the request/response payloads.
+            search_text = search_text.rstrip("\r\n")
+
             if len(search_text) < 8:
                 logger.warning(
                     f"Search pattern in {search_file} is too short. "

--- a/tests/unit/core/services/test_content_rewriter_service.py
+++ b/tests/unit/core/services/test_content_rewriter_service.py
@@ -190,6 +190,44 @@ class TestContentRewriterService(unittest.TestCase):
         rewritten = service.rewrite_reply(reply)
         self.assertEqual(rewritten, "This is an rewritten reply.")
 
+    def test_rewrite_prompt_ignores_trailing_newline_in_search_rule(self):
+        """Trailing newlines in SEARCH.txt should not prevent matches."""
+
+        os.makedirs(
+            os.path.join(self.test_config_dir, "prompts", "system", "003"),
+            exist_ok=True,
+        )
+        with open(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "system",
+                "003",
+                "SEARCH.txt",
+            ),
+            "w",
+        ) as f:
+            f.write("newline sensitive\n")
+        with open(
+            os.path.join(
+                self.test_config_dir,
+                "prompts",
+                "system",
+                "003",
+                "REPLACE.txt",
+            ),
+            "w",
+        ) as f:
+            f.write("newline resilient")
+
+        service = ContentRewriterService(config_path=self.test_config_dir)
+
+        rewritten = service.rewrite_prompt(
+            "This is newline sensitive content.", "system"
+        )
+
+        self.assertEqual(rewritten, "This is newline resilient content.")
+
     def test_ignore_rule_with_short_search_pattern(self):
         """Verify that a rule with a short search pattern is ignored."""
         # Create a rule with a search pattern shorter than 8 characters


### PR DESCRIPTION
## Summary
- trim trailing newlines from replacement rule search text so editor-added terminators do not break matches
- add a unit test covering SEARCH.txt entries that end with a newline to guard against regressions

## Testing
- python -m pytest --override-ini addopts='' tests/unit/core/services/test_content_rewriter_service.py
- python -m pytest --override-ini addopts='' *(fails: missing optional dev dependencies such as pytest-asyncio/respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e42fde406883338887e89312506670