### PR TITLE
Provide shim module for legacy backend_config import

### DIFF
--- a/src/core/models/__init__.py
+++ b/src/core/models/__init__.py
@@ -1,0 +1,25 @@
+"""Compatibility shims for legacy model module imports."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from src.core.config.app_config import BackendConfig
+
+__all__ = ["BackendConfig"]
+
+
+def _install_backend_config_module() -> None:
+    """Expose ``BackendConfig`` under the legacy module path."""
+
+    module_name = f"{__name__}.backend_config"
+    if module_name in sys.modules:
+        return
+
+    shim = ModuleType(module_name)
+    shim.BackendConfig = BackendConfig
+    sys.modules[module_name] = shim
+
+
+_install_backend_config_module()


### PR DESCRIPTION
## Summary
- add a compatibility shim under src.core.models so older backend validation imports continue to resolve BackendConfig

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/core/app/stages/test_backend_startup_validation.py -x

------
https://chatgpt.com/codex/tasks/task_e_68e63272f6c88333aa6d23520d3b0d47