### PR TITLE
Fix numeric boolean coercion for loop detection config

### DIFF
--- a/src/loop_detection/config.py
+++ b/src/loop_detection/config.py
@@ -32,7 +32,7 @@ def _coerce_to_bool(value: Any) -> bool:
             )
         return True
 
-    if isinstance(value, int | float):
+    if isinstance(value, (int, float)):
         return bool(value)
 
     if isinstance(value, bool):

--- a/tests/unit/loop_detection/test_config.py
+++ b/tests/unit/loop_detection/test_config.py
@@ -107,3 +107,9 @@ class TestInternalLoopDetectionConfig:
         assert "content_chunk_size must be positive" in errors
         assert "content_loop_threshold must be positive" in errors
         assert "max_history_length must be positive" in errors
+
+    def test_from_dict_accepts_numeric_boolean_values(self) -> None:
+        """Boolean coercion should handle numeric inputs without raising errors."""
+        config = InternalLoopDetectionConfig.from_dict({"enabled": 0})
+
+        assert config.enabled is False


### PR DESCRIPTION
## Summary
- fix the loop detection configuration boolean coercion to handle numeric values without raising runtime errors
- add a regression test covering numeric inputs passed through `InternalLoopDetectionConfig.from_dict`

## Testing
- pytest -c /tmp/pytest.ini tests/unit/loop_detection/test_config.py
- pytest -c /tmp/pytest.ini *(fails: missing optional pytest plugins such as pytest-asyncio, pytest_httpx, respx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e63272f6c88333aa6d23520d3b0d47