### PR TITLE
Handle list-based tool call payloads

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -192,15 +192,16 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
         if not content:
             return []
 
-        # If content is already a dict, use it directly
-        if isinstance(content, dict):
+        # Normalize the content into a Python structure that can be inspected
+        if isinstance(content, (dict, list)):
             data = content
-        else:
-            # Otherwise try to parse as JSON string
+        elif isinstance(content, str):
             try:
-                data = json.loads(content) if isinstance(content, str) else {}
+                data = json.loads(content)
             except (json.JSONDecodeError, TypeError, ValueError):
                 return []
+        else:
+            return []
 
         tool_calls = []
 


### PR DESCRIPTION
## Summary
- allow the tool call reactor middleware to read tool call collections that arrive as a list structure
- add a regression test that exercises list-form tool call payloads to ensure parsing coverage

## Testing
- python -m pytest tests/unit/core/services/test_tool_call_reactor_middleware.py::TestToolCallReactorMiddleware::test_process_with_tool_call_list_payload

------
https://chatgpt.com/codex/tasks/task_e_68e430399f048333936da6ea3a5adabd