### PR TITLE
Fix pytest detection for input string arguments

### DIFF
--- a/src/core/services/pytest_compression_service.py
+++ b/src/core/services/pytest_compression_service.py
@@ -72,6 +72,8 @@ class PytestCompressionService:
             # Sometimes a sub-dict holds the command
             for key in ("input", "body", "data"):
                 inner = arguments.get(key)
+                if isinstance(inner, str) and inner.strip():
+                    return inner
                 if isinstance(inner, dict):
                     sub = inner.get("command") or inner.get("cmd")
                     if isinstance(sub, str) and sub.strip():

--- a/tests/unit/core/services/pytest_compression_service_input_test.py
+++ b/tests/unit/core/services/pytest_compression_service_input_test.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.services.pytest_compression_service import PytestCompressionService
+
+
+@pytest.fixture()
+def service() -> PytestCompressionService:
+    return PytestCompressionService()
+
+
+def test_scan_for_pytest_detects_input_string(service: PytestCompressionService) -> None:
+    arguments = {"input": "pytest -q"}
+
+    result = service.scan_for_pytest("bash", arguments)
+
+    assert result is not None
+    detected, command = result
+    assert detected is True
+    assert command == "pytest -q"

--- a/tests/unit/core/services/pytest_compression_service_input_test.py
+++ b/tests/unit/core/services/pytest_compression_service_input_test.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from src.core.services.pytest_compression_service import PytestCompressionService
 
 
@@ -10,7 +9,9 @@ def service() -> PytestCompressionService:
     return PytestCompressionService()
 
 
-def test_scan_for_pytest_detects_input_string(service: PytestCompressionService) -> None:
+def test_scan_for_pytest_detects_input_string(
+    service: PytestCompressionService,
+) -> None:
     arguments = {"input": "pytest -q"}
 
     result = service.scan_for_pytest("bash", arguments)


### PR DESCRIPTION
## Summary
- allow the pytest compression service to treat string values under input/body/data keys as shell commands
- add a regression test covering pytest detection when the command is provided via an input field

## Testing
- pytest -o addopts="" tests/unit/core/services/pytest_compression_service_input_test.py
- pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e4312d901883338709a5ea1b7e923a