### PR TITLE
Add parameterized tests for loop detection command truthy and falsey inputs

### DIFF
--- a/tests/unit/core/domain/commands/loop_detection_commands/test_loop_detection_command.py
+++ b/tests/unit/core/domain/commands/loop_detection_commands/test_loop_detection_command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from pytest import MonkeyPatch
 from src.core.domain.commands.loop_detection_commands.loop_detection_command import (
     LoopDetectionCommand,
@@ -52,6 +53,56 @@ def test_execute_disables_loop_detection_with_falsey_argument() -> None:
     assert result.data == {"enabled": False}
     assert isinstance(result.new_state, SessionStateAdapter)
     assert result.new_state.loop_config.loop_detection_enabled is False
+
+
+@pytest.mark.parametrize(
+    "enabled_value",
+    ["true", "True", "YES", "1", "on", True],
+)
+def test_execute_interprets_various_truthy_values(enabled_value: object) -> None:
+    """The command treats multiple truthy representations as enabling the feature."""
+    session = Session(
+        "session-id",
+        state=SessionState(
+            loop_config=LoopDetectionConfiguration(loop_detection_enabled=False)
+        ),
+    )
+    command = LoopDetectionCommand()
+
+    result = asyncio.run(command.execute({"enabled": enabled_value}, session))
+
+    assert result.success is True
+    assert result.message == "Loop detection enabled"
+    assert result.data == {"enabled": True}
+    assert isinstance(result.new_state, SessionStateAdapter)
+    assert result.new_state.loop_config.loop_detection_enabled is True
+    # Verify the original state is not mutated.
+    assert session.state.loop_config.loop_detection_enabled is False
+
+
+@pytest.mark.parametrize(
+    "disabled_value",
+    ["false", "False", "no", "0", "off", False, 0],
+)
+def test_execute_interprets_various_falsey_values(disabled_value: object) -> None:
+    """The command treats multiple falsey representations as disabling the feature."""
+    session = Session(
+        "session-id",
+        state=SessionState(
+            loop_config=LoopDetectionConfiguration(loop_detection_enabled=True)
+        ),
+    )
+    command = LoopDetectionCommand()
+
+    result = asyncio.run(command.execute({"enabled": disabled_value}, session))
+
+    assert result.success is True
+    assert result.message == "Loop detection disabled"
+    assert result.data == {"enabled": False}
+    assert isinstance(result.new_state, SessionStateAdapter)
+    assert result.new_state.loop_config.loop_detection_enabled is False
+    # Verify the original state is not mutated.
+    assert session.state.loop_config.loop_detection_enabled is True
 
 
 def test_execute_returns_failure_when_loop_update_raises(


### PR DESCRIPTION
## Summary
- add parameterized tests exercising truthy and falsey "enabled" argument values for the loop detection command
- ensure the command leaves the original session state untouched while returning updated state adapters

## Testing
- `python -m pytest -o addopts="" tests/unit/core/domain/commands/loop_detection_commands/test_loop_detection_command.py`


------
https://chatgpt.com/codex/tasks/task_e_68e431d23cdc8333b1e2ba43c5c1faa6