### PR TITLE
Fix pytest steering for python tool commands

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -227,11 +227,19 @@ class PytestFullSuiteHandler(IToolCallHandler):
             "container.exec",
         }
 
-        if tool_name not in shell_tools:
-            # Some providers map pytest directly as function name
-            if _PYTEST_ROOT_PATTERN.search(tool_name):
-                arg_str = _extract_command(arguments)
-                return arg_str or tool_name
-            return None
+        command = _extract_command(arguments)
 
-        return _extract_command(arguments)
+        if tool_name in shell_tools:
+            return command
+
+        # Some providers map pytest directly as function name
+        if _PYTEST_ROOT_PATTERN.search(tool_name):
+            return command or tool_name
+
+        if command and _PYTEST_ROOT_PATTERN.search(command):
+            prefix = tool_name.strip()
+            if prefix:
+                return f"{prefix} {command}".strip()
+            return command
+
+        return None


### PR DESCRIPTION
## Summary
- extend the pytest full-suite steering handler to examine extracted commands from non-shell tools
- ensure python-based pytest invocations are normalized and intercepted when they target the full suite
- add unit coverage for python -m pytest flows, including both full-suite and targeted invocations

## Testing
- python -m pytest -o addopts= tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e630f8fca88333bc04017b84f4cd5d