### PR TITLE
Fix failover route creation toggling interactive flag

### DIFF
--- a/src/core/domain/commands/failover_commands.py
+++ b/src/core/domain/commands/failover_commands.py
@@ -82,8 +82,6 @@ class CreateFailoverRouteCommand(StatefulCommandBase):
         # Refactored state update
         session.state = session.state.with_backend_config(
             new_backend_config
-        ).with_interactive_just_enabled(
-            True
         )  # Changed session_state._state to session.state
 
         return CommandResult(

--- a/tests/unit/commands/test_unit_failover_commands.py
+++ b/tests/unit/commands/test_unit_failover_commands.py
@@ -63,6 +63,25 @@ async def test_create_failover_route(
 
 
 @pytest.mark.asyncio
+async def test_create_failover_route_does_not_toggle_interactive_flag(
+    mock_session: Mock,
+    mock_state_reader: ISecureStateAccess,
+    mock_state_modifier: ISecureStateModification,
+) -> None:
+    """Ensure creating a route leaves the interactive flag untouched."""
+
+    command = CreateFailoverRouteCommand(
+        state_reader=mock_state_reader, state_modifier=mock_state_modifier
+    )
+    # The interactive flag should remain whatever it was before execution.
+    assert mock_session.state.interactive_just_enabled is False
+
+    await command.execute({"name": "route", "policy": "k"}, mock_session)
+
+    assert mock_session.state.interactive_just_enabled is False
+
+
+@pytest.mark.asyncio
 async def test_delete_failover_route(
     mock_session: Mock,
     mock_state_reader: ISecureStateAccess,


### PR DESCRIPTION
## Summary
- stop the failover route command from marking interactive mode as newly enabled
- add a regression test ensuring the interactive flag remains untouched when creating a failover route

## Testing
- `python -m pytest tests/unit/commands/test_unit_failover_commands.py`
- `python -m pytest` *(fails: environment lacks optional tooling and dependencies required by quality/lint tests and connector suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e42fa0d85483339e6036963884cb04