### PR TITLE
Handle Anthropic max_output_tokens alias

### DIFF
--- a/src/anthropic_models.py
+++ b/src/anthropic_models.py
@@ -4,7 +4,7 @@ Pydantic models for Anthropic API request/response structures.
 
 from typing import Any
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from src.core.interfaces.model_bases import DomainModel
 
@@ -22,7 +22,10 @@ class AnthropicMessagesRequest(DomainModel):
     model: str
     messages: list[AnthropicMessage]
     system: str | None = None
-    max_tokens: int | None = None
+    max_tokens: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("max_output_tokens", "max_tokens"),
+    )
     metadata: dict[str, Any] | None = None
     stop_sequences: list[str] | None = Field(default=None, alias="stop_sequences")
     stream: bool | None = False

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
@@ -100,6 +100,23 @@ class TestAnthropicConverters:
         assert openai_req["stop"] == ["STOP", "END"]
         assert openai_req["stream"] is True
 
+    def test_anthropic_to_openai_request_with_max_output_tokens_alias(self) -> None:
+        """Anthropic max_output_tokens should map to OpenAI max_tokens."""
+        anthropic_req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-3-haiku-20240307",
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                ],
+                "max_output_tokens": 77,
+            }
+        )
+
+        openai_req = anthropic_to_openai_request(anthropic_req)
+
+        assert anthropic_req.max_tokens == 77
+        assert openai_req["max_tokens"] == 77
+
     def test_openai_to_anthropic_response_basic(self) -> None:
         """Test basic OpenAI to Anthropic response conversion."""
         openai_response = {


### PR DESCRIPTION
## Summary
- update the AnthropicMessagesRequest model to accept the Anthropic `max_output_tokens` field via an alias
- add a regression test ensuring Anthropic requests with `max_output_tokens` are forwarded with the expected OpenAI `max_tokens`

## Testing
- pytest --override-ini="addopts=" tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
- pytest --override-ini="addopts="

------
https://chatgpt.com/codex/tasks/task_e_68e6323f01ac8333b749af1b97570b1d