### PR TITLE
Handle single-quoted Gemini generation config values

### DIFF
--- a/src/core/commands/handlers/reasoning_handlers.py
+++ b/src/core/commands/handlers/reasoning_handlers.py
@@ -6,6 +6,7 @@ This module provides command handlers for reasoning-related settings.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 from typing import Any
@@ -260,7 +261,15 @@ class GeminiGenerationConfigHandler(BaseCommandHandler):
         try:
             # Parse the config if it's a string
             if isinstance(param_value, str):
-                config = json.loads(param_value)
+                try:
+                    config = json.loads(param_value)
+                except json.JSONDecodeError as json_error:
+                    try:
+                        config = ast.literal_eval(param_value)
+                    except (ValueError, SyntaxError):
+                        return CommandHandlerResult(
+                            success=False, message=f"Invalid JSON: {json_error}"
+                        )
             else:
                 config = param_value
 

--- a/tests/unit/core/commands/handlers/test_reasoning_handlers.py
+++ b/tests/unit/core/commands/handlers/test_reasoning_handlers.py
@@ -420,6 +420,32 @@ class TestGeminiGenerationConfigHandler:
         )
 
     @pytest.mark.asyncio
+    async def test_handle_with_single_quotes_string(
+        self, handler: GeminiGenerationConfigHandler, mock_state: ISessionState
+    ) -> None:
+        """Test handle accepts JSON-like strings using single quotes."""
+
+        config_string = "{'thinkingConfig': {'thinkingBudget': 1024}}"
+        expected_config = {"thinkingConfig": {"thinkingBudget": 1024}}
+        mock_state.reasoning_config.with_gemini_generation_config = Mock(
+            return_value=mock_state.reasoning_config
+        )
+
+        result = handler.handle(config_string, mock_state)
+
+        assert isinstance(result, CommandHandlerResult)
+        assert result.success is True
+        assert (
+            result.message
+            == f"Gemini generation config set to {expected_config}"
+        )
+        assert result.new_state is mock_state
+
+        mock_state.reasoning_config.with_gemini_generation_config.assert_called_once_with(
+            expected_config
+        )
+
+    @pytest.mark.asyncio
     async def test_handle_with_invalid_json_string(
         self, handler: GeminiGenerationConfigHandler, mock_state: ISessionState
     ) -> None:


### PR DESCRIPTION
## Summary
- allow the Gemini generation config handler to parse JSON-like strings that use single quotes
- add unit coverage ensuring the handler accepts single-quoted configuration payloads

## Testing
- `python -m pytest tests/unit/core/commands/handlers/test_reasoning_handlers.py`
- `python -m pytest` *(fails: repository baseline has many pre-existing quality gate and snapshot fixture failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e42fa0d85483339e6036963884cb04