### PR TITLE
Fix JSON schema validation handling

### DIFF
--- a/src/core/services/json_repair_service.py
+++ b/src/core/services/json_repair_service.py
@@ -42,7 +42,7 @@ class JsonRepairService:
             if schema:
                 self.validate_json(repaired_json, schema)
             return repaired_json
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError, JsonSchemaValidationError) as e:
             if strict:
                 raise e
             logger.warning(f"Failed to repair or validate JSON: {e}")

--- a/tests/unit/core/services/test_json_repair_service.py
+++ b/tests/unit/core/services/test_json_repair_service.py
@@ -28,3 +28,21 @@ def test_validate_json_invalid(json_repair_service: JsonRepairService) -> None:
         json_repair_service.validate_json(
             {"a": "1"}, {"type": "object", "properties": {"a": {"type": "number"}}}
         )
+
+
+def test_repair_and_validate_json_non_strict_returns_none(
+    json_repair_service: JsonRepairService,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "number"}},
+        "required": ["value"],
+    }
+
+    repaired = json_repair_service.repair_and_validate_json(
+        '{"value": "not-a-number"}',
+        schema=schema,
+        strict=False,
+    )
+
+    assert repaired is None


### PR DESCRIPTION
## Summary
- ensure `JsonRepairService.repair_and_validate_json` tolerates JSON Schema validation errors in non-strict mode
- add a regression test verifying that schema validation failures return `None` when strict validation is disabled

## Testing
- `python -m pytest --override-ini="addopts=" tests/unit/core/services/test_json_repair_service.py`
- `python -m pytest --override-ini="addopts="` *(fails: missing optional dev dependencies such as pytest-asyncio, respx, pytest_httpx, pytest-mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e4310eeba88333b3e8096d7949f668