### PR TITLE
Handle missing PyYAML in edit precision temperatures config

### DIFF
--- a/src/core/config/edit_precision_temperatures.py
+++ b/src/core/config/edit_precision_temperatures.py
@@ -6,7 +6,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import yaml
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    yaml = None  # type: ignore
+
 from pydantic import Field
 
 from src.core.interfaces.model_bases import DomainModel
@@ -110,6 +114,15 @@ def load_edit_precision_temperatures_config(
         )
     else:
         config_path = Path(config_path)
+
+    if yaml is None:
+        logger.warning(
+            "PyYAML is not installed; edit precision temperature overrides will use defaults"
+        )
+        config = EditPrecisionTemperaturesConfig()
+        if using_default_path:
+            _cached_config = config
+        return config
 
     if not config_path.exists():
         logger.warning(


### PR DESCRIPTION
## Summary
- avoid crashing when the optional PyYAML dependency is absent by guarding the import in the edit precision temperatures loader
- fall back to the default temperature configuration when PyYAML is unavailable

## Testing
- `python -m pytest -o addopts="" tests/unit/core/services/test_edit_precision_response_middleware.py`
- `python -m pytest -o addopts=""` *(fails: missing optional test dependencies such as pytest-asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e63264a66c8333aadca9e539b6dd72