### PR TITLE
Fix pytest handler detection for list command payloads

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -60,6 +60,8 @@ def _extract_command(arguments: Any) -> str | None:
         command = arguments.get("command") or arguments.get("cmd")
         if isinstance(command, str) and command.strip():
             return command
+        if isinstance(command, (list, tuple)) and command:
+            return " ".join(str(item) for item in command)
 
         for key in ("input", "body", "data"):
             inner = arguments.get(key)
@@ -67,6 +69,8 @@ def _extract_command(arguments: Any) -> str | None:
                 sub = inner.get("command") or inner.get("cmd")
                 if isinstance(sub, str) and sub.strip():
                     return sub
+                if isinstance(sub, (list, tuple)) and sub:
+                    return " ".join(str(item) for item in sub)
 
         args_list = arguments.get("args")
         if isinstance(args_list, list) and args_list:

--- a/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
+++ b/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
@@ -87,6 +87,24 @@ async def test_handler_passes_through_targeted_pytest() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handler_detects_list_based_command() -> None:
+    handler = PytestFullSuiteHandler(enabled=True)
+    context = ToolCallContext(
+        session_id="session-list",
+        backend_name="backend",
+        model_name="model",
+        full_response={},
+        tool_name="bash",
+        tool_arguments={"command": ["pytest", "-q"]},
+    )
+
+    assert await handler.can_handle(context) is True
+    result = await handler.handle(context)
+
+    assert result.should_swallow is True
+
+
+@pytest.mark.asyncio
 async def test_handler_enabled_flag_controls_behavior() -> None:
     handler = PytestFullSuiteHandler(enabled=False)
     context = _build_context("pytest")


### PR DESCRIPTION
## Summary
- update the pytest full-suite steering handler to normalize list and tuple command payloads
- add a regression test ensuring list-based commands trigger the steering warning

## Testing
- ./.venv/Scripts/python.exe -m pytest -o addopts="" tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- ./.venv/Scripts/python.exe -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e630f8fca88333bc04017b84f4cd5d