### PR TITLE
Fix pytest command detection for mixed-case tool names

### DIFF
--- a/src/core/services/pytest_compression_service.py
+++ b/src/core/services/pytest_compression_service.py
@@ -22,6 +22,12 @@ class PytestCompressionService:
             "container.exec",
         ]
 
+        # Normalize tool names for case-insensitive comparison while preserving
+        # the original list for backward-compatible access in tests.
+        self._normalized_shell_tool_names = {
+            name.lower() for name in self.shell_tool_names
+        }
+
         # Pattern to detect pytest in command arguments (supports pytest and py.test aliases)
         self.pytest_pattern = re.compile(r"\bpy\.?test\b", re.IGNORECASE)
 
@@ -103,8 +109,8 @@ class PytestCompressionService:
 
         Returns (True, command_string) if pytest is detected, otherwise None.
         """
-        # Only scan shell execution tools
-        if tool_name not in self.shell_tool_names:
+        # Only scan shell execution tools (case-insensitive match)
+        if tool_name.lower() not in self._normalized_shell_tool_names:
             return None
 
         command_to_check = self._extract_command_string(arguments)

--- a/tests/unit/core/services/pytest_compression_service_input_test.py
+++ b/tests/unit/core/services/pytest_compression_service_input_test.py
@@ -20,3 +20,18 @@ def test_scan_for_pytest_detects_input_string(
     detected, command = result
     assert detected is True
     assert command == "pytest -q"
+
+
+def test_scan_for_pytest_handles_mixed_case_tool_name(
+    service: PytestCompressionService,
+) -> None:
+    """Ensure detection works when the tool name uses different casing."""
+
+    arguments = "pytest --maxfail=1"
+
+    result = service.scan_for_pytest("Bash", arguments)
+
+    assert result is not None
+    detected, command = result
+    assert detected is True
+    assert command == "pytest --maxfail=1"


### PR DESCRIPTION
## Summary
- normalize shell tool identifiers in the pytest compression service so detection works regardless of casing
- add a regression test covering mixed-case tool names when scanning tool calls for pytest commands

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/pytest_compression_service_input_test.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e6329921608333b76de44b6e31ab0f