### PR TITLE
Fix zero start time handling in performance tracker

### DIFF
--- a/src/performance_tracker.py
+++ b/src/performance_tracker.py
@@ -50,7 +50,7 @@ class PerformanceMetrics(InternalDTO):
 
         end_time = time.time()
         start_time = self._markers.get(f"{self._current_phase}_start")
-        if start_time:
+        if start_time is not None:
             duration = end_time - start_time
 
             # Store the duration based on phase name

--- a/tests/unit/test_performance_tracker.py
+++ b/tests/unit/test_performance_tracker.py
@@ -74,6 +74,17 @@ def test_log_summary_reports_overhead_without_phase_timings(monkeypatch, caplog)
     assert "overhead=1.000s" in message
 
 
+def test_end_phase_handles_zero_start_time(monkeypatch):
+    time_values = _time_sequence(0.0, 1.5)
+    monkeypatch.setattr(performance_tracker.time, "time", time_values)
+
+    metrics = PerformanceMetrics(request_start=0.0)
+    metrics.start_phase("command_processing")
+    metrics.end_phase()
+
+    assert metrics.command_processing_time == 1.5
+
+
 def test_track_request_performance_finalizes(monkeypatch):
     calls: list[PerformanceMetrics] = []
 


### PR DESCRIPTION
## Summary
- ensure PerformanceMetrics records phase durations even when the start timestamp is zero
- add a regression test that covers zero-valued start times for the performance tracker

## Testing
- python -m pytest tests/unit/test_performance_tracker.py --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e63256552c8333b6669b38625e6679