### PR TITLE
Fix middleware response content preservation

### DIFF
--- a/src/core/services/middleware_application_manager.py
+++ b/src/core/services/middleware_application_manager.py
@@ -104,7 +104,10 @@ class MiddlewareApplicationManager(IMiddlewareApplicationManager):
                     f"Error applying middleware {mw.__class__.__name__}: {e}",
                     exc_info=True,
                 )
-        return processed_response.content or ""
+        content_value = processed_response.content
+        if content_value is None:
+            return ""
+        return content_value
 
     async def _apply_streaming_middleware(
         self,

--- a/src/core/services/streaming/middleware_application_processor.py
+++ b/src/core/services/streaming/middleware_application_processor.py
@@ -64,8 +64,12 @@ class MiddlewareApplicationProcessor(IStreamProcessor):
                 processed_response = result
 
         # Convert back to StreamingContent
+        content_value = processed_response.content
+        if content_value is None:
+            content_value = ""
+
         return StreamingContent(
-            content=processed_response.content or "",
+            content=content_value,
             is_done=content.is_done,
             is_cancellation=content.is_cancellation,
             metadata=processed_response.metadata,

--- a/tests/unit/core/services/test_middleware_content_preservation.py
+++ b/tests/unit/core/services/test_middleware_content_preservation.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from src.core.interfaces.response_processor_interface import (
+    IResponseMiddleware,
+    ProcessedResponse,
+)
+from src.core.services.middleware_application_manager import MiddlewareApplicationManager
+from src.core.services.streaming.middleware_application_processor import (
+    MiddlewareApplicationProcessor,
+)
+from src.core.domain.streaming_content import StreamingContent
+
+
+class _FalsyContentMiddleware(IResponseMiddleware):
+    def __init__(self, content: object) -> None:
+        super().__init__()
+        self._content = content
+
+    async def process(
+        self,
+        response: ProcessedResponse | object,
+        session_id: str,
+        context: dict[str, object],
+        is_streaming: bool = False,
+        stop_event: object | None = None,
+    ) -> ProcessedResponse:
+        metadata = {}
+        usage = None
+        if isinstance(response, ProcessedResponse):
+            metadata = response.metadata
+            usage = response.usage
+        return ProcessedResponse(content=self._content, metadata=metadata, usage=usage)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_preserves_falsy_content() -> None:
+    middleware = _FalsyContentMiddleware({})
+    manager = MiddlewareApplicationManager([middleware])
+
+    result = await manager.apply_middleware("ignored")
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_streaming_preserves_falsy_content() -> None:
+    middleware = _FalsyContentMiddleware([])
+    manager = MiddlewareApplicationManager([middleware])
+
+    async def _source() -> AsyncIterator[ProcessedResponse]:
+        yield ProcessedResponse(content="initial", metadata={"step": 1})
+
+    stream = await manager.apply_middleware(
+        _source(),
+        is_streaming=True,
+        session_id="session",
+    )
+
+    chunks = [chunk async for chunk in stream]
+    assert len(chunks) == 1
+    assert isinstance(chunks[0], ProcessedResponse)
+    assert chunks[0].content == []
+    assert chunks[0].metadata == {"step": 1}
+
+
+@pytest.mark.asyncio
+async def test_stream_processor_preserves_falsy_content() -> None:
+    middleware = _FalsyContentMiddleware(0)
+    processor = MiddlewareApplicationProcessor([middleware])
+    chunk = StreamingContent(content="initial", metadata={"session_id": "s"})
+
+    processed = await processor.process(chunk)
+
+    assert processed.content == 0
+    assert processed.metadata == {"session_id": "s"}


### PR DESCRIPTION
## Summary
- ensure the middleware application manager returns falsy payloads unchanged instead of coercing them to empty strings
- update the streaming middleware processor to preserve falsy chunk content when rebuilding `StreamingContent`
- add regression tests covering non-streaming, streaming, and processor flows for falsy responses

## Testing
- python -m pytest tests/unit/core/services/test_middleware_content_preservation.py
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e63272f6c88333aa6d23520d3b0d47