### PR TITLE
Fix session backend update to use interface methods

### DIFF
--- a/src/core/services/session_service_impl.py
+++ b/src/core/services/session_service_impl.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 from src.core.domain.session import Session
 from src.core.interfaces.repositories_interface import ISessionRepository
 from src.core.interfaces.session_service_interface import ISessionService
@@ -40,13 +38,9 @@ class SessionService(ISessionService):
     ) -> None:
         session = await self.get_session(session_id)
         # SessionState is immutable, so with_backend_config returns a new instance
-        from src.core.domain.configuration.backend_config import BackendConfiguration
-
-        new_state = session.state.with_backend_config(
-            cast(BackendConfiguration, session.state.backend_config).model_copy(
-                update={"backend_type": backend_type, "model": model}
-            )
-        )
+        current_config = session.state.backend_config
+        updated_config = current_config.with_backend(backend_type).with_model(model)
+        new_state = session.state.with_backend_config(updated_config)
         session.state = new_state
         await self._session_repository.update(session)
 

--- a/tests/unit/core/services/test_session_service_impl.py
+++ b/tests/unit/core/services/test_session_service_impl.py
@@ -1,7 +1,4 @@
-from __future__ import annotations
-
 import pytest
-
 from src.core.domain.session import Session
 from src.core.interfaces.repositories_interface import ISessionRepository
 from src.core.services.session_service_impl import SessionService
@@ -13,7 +10,7 @@ class InMemorySessionRepository(ISessionRepository):
     def __init__(self) -> None:
         self._sessions: dict[str, Session] = {}
 
-    async def get_by_id(self, id: str) -> Session | None:  # noqa: A003 - interface contract
+    async def get_by_id(self, id: str) -> Session | None:
         return self._sessions.get(id)
 
     async def get_all(self) -> list[Session]:
@@ -27,7 +24,7 @@ class InMemorySessionRepository(ISessionRepository):
         self._sessions[entity.session_id] = entity
         return entity
 
-    async def delete(self, id: str) -> bool:  # noqa: A003 - interface contract
+    async def delete(self, id: str) -> bool:
         return self._sessions.pop(id, None) is not None
 
     async def get_by_user_id(self, user_id: str) -> list[Session]:

--- a/tests/unit/core/services/test_session_service_impl.py
+++ b/tests/unit/core/services/test_session_service_impl.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.domain.session import Session
+from src.core.interfaces.repositories_interface import ISessionRepository
+from src.core.services.session_service_impl import SessionService
+
+
+class InMemorySessionRepository(ISessionRepository):
+    """Simple in-memory session repository for testing."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, Session] = {}
+
+    async def get_by_id(self, id: str) -> Session | None:  # noqa: A003 - interface contract
+        return self._sessions.get(id)
+
+    async def get_all(self) -> list[Session]:
+        return list(self._sessions.values())
+
+    async def add(self, entity: Session) -> Session:
+        self._sessions[entity.session_id] = entity
+        return entity
+
+    async def update(self, entity: Session) -> Session:
+        self._sessions[entity.session_id] = entity
+        return entity
+
+    async def delete(self, id: str) -> bool:  # noqa: A003 - interface contract
+        return self._sessions.pop(id, None) is not None
+
+    async def get_by_user_id(self, user_id: str) -> list[Session]:
+        return [s for s in self._sessions.values() if getattr(s, "user_id", None) == user_id]
+
+    async def cleanup_expired(self, max_age_seconds: int) -> int:
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_update_session_backend_config_updates_backend_and_model() -> None:
+    repo = InMemorySessionRepository()
+    service = SessionService(repo)
+
+    session = Session(session_id="sess-1")
+    await repo.add(session)
+
+    await service.update_session_backend_config("sess-1", "openai", "gpt-4")
+
+    stored = await repo.get_by_id("sess-1")
+    assert stored is not None
+    assert stored.state.backend_config.backend_type == "openai"
+    assert stored.state.backend_config.model == "gpt-4"
+


### PR DESCRIPTION
## Summary
- update `SessionService.update_session_backend_config` to use interface methods so backend/model overrides persist
- add a dedicated unit test covering the backend/model update path

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/test_session_service_impl.py
- python -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e43090727483339e00d3874fafe711