### PR TITLE
Fix Responses API schema validation for $ref properties

### DIFF
--- a/tests/unit/core/app/controllers/test_responses_controller.py
+++ b/tests/unit/core/app/controllers/test_responses_controller.py
@@ -1,0 +1,42 @@
+"""Unit tests for the ResponsesController front-end logic."""
+
+import pytest
+
+from src.core.app.controllers.responses_controller import ResponsesController
+
+
+class TestResponsesControllerSchemaValidation:
+    """Tests covering JSON schema validation helper logic."""
+
+    def test_validate_json_schema_allows_ref_only_properties(self) -> None:
+        """Ensure properties that rely on $ref do not raise validation errors."""
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "user": {"$ref": "#/$defs/user"},
+            },
+            "$defs": {
+                "user": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                }
+            },
+        }
+
+        # Should not raise an exception
+        ResponsesController._validate_json_schema(schema)
+
+    def test_validate_json_schema_requires_type_or_structure(self) -> None:
+        """Properties without type or structural keywords should be rejected."""
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "invalid": {},
+            },
+        }
+
+        with pytest.raises(ValueError):
+            ResponsesController._validate_json_schema(schema)


### PR DESCRIPTION
## Summary
- update the Responses API controller to accept JSON schemas that rely on $ref or other structural keywords without an explicit type field and to better normalize multi-type declarations
- relax array validation to allow tuple/list item schemas and reuse the computed type information for required-field checks
- add unit coverage to ensure $ref-only properties are accepted while still rejecting empty property definitions

## Testing
- python -m pytest -o addopts='' tests/unit/core/app/controllers/test_responses_controller.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e43161a6a48333b662c19739f011db