### PR TITLE
Fix tool call history mutation bug

### DIFF
--- a/src/core/services/tool_call_reactor_service.py
+++ b/src/core/services/tool_call_reactor_service.py
@@ -8,6 +8,7 @@ tool call handlers and orchestrates their execution.
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -123,16 +124,18 @@ class ToolCallReactorService(IToolCallReactor):
             else:
                 timestamp = datetime.now(timezone.utc)
 
+            history_context = {
+                "backend_name": context.backend_name,
+                "model_name": context.model_name,
+                "calling_agent": context.calling_agent,
+                "timestamp": timestamp,
+                "tool_arguments": copy.deepcopy(context.tool_arguments),
+            }
+
             await self._history_tracker.record_tool_call(
                 context.session_id,
                 context.tool_name,
-                {
-                    "backend_name": context.backend_name,
-                    "model_name": context.model_name,
-                    "calling_agent": context.calling_agent,
-                    "timestamp": timestamp,
-                    "tool_arguments": context.tool_arguments,
-                },
+                history_context,
             )
 
         # Get handlers sorted by priority (highest first)


### PR DESCRIPTION
## Summary
- deep-copy tool call arguments before recording history entries to prevent later mutations from altering stored context
- add regression test ensuring recorded tool arguments remain stable even when the original context is mutated

## Testing
- python -m pytest tests/unit/core/services/test_tool_call_reactor_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e630f8fca88333bc04017b84f4cd5d