### PR TITLE
Fix backend service DI alias

### DIFF
--- a/src/core/app/stages/backend.py
+++ b/src/core/app/stages/backend.py
@@ -248,9 +248,16 @@ class BackendStage(InitializationStage):
                 BackendService, implementation_factory=backend_service_factory
             )
 
+            def _backend_service_alias_factory(
+                provider: IServiceProvider,
+            ) -> BackendService:
+                """Resolve the concrete BackendService singleton for the interface."""
+
+                return provider.get_required_service(BackendService)
+
             services.add_singleton(
                 cast(type, IBackendService),
-                implementation_factory=backend_service_factory,
+                implementation_factory=_backend_service_alias_factory,
             )
 
             if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
## Summary
- ensure the backend service interface resolves to the same singleton as the concrete implementation
- add a regression test covering the backend service DI aliasing behavior

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/app/stages/test_backend_startup_validation.py -q
- python -m pytest --override-ini addopts="" -q

------
https://chatgpt.com/codex/tasks/task_e_68e4307d7b4883338748d663a3553750