### PR TITLE
Handle schema validation errors in JSON repair service

### DIFF
--- a/tests/unit/core/services/test_json_repair_service.py
+++ b/tests/unit/core/services/test_json_repair_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from src.core.common.exceptions import JSONParsingError, ValidationError
 from src.core.services.json_repair_service import JsonRepairService
 
 
@@ -28,3 +29,43 @@ def test_validate_json_invalid(json_repair_service: JsonRepairService) -> None:
         json_repair_service.validate_json(
             {"a": "1"}, {"type": "object", "properties": {"a": {"type": "number"}}}
         )
+
+
+def test_repair_and_validate_json_schema_failure_best_effort(
+    json_repair_service: JsonRepairService,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}},
+        "required": ["a"],
+    }
+
+    repaired = json_repair_service.repair_and_validate_json(
+        '{"a": "text"}', schema=schema, strict=False
+    )
+
+    assert repaired is None
+
+
+def test_repair_and_validate_json_schema_failure_strict(
+    json_repair_service: JsonRepairService,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}},
+        "required": ["a"],
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        json_repair_service.repair_and_validate_json(
+            '{"a": "text"}', schema=schema, strict=True
+        )
+
+    assert "JSON does not match required schema" in str(exc_info.value)
+
+
+def test_repair_and_validate_json_parse_failure_strict(
+    json_repair_service: JsonRepairService,
+) -> None:
+    with pytest.raises(JSONParsingError):
+        json_repair_service.repair_and_validate_json("not-json", strict=True)


### PR DESCRIPTION
## Summary
- raise structured ValidationError when repaired JSON fails schema validation in strict mode
- return None for best-effort schema failures and surface JSONParsingError for repair issues
- cover the new behaviors with JsonRepairService unit tests

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/test_json_repair_service.py
- python -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e4310eeba88333b3e8096d7949f668