### PR TITLE
Handle list-based tool call payloads in the reactor middleware

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -204,12 +204,16 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
         # If content is already a dict, use it directly
         if isinstance(content, dict):
             data = content
-        else:
+        elif isinstance(content, list):
+            data = content
+        elif isinstance(content, str):
             # Otherwise try to parse as JSON string
             try:
-                data = json.loads(content) if isinstance(content, str) else {}
+                data = json.loads(content)
             except (json.JSONDecodeError, TypeError, ValueError):
                 return []
+        else:
+            return []
 
         tool_calls = []
 

--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -201,10 +201,8 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
         if not content:
             return []
 
-        # If content is already a dict, use it directly
-        if isinstance(content, dict):
-            data = content
-        elif isinstance(content, list):
+        # If content is already a dict or list, use it directly
+        if isinstance(content, (dict, list)):
             data = content
         elif isinstance(content, str):
             # Otherwise try to parse as JSON string

--- a/tests/unit/core/services/test_tool_call_reactor_middleware.py
+++ b/tests/unit/core/services/test_tool_call_reactor_middleware.py
@@ -345,6 +345,30 @@ class TestToolCallReactorMiddleware:
         assert call_args.tool_name == "test_tool"
 
     @pytest.mark.asyncio
+    async def test_process_list_tool_calls_array(self, middleware, mock_reactor):
+        """Test processing when response content is already a list of tool calls."""
+        tool_calls = [
+            {
+                "id": "call_456",
+                "type": "function",
+                "function": {"name": "list_tool", "arguments": '{"foo": "bar"}'},
+            }
+        ]
+
+        response = ProcessedResponse(content=tool_calls)
+        mock_reactor.process_tool_call.return_value = None
+
+        await middleware.process(
+            response=response,
+            session_id="test_session",
+            context={"backend_name": "test", "model_name": "test"},
+        )
+
+        mock_reactor.process_tool_call.assert_called_once()
+        call_args = mock_reactor.process_tool_call.call_args[0][0]
+        assert call_args.tool_name == "list_tool"
+
+    @pytest.mark.asyncio
     async def test_process_invalid_json_content(self, middleware, mock_reactor):
         """Test processing response with invalid JSON content."""
         response = ProcessedResponse(content="invalid json")


### PR DESCRIPTION
## Summary
- allow the tool call reactor middleware to consume responses whose content is already a list of tool call dictionaries
- add a unit test to ensure list-formatted tool calls are forwarded to the reactor

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_tool_call_reactor_middleware.py
- python -m pytest -o addopts='' *(fails: missing dev-only pytest plugins such as pytest-asyncio, pytest-httpx, respx, pytest-mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e430399f048333936da6ea3a5adabd