### PR TITLE
Fix Anthropic controller response status propagation

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -265,6 +265,8 @@ class AnthropicController:
                 if logger.isEnabledFor(logging.INFO):
                     logger.info(f"Returning JSON response: {anthropic_response_data}")
 
+                status_code = getattr(adapted_response, "status_code", 200)
+
                 # If we're using the OpenAI format (choices), convert it to Anthropic format
                 if (
                     isinstance(anthropic_response_data, dict)
@@ -303,6 +305,7 @@ class AnthropicController:
                     return FastAPIResponse(
                         content=json.dumps(anthropic_formatted),
                         media_type="application/json",
+                        status_code=status_code,
                         headers=safe_headers,
                     )
                 else:
@@ -321,6 +324,7 @@ class AnthropicController:
                     return FastAPIResponse(
                         content=json.dumps(anthropic_response_data),
                         media_type="application/json",
+                        status_code=status_code,
                         headers=safe_headers,
                     )
         except LLMProxyError as e:


### PR DESCRIPTION
## Summary
- preserve upstream HTTP status codes when converting non-streaming Anthropic responses to JSON
- reuse the original status code for both OpenAI-formatted and native Anthropic payloads

## Testing
- ./.venv/Scripts/python.exe -m pytest -c /tmp/pytest.ini tests/chat_completions_tests/test_anthropic_frontend.py::test_anthropic_messages_non_streaming_frontend -q
- ./.venv/Scripts/python.exe -m pytest -c /tmp/pytest.ini

------
https://chatgpt.com/codex/tasks/task_e_68e43161a6a48333b662c19739f011db