### PR TITLE
Add coverage tests for loop detection command registry

### DIFF
--- a/tests/unit/core/domain/commands/loop_detection_commands/test_init_module.py
+++ b/tests/unit/core/domain/commands/loop_detection_commands/test_init_module.py
@@ -5,6 +5,14 @@ from types import ModuleType
 
 import pytest
 
+from src.core.domain.commands.loop_detection_commands import (
+    get_loop_detection_command,
+    get_loop_detection_commands,
+)
+from src.core.domain.commands.loop_detection_commands.loop_detection_command import (
+    LoopDetectionCommand,
+)
+
 MODULE_PATH = "src.core.domain.commands.loop_detection_commands"
 EXPECTED_EXPORTS = [
     "LoopDetectionCommand",
@@ -35,3 +43,34 @@ def test_module_exports_resolve_to_public_attributes(name: str) -> None:
     exported_object = getattr(module, name)
 
     assert exported_object.__name__ == name
+
+
+def test_get_loop_detection_command_returns_registered_class() -> None:
+    """``get_loop_detection_command`` returns the requested command class."""
+
+    command_cls = get_loop_detection_command("LoopDetectionCommand")
+
+    assert command_cls is LoopDetectionCommand
+
+
+def test_get_loop_detection_command_with_unknown_name_raises_value_error() -> None:
+    """Requesting an unknown command name raises ``ValueError``."""
+
+    with pytest.raises(ValueError) as exc_info:
+        get_loop_detection_command("unknown-command")
+
+    assert "Unknown loop detection command" in str(exc_info.value)
+
+
+def test_get_loop_detection_commands_returns_independent_copy() -> None:
+    """Modifying the returned mapping does not affect future lookups."""
+
+    first_snapshot = get_loop_detection_commands()
+    assert first_snapshot["LoopDetectionCommand"] is LoopDetectionCommand
+
+    first_snapshot.pop("LoopDetectionCommand")
+
+    second_snapshot = get_loop_detection_commands()
+
+    assert "LoopDetectionCommand" in second_snapshot
+    assert first_snapshot is not second_snapshot


### PR DESCRIPTION
## Summary
- add tests that exercise the loop detection command registry helper functions
- verify that lookups succeed for known commands and raise errors for unknown names
- assert that the registry snapshot returned to callers is isolated from internal state

## Testing
- python -m pytest -o addopts= tests/unit/core/domain/commands/loop_detection_commands/test_init_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e431b79f3483339a071cf75c60a4d4