### PR TITLE
Fix: redact OpenAI initialization log

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -83,7 +83,10 @@ class OpenAIConnector(LLMBackend):
 
     async def initialize(self, **kwargs: Any) -> None:
         self.api_key = kwargs.get("api_key")
-        logger.info(f"OpenAIConnector initialize called. api_key: {self.api_key}")
+        logger.info(
+            "OpenAIConnector initialize called. api_key_provided=%s",
+            "yes" if self.api_key else "no",
+        )
         if "api_base_url" in kwargs:
             self.api_base_url = kwargs["api_base_url"]
 

--- a/tests/unit/openai_connector_tests/openai_logging_test.py
+++ b/tests/unit/openai_connector_tests/openai_logging_test.py
@@ -1,0 +1,28 @@
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.connectors.openai import OpenAIConnector
+from src.core.config.app_config import AppConfig
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_log_raw_api_key(caplog: pytest.LogCaptureFixture) -> None:
+    client = AsyncMock()
+    response = MagicMock()
+    response.json.return_value = {"data": []}
+    client.get.return_value = response
+
+    config = AppConfig()
+    connector = OpenAIConnector(client=client, config=config)
+
+    caplog.set_level(logging.INFO, logger="src.connectors.openai")
+    api_key = "sk-test-very-secret-key"
+
+    await connector.initialize(api_key=api_key)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("api_key_provided=yes" in message for message in messages)
+    assert all(api_key not in message for message in messages)
+    client.get.assert_awaited()


### PR DESCRIPTION
## Summary
- redact the OpenAI connector initialization log so that it no longer prints the raw API key
- add a regression test to ensure initialization logs only indicate whether a key was provided

## Testing
- pytest -o addopts="" tests/unit/openai_connector_tests/openai_logging_test.py
- pytest -o addopts="" *(fails: missing pytest_asyncio, respx, pytest_httpx, pytest_mock in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4312d901883338709a5ea1b7e923a