### PR TITLE
Fix responses controller DI resolution logging

### DIFF
--- a/src/core/app/controllers/__init__.py
+++ b/src/core/app/controllers/__init__.py
@@ -246,14 +246,20 @@ async def get_responses_controller_if_available(
 
     try:
         responses_controller = service_provider.get_service(ResponsesController)
-        logger.debug(
-            f"Got ResponsesController from service provider: {type(responses_controller).__name__}"
-        )
-        logger.debug(
-            f"ResponsesController processor type: {type(responses_controller._processor).__name__}"
-        )
-        if responses_controller:
+        if responses_controller is not None:
+            logger.debug(
+                "Got ResponsesController from service provider: %s",
+                type(responses_controller).__name__,
+            )
+            processor = getattr(responses_controller, "_processor", None)
+            if processor is not None:
+                logger.debug(
+                    "ResponsesController processor type: %s",
+                    type(processor).__name__,
+                )
             return cast(ResponsesController, responses_controller)
+
+        logger.debug("ResponsesController not pre-registered; creating via factory")
         return cast(ResponsesController, get_responses_controller(service_provider))
     except Exception as e:
         logger.exception(


### PR DESCRIPTION
## Summary
- guard responses controller resolution logging to avoid AttributeError when the controller is not registered
- fall back cleanly to constructing a controller via the factory when DI does not provide an instance

## Testing
- python -m pytest *(fails: missing pytest-xdist plugin to satisfy -n option from configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e43161a6a48333b662c19739f011db