### PR TITLE
Fix Gemini stream chunk bytes handling

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -176,7 +176,7 @@ class GeminiBackend(LLMBackend):
         if isinstance(raw_chunk, dict):
             return raw_chunk
 
-        if isinstance(raw_chunk, bytes | bytearray):
+        if isinstance(raw_chunk, (bytes, bytearray)):
             raw_chunk = raw_chunk.decode("utf-8", errors="ignore")
 
         if not isinstance(raw_chunk, str):

--- a/tests/unit/connectors/test_gemini_stream_chunk_coercion.py
+++ b/tests/unit/connectors/test_gemini_stream_chunk_coercion.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from src.connectors.gemini import GeminiBackend
+
+
+def test_coerce_stream_chunk_accepts_bytes_payload() -> None:
+    chunk = (
+        b"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]}}]}\n\n"
+    )
+
+    result = GeminiBackend._coerce_stream_chunk(chunk)
+
+    assert result == {
+        "candidates": [
+            {"content": {"parts": [{"text": "hi"}]}}
+        ]
+    }


### PR DESCRIPTION
## Summary
- allow `GeminiBackend._coerce_stream_chunk` to decode byte and bytearray payloads without raising a `TypeError`
- add a regression test covering byte-encoded Gemini streaming chunks

## Testing
- `./.venv/Scripts/python.exe -m pytest tests/unit/connectors/test_gemini_stream_chunk_coercion.py -o addopts=`
- `./.venv/Scripts/python.exe -m pytest -o addopts=` *(fails: missing optional pytest plugins such as pytest-asyncio, pytest_httpx, respx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e43146ed4c8333a0ef5c9ba473608d