### PR TITLE
Add tests for loop detection command registry

### DIFF
--- a/tests/unit/core/domain/commands/loop_detection_commands/test_registry.py
+++ b/tests/unit/core/domain/commands/loop_detection_commands/test_registry.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from typing import Any
 
 import pytest
-
 from src.core.domain.commands.loop_detection_commands import (
     LoopDetectionCommand,
     ToolLoopDetectionCommand,

--- a/tests/unit/core/domain/commands/loop_detection_commands/test_registry.py
+++ b/tests/unit/core/domain/commands/loop_detection_commands/test_registry.py
@@ -1,0 +1,65 @@
+"""Tests for loop detection command registry helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from src.core.domain.commands.loop_detection_commands import (
+    LoopDetectionCommand,
+    ToolLoopDetectionCommand,
+    ToolLoopMaxRepeatsCommand,
+    ToolLoopModeCommand,
+    ToolLoopTTLCommand,
+    get_loop_detection_command,
+    get_loop_detection_commands,
+)
+
+EXPECTED_COMMANDS: Mapping[str, type[Any]] = {
+    "LoopDetectionCommand": LoopDetectionCommand,
+    "ToolLoopDetectionCommand": ToolLoopDetectionCommand,
+    "ToolLoopMaxRepeatsCommand": ToolLoopMaxRepeatsCommand,
+    "ToolLoopModeCommand": ToolLoopModeCommand,
+    "ToolLoopTTLCommand": ToolLoopTTLCommand,
+}
+
+
+@pytest.mark.parametrize("command_name, command_cls", EXPECTED_COMMANDS.items())
+def test_get_loop_detection_command_returns_registered_class(
+    command_name: str, command_cls: type[Any]
+) -> None:
+    """Each known command name resolves to its registered class."""
+
+    resolved = get_loop_detection_command(command_name)
+
+    assert resolved is command_cls
+
+
+def test_get_loop_detection_command_unknown_name() -> None:
+    """An unknown command name raises a clear ``ValueError``."""
+
+    with pytest.raises(ValueError, match="Unknown loop detection command: unknown"):
+        get_loop_detection_command("unknown")
+
+
+def test_get_loop_detection_commands_returns_copy() -> None:
+    """Mutating a retrieved mapping does not affect the registry state."""
+
+    commands = get_loop_detection_commands()
+
+    # Baseline sanity check for returned mapping contents.
+    assert commands == EXPECTED_COMMANDS
+
+    # Mutate the mapping and ensure a subsequent call is unaffected.
+    mutable_commands = dict(commands)
+    mutable_commands["LoopDetectionCommand"] = type(
+        "DummyLoopDetectionCommand",
+        (),
+        {},
+    )
+
+    fresh_commands = get_loop_detection_commands()
+
+    assert fresh_commands == EXPECTED_COMMANDS


### PR DESCRIPTION
## Summary
- add focused unit tests covering the loop detection command registry helpers
- verify successful resolution of registered commands, error handling for unknown names, and immutability of returned mappings

## Testing
- python -m pytest tests/unit/core/domain/commands/loop_detection_commands/test_registry.py -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e431b79f3483339a071cf75c60a4d4