### PR TITLE
Fix invalid isinstance union in FastAPI exception adapter

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -60,7 +60,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE

--- a/tests/unit/test_transport_adapters.py
+++ b/tests/unit/test_transport_adapters.py
@@ -11,6 +11,7 @@ from src.core.common.exceptions import (
     AuthenticationError,
     BackendError,
     ConfigurationError,
+    InvalidRequestError,
     RateLimitExceededError,
 )
 from src.core.domain.request_context import RequestContext
@@ -208,6 +209,11 @@ class TestExceptionAdapters:
         assert http_exc.status_code == 400
         assert isinstance(http_exc.detail, dict)
         assert http_exc.detail.get("details", {}).get("param") == "model"
+
+        invalid_error = InvalidRequestError("Bad payload", details={"field": "messages"})
+        http_exc = map_domain_exception_to_http_exception(invalid_error)
+        assert http_exc.status_code == 400
+        assert http_exc.detail.get("details", {}).get("field") == "messages"
 
         # Test backend error
         backend_error = BackendError("Backend unavailable")


### PR DESCRIPTION
## Summary
- fix the FastAPI exception adapter to use a tuple when checking for configuration versus invalid request errors
- extend the transport adapter test coverage to assert InvalidRequestError mapping to HTTP 400 responses

## Testing
- `python -m pytest -c /tmp/pytest_min.ini tests/unit/test_transport_adapters.py::TestExceptionAdapters::test_map_domain_exception_to_http_exception`
- `python -m pytest -c /tmp/pytest_min.ini` *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e43177d5148333a4f9f4518114a37b