### PR TITLE
Fix loop cancellation SSE output

### DIFF
--- a/src/core/domain/streaming_content.py
+++ b/src/core/domain/streaming_content.py
@@ -48,6 +48,15 @@ class StreamingContent:
     def to_bytes(self) -> bytes:
         """Convert this chunk to a bytes representation for streaming."""
         if self.is_done:
+            if self.is_cancellation and self.content:
+                data = {
+                    "choices": [{"delta": {"content": self.content}}],
+                    "finish_reason": "cancelled",
+                }
+                for key in ["id", "model", "created"]:
+                    if key in self.metadata:
+                        data[key] = self.metadata[key]
+                return f"data: {json.dumps(data)}\n\ndata: [DONE]\n\n".encode()
             return b"data: [DONE]\n\n"
 
         # Simplified serialization for streaming

--- a/src/core/domain/streaming_response_processor.py
+++ b/src/core/domain/streaming_response_processor.py
@@ -7,7 +7,6 @@ responses in a consistent way, regardless of the source or format.
 
 from __future__ import annotations
 
-import json
 import logging
 from abc import ABC, abstractmethod
 

--- a/src/core/domain/streaming_response_processor.py
+++ b/src/core/domain/streaming_response_processor.py
@@ -84,14 +84,18 @@ class LoopDetectionProcessor(IStreamProcessor):
     ) -> StreamingContent:
         """Create a StreamingContent object with a cancellation message."""
         payload = (
-            f"[Response cancelled: Loop detected - Pattern "
+            "[Response cancelled: Loop detected - Pattern "
             f"'{detection_event.pattern[:30]}...' repeated "
             f"{detection_event.repetition_count} times]"
         )
-        # Return as a final chunk with the cancellation message
+
         return StreamingContent(
-            content=f"data: {json.dumps({'content': payload})}\n\n",
+            content=payload,
             is_done=True,
             is_cancellation=True,
-            metadata={"loop_detected": True, "pattern": detection_event.pattern},
+            metadata={
+                "loop_detected": True,
+                "pattern": detection_event.pattern,
+                "repetition_count": detection_event.repetition_count,
+            },
         )

--- a/tests/unit/test_streaming_normalizer.py
+++ b/tests/unit/test_streaming_normalizer.py
@@ -63,6 +63,15 @@ class TestStreamingContent:
         done = StreamingContent(is_done=True)
         assert done.to_bytes() == b"data: [DONE]\n\n"
 
+    def test_to_bytes_cancellation_message(self) -> None:
+        """Cancellation chunks should include the message before the done marker."""
+        content = StreamingContent(
+            content="Loop detected", is_done=True, is_cancellation=True
+        )
+        bytes_data = content.to_bytes()
+        assert b"Loop detected" in bytes_data
+        assert bytes_data.endswith(b"data: [DONE]\n\n")
+
 
 class MockStreamProcessor(IStreamProcessor):
     """Mock stream processor for testing."""


### PR DESCRIPTION
## Summary
- ensure StreamingContent emits cancellation payloads before the SSE done marker so clients receive loop warnings
- simplify LoopDetectionProcessor cancellation construction and carry additional metadata for diagnostics
- add regression coverage verifying cancellation chunks include the warning text

## Testing
- `pytest -o addopts= tests/unit/test_streaming_normalizer.py`
- `pytest -o addopts= tests/unit/loop_detection/test_streaming_wrapper.py`
- `pytest -o addopts=` *(fails: missing optional dev dependencies such as pytest-asyncio, pytest_httpx, pytest_mock, hypothesis, respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e430c1ddac8333bd9e17c54954f11a