### PR TITLE
Fix OpenAI responses translation format

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -602,7 +602,7 @@ class OpenAIConnector(LLMBackend):
         # Convert to domain response first, then back to ensure consistency
         # We'll treat the Responses API response as a special case of OpenAI response
         domain_response = self.translation_service.to_domain_response(
-            response_data, "openai"
+            response_data, "openai-responses"
         )
 
         # Convert back to Responses API format for the final response


### PR DESCRIPTION
## Summary
- ensure the OpenAI Responses connector converts provider payloads using the openai-responses translator
- add a regression test that verifies the Responses API path calls the correct translation format

## Testing
- python -m pytest -c pytest-empty.ini tests/integration/test_openai_responses_backend.py::TestOpenAIResponsesBackendIntegration::test_responses_api_uses_openai_responses_translation
- python -m pytest -c pytest-empty.ini *(fails: missing pytest_asyncio, pytest_httpx, respx, pytest_mock dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4312d901883338709a5ea1b7e923a