### PR TITLE
Fix JSON repair middleware handling empty payloads

### DIFF
--- a/src/core/app/middleware/json_repair_middleware.py
+++ b/src/core/app/middleware/json_repair_middleware.py
@@ -74,7 +74,7 @@ class JsonRepairMiddleware(IResponseMiddleware):
                     schema=self.config.session.json_repair_schema,
                     strict=strict_effective,
                 )
-                if repaired_json:
+                if repaired_json is not None:
                     metrics.inc(
                         "json_repair.non_streaming.strict_success"
                         if strict_effective
@@ -93,7 +93,7 @@ class JsonRepairMiddleware(IResponseMiddleware):
                     else "json_repair.non_streaming.best_effort_fail"
                 )
                 raise
-            if repaired_json:
+            if repaired_json is not None:
                 if logger.isEnabledFor(logging.INFO):
                     logger.info(f"JSON detected and repaired for session {session_id}")
                 response.content = json.dumps(repaired_json)

--- a/tests/unit/core/services/test_json_repair_middleware.py
+++ b/tests/unit/core/services/test_json_repair_middleware.py
@@ -61,6 +61,18 @@ async def test_process_response_invalid(
     assert processed_response.metadata.get("repaired")
 
 
+async def test_process_response_empty_object(
+    json_repair_middleware: JsonRepairMiddleware,
+) -> None:
+    response = ProcessedResponse(content="{}")
+    processed_response = await json_repair_middleware.process(
+        response, "session_id", {}
+    )
+
+    assert processed_response.content == "{}"
+    assert processed_response.metadata.get("repaired") is True
+
+
 async def test_process_response_best_effort_failure_metrics(
     json_repair_middleware: JsonRepairMiddleware,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- ensure JsonRepairMiddleware treats repaired payloads as successful even when the JSON object is empty
- add a regression test covering empty-object responses and confirming the repaired flag is applied

## Testing
- python -m pytest -c /tmp/pytest-no-addopts.ini tests/unit/core/services/test_json_repair_middleware.py
- python -m pytest -c /tmp/pytest-no-addopts.ini *(fails: missing optional test dependencies such as pytest_asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e4310eeba88333b3e8096d7949f668