### PR TITLE
Fix failover coordinator route normalization

### DIFF
--- a/src/core/services/failover_coordinator.py
+++ b/src/core/services/failover_coordinator.py
@@ -19,19 +19,59 @@ class FailoverCoordinator(IFailoverCoordinator):
     def get_failover_attempts(
         self, model: str, backend_type: str
     ) -> list[FailoverAttempt]:
-        # The FailoverService expects a BackendConfiguration-like object. The
-        # service implementation in this codebase uses the `failover_routes`
-        # attribute. We'll pass a simple adapter object that has a `failover_routes`
-        # attribute to satisfy the method signature.
-        class _Adapter:
-            def __init__(self, routes: dict[str, Any]):
-                # FailoverService expects a mapping keyed by model name to route
-                # objects. Ensure we pass a dict[str, dict] shape.
-                self.failover_routes: dict[str, dict[str, Any]] = routes
+        # First, check for a direct backend-level failover mapping such as
+        # {"openai": "anthropic"}. These routes simply swap the backend while
+        # reusing the same model name.
+        direct_route = self._svc.get_failover_route(backend_type)
+        if isinstance(direct_route, str) and direct_route:
+            return [FailoverAttempt(backend=direct_route, model=model)]
 
-        adapter = _Adapter(dict(self._svc.failover_routes))
-        return self._svc.get_failover_attempts(adapter, model, backend_type)
+        # Normalize any structured route definitions (policy/elements) so they
+        # can be consumed by FailoverService.get_failover_attempts, which expects
+        # a BackendConfiguration-like object exposing ``failover_routes`` keyed by
+        # model name.
+        normalized_routes = self._normalize_routes(direct_route, model)
+        if not normalized_routes:
+            # Fall back to the raw failover_routes mapping maintained by the
+            # service. This may already be keyed by model name when populated
+            # from backend configuration objects.
+            normalized_routes = self._normalize_routes(
+                self._svc.failover_routes, model
+            )
+
+        if not normalized_routes:
+            return []
+
+        class _Adapter:
+            def __init__(self, routes: dict[str, dict[str, Any]]) -> None:
+                self.failover_routes = routes
+
+        return self._svc.get_failover_attempts(_Adapter(normalized_routes), model, backend_type)
 
     def register_route(self, model: str, route: dict) -> None:
         # Route registration is handled on the underlying service.
         self._svc.failover_routes[model] = route
+
+    def _normalize_routes(
+        self, raw_routes: Any, model: str
+    ) -> dict[str, dict[str, Any]] | None:
+        if not isinstance(raw_routes, dict):
+            return None
+
+        # If the dictionary already looks like {model: {...}}, extract the
+        # requested model entry when present.
+        if model in raw_routes and isinstance(raw_routes[model], dict):
+            return {model: raw_routes[model]}
+
+        # Handle dictionaries that represent a single route definition with
+        # policy/elements keys (e.g., {"policy": "k", "elements": [...]}) by
+        # wrapping them under the requested model name.
+        if {"policy", "elements"}.intersection(raw_routes.keys()):
+            return {model: raw_routes}
+
+        # In some scenarios the mapping may already be keyed by multiple models;
+        # ensure all values are dictionaries before using it directly.
+        if raw_routes and all(isinstance(v, dict) for v in raw_routes.values()):
+            return {k: v for k, v in raw_routes.items() if isinstance(v, dict)} or None
+
+        return None

--- a/tests/unit/core/services/test_failover_coordinator.py
+++ b/tests/unit/core/services/test_failover_coordinator.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from src.core.services.failover_coordinator import FailoverCoordinator
+from src.core.services.failover_service import FailoverAttempt, FailoverService
+
+
+def test_coordinator_handles_simple_backend_mapping() -> None:
+    service = FailoverService({"openai": "anthropic"})
+    coordinator = FailoverCoordinator(service)
+
+    attempts = coordinator.get_failover_attempts("gpt-4o", "openai")
+
+    assert attempts == [FailoverAttempt(backend="anthropic", model="gpt-4o")]
+
+
+def test_coordinator_normalizes_structured_routes() -> None:
+    service = FailoverService(
+        {"openai": {"policy": "k", "elements": ["openrouter:meta/llama-3"]}}
+    )
+    coordinator = FailoverCoordinator(service)
+
+    attempts = coordinator.get_failover_attempts("gpt-4o", "openai")
+
+    assert attempts == [FailoverAttempt(backend="openrouter", model="meta/llama-3")]


### PR DESCRIPTION
## Summary
- normalize failover route lookup in `FailoverCoordinator` so both direct backend mappings and structured policy-based routes are respected
- add unit coverage demonstrating the coordinator handles string and structured failover routes

## Testing
- `python -m pytest -o addopts="" tests/unit/core/services/test_failover_coordinator.py`
- `python -m pytest -o addopts="" tests/unit/core/test_failover_service.py`
- `python -m pytest -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68e430af996083338bce353fe7aacec3