### PR TITLE
Fix logging redaction for non-string dict keys

### DIFF
--- a/src/core/common/logging_utils.py
+++ b/src/core/common/logging_utils.py
@@ -136,8 +136,8 @@ def redact(value: str, mask: str = "***") -> str:
 
 
 def redact_dict(
-    data: dict[str, Any], redacted_fields: set[str] | None = None, mask: str = "***"
-) -> dict[str, Any]:
+    data: dict[Any, Any], redacted_fields: set[str] | None = None, mask: str = "***"
+) -> dict[Any, Any]:
     """Redact sensitive fields in a dictionary.
 
     Args:
@@ -151,10 +151,16 @@ def redact_dict(
     if redacted_fields is None:
         redacted_fields = DEFAULT_REDACTED_FIELDS
 
-    result: dict[str, Any] = {}
+    normalized_fields = {
+        field.lower() for field in redacted_fields if isinstance(field, str)
+    }
+
+    result: dict[Any, Any] = {}
 
     for key, value in data.items():
-        if key.lower() in redacted_fields:
+        key_lower = key.lower() if isinstance(key, str) else None
+
+        if key_lower is not None and key_lower in normalized_fields:
             if isinstance(value, str):
                 result[key] = redact(value, mask)
             else:


### PR DESCRIPTION
## Summary
- guard `redact_dict` against non-string dictionary keys and normalize custom field names
- extend the logging utility tests to cover the new redaction behavior

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/test_logging_utils.py
- python -m pytest --override-ini addopts="" *(fails: missing optional dev dependencies such as pytest_asyncio/respx in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63272f6c88333aa6d23520d3b0d47