### PR TITLE
Fix finish reason mapping for Anthropic converter

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -284,7 +284,7 @@ def _map_finish_reason(openai_reason: str | None) -> str | None:
     """
     if openai_reason is None:
         return None
-    return _FINISH_REASON_MAP.get(openai_reason, "end_turn")
+    return _FINISH_REASON_MAP.get(openai_reason, openai_reason)
 
 
 def openai_stream_to_anthropic_stream(chunk_data: str) -> str:

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
@@ -232,7 +232,7 @@ class TestAnthropicConverters:
         assert _map_finish_reason("content_filter") == "stop_sequence"
         assert _map_finish_reason("function_call") == "tool_use"
         assert _map_finish_reason(None) is None
-        assert _map_finish_reason("unknown") == "end_turn"
+        assert _map_finish_reason("unknown") == "unknown"
 
     def test_get_anthropic_models(self) -> None:
         """Test Anthropic models endpoint response."""


### PR DESCRIPTION
## Summary
- ensure Anthropic finish reason mapping preserves unknown reasons instead of defaulting to `end_turn`
- update the converter test to expect passthrough behavior for unmapped finish reasons

## Testing
- ./.venv/Scripts/python.exe -m pytest -o addopts='' tests/unit/anthropic_frontend_tests/test_anthropic_converters.py::TestAnthropicConverters::test_map_finish_reason -q
- ./.venv/Scripts/python.exe -m pytest -o addopts='' -q

------
https://chatgpt.com/codex/tasks/task_e_68e4307d7b4883338748d663a3553750