### PR TITLE
Add helper for command service interfaces

### DIFF
--- a/src/core/interfaces/command_service.py
+++ b/src/core/interfaces/command_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from src.core.domain.processed_result import ProcessedResult
+from src.core.interfaces.command_service_interface import ICommandService
+
+CommandServiceHandler = Callable[[list[Any], str], Awaitable[ProcessedResult]]
+
+
+class FunctionCommandService(ICommandService):
+    """Adapter that turns a coroutine function into an ``ICommandService``."""
+
+    def __init__(self, handler: CommandServiceHandler):
+        if handler is None:
+            raise ValueError("A handler callable must be provided for the command service.")
+        if not callable(handler):
+            raise TypeError("The command service handler must be callable.")
+        self._handler = handler
+
+    async def process_commands(
+        self, messages: list[Any], session_id: str
+    ) -> ProcessedResult:
+        return await self._handler(messages, session_id)
+
+
+def ensure_command_service(
+    service: ICommandService | CommandServiceHandler | None,
+) -> ICommandService:
+    """Validate or adapt a command service value.
+
+    Args:
+        service: Either an ``ICommandService`` instance, an async handler callable,
+            or ``None``.
+
+    Returns:
+        A concrete ``ICommandService`` implementation.
+
+    Raises:
+        ValueError: If ``service`` is ``None``.
+        TypeError: If ``service`` is not an ``ICommandService`` or a valid handler.
+    """
+
+    if service is None:
+        raise ValueError("A command service instance is required.")
+
+    if isinstance(service, ICommandService):
+        return service
+
+    if callable(service):
+        return FunctionCommandService(service)  # type: ignore[arg-type]
+
+    raise TypeError("The provided command service is not valid.")
+
+
+__all__ = ["FunctionCommandService", "ensure_command_service"]

--- a/tests/unit/core/test_command_service_module.py
+++ b/tests/unit/core/test_command_service_module.py
@@ -1,0 +1,63 @@
+import pytest
+
+from src.core.domain.processed_result import ProcessedResult
+from src.core.interfaces.command_service import ensure_command_service
+from src.core.interfaces.command_service_interface import ICommandService
+
+
+class ConcreteCommandService(ICommandService):
+    async def process_commands(
+        self, messages: list[str], session_id: str
+    ) -> ProcessedResult:
+        return ProcessedResult(
+            modified_messages=messages,
+            command_executed=True,
+            command_results=[session_id],
+        )
+
+
+@pytest.mark.asyncio
+async def test_ensure_command_service_accepts_valid_service() -> None:
+    service = ConcreteCommandService()
+
+    validated_service = ensure_command_service(service)
+
+    assert validated_service is service
+
+    result = await validated_service.process_commands(["message"], "session")
+    assert result.command_executed is True
+    assert result.command_results == ["session"]
+    assert result.modified_messages == ["message"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_command_service_wraps_async_callable() -> None:
+    async def handler(messages: list[str], session_id: str) -> ProcessedResult:
+        return ProcessedResult(
+            modified_messages=[f"{session_id}:{value}" for value in messages],
+            command_executed=bool(messages),
+            command_results=[session_id],
+        )
+
+    validated_service = ensure_command_service(handler)
+
+    assert isinstance(validated_service, ICommandService)
+
+    result = await validated_service.process_commands(["message"], "session")
+    assert result.modified_messages == ["session:message"]
+    assert result.command_executed is True
+    assert result.command_results == ["session"]
+
+
+def test_ensure_command_service_rejects_none() -> None:
+    with pytest.raises(ValueError) as exc:
+        ensure_command_service(None)
+
+    assert "command service" in str(exc.value).lower()
+
+
+def test_ensure_command_service_rejects_invalid_type() -> None:
+    with pytest.raises(TypeError) as exc:
+        ensure_command_service(object())
+
+    assert "command service" in str(exc.value).lower()


### PR DESCRIPTION
## Summary
- add a command service helper module that validates and adapts services
- implement a callable adapter to satisfy the ICommandService contract
- cover the new helper with unit tests including error handling paths

## Testing
- python -m pytest -c /tmp/pytest_min.ini tests/unit/core/test_command_service_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e6333471e0833397ec05aaf30a7d12