### PR TITLE
Fix detection of hyphenated in-chat commands

### DIFF
--- a/src/core/services/command_utils.py
+++ b/src/core/services/command_utils.py
@@ -19,8 +19,16 @@ def get_command_pattern(command_prefix: str) -> re.Pattern:
     """
     # Escape special regex characters in the prefix
     escaped_prefix = re.escape(command_prefix)
-    # Pattern to match commands with optional arguments in parentheses
-    return re.compile(rf"{escaped_prefix}(?P<cmd>\w+)(?:\((?P<args>.*?)\))?")
+    # Pattern to match commands with optional arguments in parentheses.
+    # Historically command names have included hyphens (e.g. "project-dir" or
+    # "no-think"), but the previous implementation only used ``\w+`` which
+    # stops matching as soon as a hyphen is encountered. As a result those
+    # commands were never detected even though they are among the most common
+    # interactive commands. Expanding the character class to include hyphens
+    # restores the expected behaviour without affecting existing commands.
+    return re.compile(
+        rf"{escaped_prefix}(?P<cmd>[A-Za-z0-9][A-Za-z0-9_-]*)(?:\((?P<args>.*?)\))?"
+    )
 
 
 class CommandRegistry:

--- a/tests/unit/test_get_command_pattern.py
+++ b/tests/unit/test_get_command_pattern.py
@@ -8,6 +8,11 @@ def test_get_command_pattern_default_prefix() -> None:
     pattern = get_command_pattern(DEFAULT_COMMAND_PREFIX)
     assert pattern.match("!/hello")
     assert pattern.match("!/cmd(arg=val)")
+    # Hyphenated command names are common (e.g. project-dir, no-think)
+    match = pattern.match("!/project-dir(/tmp)")
+    assert match is not None
+    assert match.group("cmd") == "project-dir"
+    assert match.group("args") == "/tmp"
     assert not pattern.match("/hello")
     m = pattern.match("!/hello")
     assert m and m.group("cmd") == "hello" and (m.group("args") or "") == ""


### PR DESCRIPTION
## Summary
- allow the shared command-regex helper to capture hyphenated command names so handlers such as !/project-dir work again
- extend the get_command_pattern unit test to cover hyphenated command detection

## Testing
- python -m pytest tests/unit/test_get_command_pattern.py tests/unit/test_command_utils.py
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e630987d6483339d3193d35c915a6e