### PR TITLE
Propagate tool call reactor handler metadata

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -161,7 +161,10 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
                     # Create a new response with the replacement content
                     if result.replacement_response:
                         replacement_response = self._create_replacement_response(
-                            response, result.replacement_response, tool_call
+                            response,
+                            result.replacement_response,
+                            tool_call,
+                            result.metadata,
                         )
                         return replacement_response
                     else:
@@ -232,6 +235,7 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
         original_response: Any,
         replacement_content: str,
         original_tool_call: dict[str, Any],
+        reaction_metadata: dict[str, Any] | None = None,
     ) -> Any:
         """Create a replacement response with the steering content.
 
@@ -246,15 +250,34 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
         # If the original response has a content attribute, create a new ProcessedResponse
         if hasattr(original_response, "content"):
             # Create a new ProcessedResponse with the replacement content
-            new_response = ProcessedResponse(
-                content=replacement_content,
-                usage=getattr(original_response, "usage", None),
-                metadata={
-                    **getattr(original_response, "metadata", {}),
+            original_metadata = getattr(original_response, "metadata", {}) or {}
+            merged_metadata: dict[str, Any] = dict(original_metadata)
+
+            if reaction_metadata:
+                existing_reactor_metadata = {}
+                if isinstance(
+                    merged_metadata.get("tool_call_reactor"), dict
+                ):
+                    existing_reactor_metadata = {
+                        **merged_metadata["tool_call_reactor"],
+                    }
+                merged_metadata["tool_call_reactor"] = {
+                    **existing_reactor_metadata,
+                    **reaction_metadata,
+                }
+
+            merged_metadata.update(
+                {
                     "tool_call_swallowed": True,
                     "original_tool_call": original_tool_call,
                     "replacement_provided": True,
-                },
+                }
+            )
+
+            new_response = ProcessedResponse(
+                content=replacement_content,
+                usage=getattr(original_response, "usage", None),
+                metadata=merged_metadata,
             )
             return new_response
 


### PR DESCRIPTION
## Summary
- ensure the tool call reactor middleware preserves handler metadata when emitting replacement responses
- cover the metadata propagation with unit tests, including merging with existing metadata

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/core/services/test_tool_call_reactor_middleware.py
- python -m pytest --override-ini=addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e430399f048333936da6ea3a5adabd