### PR TITLE
Improve coverage for tool loop detection command

### DIFF
--- a/tests/unit/commands/loop_detection_commands/test_tool_loop_detection_command.py
+++ b/tests/unit/commands/loop_detection_commands/test_tool_loop_detection_command.py
@@ -1,4 +1,9 @@
 import asyncio
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
 
 from src.core.domain.commands.loop_detection_commands.tool_loop_detection_command import (
     ToolLoopDetectionCommand,
@@ -9,14 +14,23 @@ from src.core.domain.configuration.loop_detection_config import (
 from src.core.domain.session import Session, SessionState
 
 
+def _build_session(loop_config: LoopDetectionConfiguration) -> Session:
+    return Session("session-id", state=SessionState(loop_config=loop_config))
+
+
+def _run_command(
+    command: ToolLoopDetectionCommand, args: Mapping[str, Any], session: Session
+):
+    return asyncio.run(command.execute(args, session))
+
+
 def test_execute_enables_tool_loop_detection_when_true() -> None:
     command = ToolLoopDetectionCommand()
-    session_state = SessionState(
-        loop_config=LoopDetectionConfiguration(tool_loop_detection_enabled=False)
+    session = _build_session(
+        LoopDetectionConfiguration(tool_loop_detection_enabled=False)
     )
-    session = Session("session-id", state=session_state)
 
-    result = asyncio.run(command.execute({"enabled": "true"}, session))
+    result = _run_command(command, {"enabled": "true"}, session)
 
     assert result.success is True
     assert result.name == "tool-loop-detection"
@@ -27,12 +41,11 @@ def test_execute_enables_tool_loop_detection_when_true() -> None:
 
 def test_execute_disables_tool_loop_detection_when_false() -> None:
     command = ToolLoopDetectionCommand()
-    session_state = SessionState(
-        loop_config=LoopDetectionConfiguration(tool_loop_detection_enabled=True)
+    session = _build_session(
+        LoopDetectionConfiguration(tool_loop_detection_enabled=True)
     )
-    session = Session("session-id", state=session_state)
 
-    result = asyncio.run(command.execute({"enabled": "false"}, session))
+    result = _run_command(command, {"enabled": "false"}, session)
 
     assert result.success is True
     assert result.message == "Tool loop detection disabled"
@@ -42,17 +55,56 @@ def test_execute_disables_tool_loop_detection_when_false() -> None:
 
 def test_execute_defaults_to_enable_when_argument_missing() -> None:
     command = ToolLoopDetectionCommand()
-    session_state = SessionState(
-        loop_config=LoopDetectionConfiguration(tool_loop_detection_enabled=False)
+    session = _build_session(
+        LoopDetectionConfiguration(tool_loop_detection_enabled=False)
     )
-    session = Session("session-id", state=session_state)
 
-    result = asyncio.run(command.execute({}, session))
+    result = _run_command(command, {}, session)
 
     assert result.success is True
     assert result.data == {"enabled": True}
     assert result.message == "Tool loop detection enabled"
     assert result.new_state.loop_config.tool_loop_detection_enabled is True
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("yes", True),
+        ("YES", True),
+        ("1", True),
+        ("on", True),
+        (True, True),
+        ("no", False),
+        ("0", False),
+        (False, False),
+    ],
+)
+def test_execute_handles_various_truthy_and_falsy_values(
+    value: Any, expected: bool
+) -> None:
+    command = ToolLoopDetectionCommand()
+    session = _build_session(
+        LoopDetectionConfiguration(tool_loop_detection_enabled=not expected)
+    )
+
+    result = _run_command(command, {"enabled": value}, session)
+
+    assert result.success is True
+    assert result.data == {"enabled": expected}
+    assert result.new_state.loop_config.tool_loop_detection_enabled is expected
+
+
+def test_command_metadata_properties() -> None:
+    command = ToolLoopDetectionCommand()
+
+    assert command.name == "tool-loop-detection"
+    assert command.format == "tool-loop-detection(enabled=true|false)"
+    assert (
+        command.description
+        == "Enable or disable tool loop detection for the current session"
+    )
+    assert command.examples == ["!/tool-loop-detection(enabled=true)"]
 
 
 class _FailingState:
@@ -70,11 +122,12 @@ class _FailingSession:
         self.state = _FailingState()
 
 
-def test_execute_returns_error_result_when_state_update_fails() -> None:
+def test_execute_returns_error_result_when_state_update_fails(caplog: pytest.LogCaptureFixture) -> None:
     command = ToolLoopDetectionCommand()
     session = _FailingSession()
 
-    result = asyncio.run(command.execute({"enabled": "true"}, session))
+    with caplog.at_level(logging.ERROR):
+        result = _run_command(command, {"enabled": "true"}, session)
 
     assert result.success is False
     assert result.name == "tool-loop-detection"
@@ -83,3 +136,4 @@ def test_execute_returns_error_result_when_state_update_fails() -> None:
         result.message
         == "Error toggling tool loop detection: unable to persist loop configuration"
     )
+    assert "Error toggling tool loop detection" in caplog.text


### PR DESCRIPTION
## Summary
- add helper utilities and new parametrized scenarios to the tool loop detection command unit tests
- cover metadata properties and error logging branches to increase confidence in the command behaviour

## Testing
- pytest tests/unit/commands/loop_detection_commands/test_tool_loop_detection_command.py -q --override-ini=addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e431da181083339041f3d1a5bc94f4