### PR TITLE
Fix Anthropic response conversion fallback

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -270,24 +270,10 @@ class AnthropicController:
                     isinstance(anthropic_response_data, dict)
                     and "choices" in anthropic_response_data
                 ):
-                    # Convert OpenAI format to Anthropic format
-                    first_choice = anthropic_response_data["choices"][0]
-                    anthropic_formatted = {
-                        "id": anthropic_response_data.get(
-                            "id", "msg_" + str(hash(str(anthropic_response_data)))
-                        ),
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [
-                            {"type": "text", "text": first_choice["message"]["content"]}
-                        ],
-                        "model": anthropic_response_data.get("model", ""),
-                        "stop_reason": first_choice.get("finish_reason", "end_turn"),
-                        "stop_sequence": None,
-                        "usage": anthropic_response_data.get(
-                            "usage", {"input_tokens": 0, "output_tokens": 0}
-                        ),
-                    }
+                    # Convert OpenAI format to Anthropic format using shared converter
+                    anthropic_formatted = openai_to_anthropic_response(
+                        anthropic_response_data
+                    )
                     # Sanitize headers to remove compression hints that can confuse clients
                     raw_headers = getattr(adapted_response, "headers", {})
                     safe_headers = {


### PR DESCRIPTION
## Summary
- reuse the shared OpenAI-to-Anthropic converter when formatting fallback responses so finish reasons stay consistent

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/anthropic_frontend_tests
- python -m pytest --override-ini=addopts="" tests/unit/test_anthropic_server.py
- python -m pytest --override-ini=addopts="" *(fails: missing optional test dependencies such as pytest_asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e4307d7b4883338748d663a3553750