### PR TITLE
Fix pytest full suite handler command extraction

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -63,6 +63,8 @@ def _extract_command(arguments: Any) -> str | None:
 
         for key in ("input", "body", "data"):
             inner = arguments.get(key)
+            if isinstance(inner, str) and inner.strip():
+                return inner
             if isinstance(inner, dict):
                 sub = inner.get("command") or inner.get("cmd")
                 if isinstance(sub, str) and sub.strip():

--- a/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
+++ b/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
@@ -39,6 +39,19 @@ def _build_context(command: str, session_id: str = "session-1") -> ToolCallConte
     )
 
 
+def _build_context_with_input(
+    command: str, session_id: str = "session-1"
+) -> ToolCallContext:
+    return ToolCallContext(
+        session_id=session_id,
+        backend_name="backend",
+        model_name="model",
+        full_response={},
+        tool_name="bash",
+        tool_arguments={"input": command},
+    )
+
+
 @pytest.mark.asyncio
 async def test_handler_swallow_first_full_suite_command() -> None:
     handler = PytestFullSuiteHandler(enabled=True)
@@ -94,3 +107,14 @@ async def test_handler_enabled_flag_controls_behavior() -> None:
     assert await handler.can_handle(context) is False
     result = await handler.handle(context)
     assert result.should_swallow is False
+
+
+@pytest.mark.asyncio
+async def test_handler_detects_command_from_input_string() -> None:
+    handler = PytestFullSuiteHandler(enabled=True)
+    context = _build_context_with_input("pytest")
+
+    assert await handler.can_handle(context) is True
+    result = await handler.handle(context)
+
+    assert result.should_swallow is True


### PR DESCRIPTION
## Summary
- ensure the pytest full suite handler recognises commands supplied through input/body/data string arguments
- add unit coverage for the new extraction path

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68e6329921608333b76de44b6e31ab0f