### PR TITLE
Fix Gemini generation config camelCase parsing

### DIFF
--- a/src/core/domain/configuration/gemini_config.py
+++ b/src/core/domain/configuration/gemini_config.py
@@ -121,17 +121,21 @@ class GeminiGenerationConfig(ValueObject, IBackendSpecificConfig):
         ):
             updates["safety_settings"] = config_dict["safetySettings"]
 
-        # Handle generation parameters
-        for param in [
-            "temperature",
-            "top_p",
-            "top_k",
-            "max_output_tokens",
-            "candidate_count",
-            "stop_sequences",
-        ]:
-            if param in config_dict:
-                updates[param] = config_dict[param]
+        # Handle generation parameters (support both snake_case and camelCase)
+        parameter_aliases: dict[str, tuple[str, ...]] = {
+            "temperature": ("temperature",),
+            "top_p": ("top_p", "topP"),
+            "top_k": ("top_k", "topK"),
+            "max_output_tokens": ("max_output_tokens", "maxOutputTokens"),
+            "candidate_count": ("candidate_count", "candidateCount"),
+            "stop_sequences": ("stop_sequences", "stopSequences"),
+        }
+
+        for field_name, aliases in parameter_aliases.items():
+            for alias in aliases:
+                if alias in config_dict:
+                    updates[field_name] = config_dict[alias]
+                    break
 
         return self.model_copy(update=updates)
 

--- a/tests/unit/core/domain/configuration/test_gemini_config.py
+++ b/tests/unit/core/domain/configuration/test_gemini_config.py
@@ -1,0 +1,43 @@
+"""Tests for the Gemini generation configuration helpers."""
+
+from src.core.domain.configuration.gemini_config import GeminiGenerationConfig
+
+
+def test_with_generation_config_supports_camel_case_keys() -> None:
+    """Ensure camelCase generation config keys are parsed correctly."""
+
+    config = GeminiGenerationConfig()
+
+    updated = config.with_generation_config(
+        {
+            "temperature": 0.4,
+            "topP": 0.7,
+            "topK": 32,
+            "maxOutputTokens": 1024,
+            "candidateCount": 2,
+            "stopSequences": ["STOP"],
+        }
+    )
+
+    assert updated.temperature == 0.4
+    assert updated.top_p == 0.7
+    assert updated.top_k == 32
+    assert updated.max_output_tokens == 1024
+    assert updated.candidate_count == 2
+    assert updated.stop_sequences == ["STOP"]
+
+
+def test_with_generation_config_keeps_snake_case_support() -> None:
+    """Verify snake_case keys continue to work for backwards compatibility."""
+
+    config = GeminiGenerationConfig()
+
+    updated = config.with_generation_config(
+        {
+            "top_p": 0.55,
+            "top_k": 16,
+        }
+    )
+
+    assert updated.top_p == 0.55
+    assert updated.top_k == 16


### PR DESCRIPTION
## Summary
- ensure `GeminiGenerationConfig.with_generation_config` accepts both snake_case and camelCase generation parameters
- add regression tests covering camelCase and snake_case input parsing

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/core/domain/configuration/test_gemini_config.py -q
- python -m pytest --override-ini=addopts="" -q *(fails: missing optional dev test dependencies such as pytest_asyncio and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e63264a66c8333aadca9e539b6dd72