### PR TITLE
Handle null tool function payloads in reactor middleware

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -120,8 +120,17 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
 
         # Process each tool call through the reactor
         for tool_call in tool_calls:
+            function_payload = tool_call.get("function")
+
+            if not isinstance(function_payload, dict):
+                logger.debug(
+                    "Skipping tool call with invalid function payload: %s",
+                    tool_call,
+                )
+                continue
+
             # Parse tool arguments if they are a JSON string
-            tool_arguments_raw = tool_call.get("function", {}).get("arguments", {})
+            tool_arguments_raw = function_payload.get("arguments", {})
             tool_arguments: dict[str, Any] = {}
             if isinstance(tool_arguments_raw, str):
                 try:
@@ -144,7 +153,7 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
                 backend_name=backend_name,
                 model_name=model_name,
                 full_response=response.content,
-                tool_name=tool_call.get("function", {}).get("name", "unknown"),
+                tool_name=function_payload.get("name", "unknown"),
                 tool_arguments=tool_arguments,
                 calling_agent=calling_agent,
             )

--- a/tests/unit/core/services/test_tool_call_reactor_middleware.py
+++ b/tests/unit/core/services/test_tool_call_reactor_middleware.py
@@ -359,6 +359,36 @@ class TestToolCallReactorMiddleware:
         mock_reactor.process_tool_call.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_process_tool_call_with_null_function(self, middleware, mock_reactor):
+        """Tool calls with null function payload should be skipped safely."""
+        tool_call_response = {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": None,
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        response = ProcessedResponse(content=json.dumps(tool_call_response))
+
+        result = await middleware.process(
+            response=response,
+            session_id="test_session",
+            context={"backend_name": "test", "model_name": "test"},
+        )
+
+        assert result == response
+        mock_reactor.process_tool_call.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_process_dict_content(self, middleware, mock_reactor):
         """Test processing response with dict content."""
         tool_call_response = {


### PR DESCRIPTION
## Summary
- skip malformed tool calls whose function payload is missing so the reactor middleware does not crash
- add a regression test covering null function payloads to lock in the behavior

## Testing
- python -m pytest -c /tmp/pytest_no_addopts.ini tests/unit/core/services/test_tool_call_reactor_middleware.py
- python -m pytest -c /tmp/pytest_no_addopts.ini *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock, and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e430399f048333936da6ea3a5adabd