### PR TITLE
Fix Gemini backend stream chunk decoding type check

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -176,7 +176,7 @@ class GeminiBackend(LLMBackend):
         if isinstance(raw_chunk, dict):
             return raw_chunk
 
-        if isinstance(raw_chunk, bytes | bytearray):
+        if isinstance(raw_chunk, (bytes, bytearray)):
             raw_chunk = raw_chunk.decode("utf-8", errors="ignore")
 
         if not isinstance(raw_chunk, str):


### PR DESCRIPTION
## Summary
- prevent `isinstance` from receiving a typing union when coercing Gemini streaming chunks
- ensure byte-oriented streaming responses are decoded correctly before further processing

## Testing
- `python -m pytest -o addopts='' tests/unit/gemini_connector_tests/test_streaming_success.py` *(fails: missing pytest_asyncio dependency)*
- `python -m pytest -o addopts=''` *(fails: missing pytest_asyncio, pytest_httpx, respx, pytest_mock dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e63264a66c8333aadca9e539b6dd72