### PR TITLE
Fix retry-after header when reset time reached

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -36,7 +36,7 @@ def _build_retry_after_header(reset_at: float | None) -> dict[str, str] | None:
         return None
 
     now = time.time()
-    delay_seconds = reset_at - now if reset_at > now else reset_at
+    delay_seconds = reset_at - now if reset_at >= now else reset_at
     if delay_seconds <= 0:
         return {"Retry-After": "0"}
 

--- a/tests/unit/test_transport_adapters.py
+++ b/tests/unit/test_transport_adapters.py
@@ -223,3 +223,8 @@ class TestExceptionAdapters:
         http_exc = map_domain_exception_to_http_exception(rate_error)
         assert http_exc.status_code == 429
         assert http_exc.headers == {"Retry-After": "61"}
+
+        # Test rate limit when reset_at equals current time (immediate retry)
+        immediate_reset_error = RateLimitExceededError("retry now", reset_at=500.0)
+        http_exc = map_domain_exception_to_http_exception(immediate_reset_error)
+        assert http_exc.headers == {"Retry-After": "0"}


### PR DESCRIPTION
## Summary
- treat rate limit reset timestamps equal to the current time as having no remaining delay when building Retry-After headers
- extend the exception adapter tests to cover immediate retry scenarios for rate limits

## Testing
- python -m pytest -o addopts='' tests/unit/test_transport_adapters.py
- python -m pytest -o addopts='' *(fails: missing optional dev dependencies such as pytest_asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e43177d5148333a4f9f4518114a37b