### PR TITLE
Fix CLI log file override behavior

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -414,8 +414,8 @@ def apply_cli_args(args: argparse.Namespace) -> AppConfig:
     # Logging configuration
     if args.log_file is not None:
         cfg.logging.log_file = args.log_file
-    else:
-        # Set default log file if none specified
+    elif not cfg.logging.log_file:
+        # Set default log file if none specified by CLI or config
         from pathlib import Path
 
         default_log_file = "logs/proxy.log"

--- a/tests/unit/test_cli_di.py
+++ b/tests/unit/test_cli_di.py
@@ -6,11 +6,12 @@ import pytest
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
+
 from fastapi.testclient import TestClient
 from src.constants import DEFAULT_COMMAND_PREFIX
 from src.core.app.test_builder import build_test_app as app_main_build_app
-from src.core.config.app_config import AppConfig
 from src.core.cli import apply_cli_args, main, parse_cli_args
+from src.core.config.app_config import AppConfig
 from src.core.interfaces.session_service_interface import ISessionService
 
 from tests.utils.test_di_utils import get_required_service_from_app

--- a/tests/unit/test_cli_di.py
+++ b/tests/unit/test_cli_di.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.filterwarnings(
 from fastapi.testclient import TestClient
 from src.constants import DEFAULT_COMMAND_PREFIX
 from src.core.app.test_builder import build_test_app as app_main_build_app
+from src.core.config.app_config import AppConfig
 from src.core.cli import apply_cli_args, main, parse_cli_args
 from src.core.interfaces.session_service_interface import ISessionService
 
@@ -101,6 +102,18 @@ from pathlib import Path
 def test_cli_log_argument(tmp_path: Path) -> None:
     args = parse_cli_args(["--log", str(tmp_path / "out.log")])
     assert args.log_file == str(tmp_path / "out.log")
+
+
+def test_apply_cli_args_preserves_config_log_file(tmp_path: Path) -> None:
+    config = AppConfig()
+    existing_log = tmp_path / "configured.log"
+    config.logging.log_file = str(existing_log)
+
+    with patch("src.core.cli.load_config", return_value=config):
+        args = parse_cli_args([])
+        applied = apply_cli_args(args)
+
+    assert applied.logging.log_file == str(existing_log)
 
 
 def test_main_log_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure the CLI keeps an existing log file path from configuration when no --log flag is provided
- add a regression test covering the preserved log file path scenario

## Testing
- python -m pytest -o addopts= tests/unit/test_cli_di.py::test_apply_cli_args_preserves_config_log_file
- python -m pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e42fec0a988333b4860d1e787e89c3