### PR TITLE
Fix Gemini OAuth personal model prefix stripping

### DIFF
--- a/src/connectors/gemini_oauth_personal.py
+++ b/src/connectors/gemini_oauth_personal.py
@@ -1151,7 +1151,7 @@ class GeminiOAuthPersonalConnector(GeminiBackend):
             model_name = effective_model
             prefix = "gemini-cli-oauth-personal:"
             if model_name.startswith(prefix):
-                model_name = model_name[len(prefix):]
+                model_name = model_name[len(prefix) :]
 
             # Check if streaming is requested
             is_streaming = getattr(request_data, "stream", False)

--- a/src/connectors/gemini_oauth_personal.py
+++ b/src/connectors/gemini_oauth_personal.py
@@ -1149,16 +1149,9 @@ class GeminiOAuthPersonalConnector(GeminiBackend):
         try:
             # Use the effective model (strip gemini-cli-oauth-personal: prefix if present)
             model_name = effective_model
-            if model_name.startswith("gemini-cli-oauth-personal:"):
-                model_name = model_name[
-                    25:
-                ]  # Remove "gemini-cli-oauth-personal:" prefix
-
-            # Fix the model name stripping bug
-            if model_name.startswith("gemini-cli-oauth-personal:"):
-                model_name = model_name[
-                    27:
-                ]  # Remove "gemini-cli-oauth-personal:" prefix
+            prefix = "gemini-cli-oauth-personal:"
+            if model_name.startswith(prefix):
+                model_name = model_name[len(prefix):]
 
             # Check if streaming is requested
             is_streaming = getattr(request_data, "stream", False)


### PR DESCRIPTION
## Summary
- ensure the Gemini OAuth personal connector removes the backend prefix using a length-based slice so model overrides resolve correctly

## Testing
- python -m pytest tests/unit/connectors/test_gemini_oauth_personal.py
- python -m pytest  # fails: repository already contains multiple lint/type-check/dependency tasks that fail in a clean checkout

------
https://chatgpt.com/codex/tasks/task_e_68e42fbeab008333acb3668c10c9d043