### PR TITLE
Fix oneoff command backend/model argument parsing

### DIFF
--- a/src/core/domain/commands/oneoff_command.py
+++ b/src/core/domain/commands/oneoff_command.py
@@ -105,6 +105,14 @@ class OneoffCommand(StatelessCommandBase, BaseCommand):
     def _extract_route_argument(self, args: Mapping[str, Any]) -> str | None:
         """Extract the backend/model argument from parsed command args."""
 
+        backend_value = args.get("backend")
+        model_value = args.get("model")
+        if isinstance(backend_value, str) and isinstance(model_value, str):
+            backend_candidate = backend_value.strip()
+            model_candidate = model_value.strip()
+            if backend_candidate and model_candidate:
+                return f"{backend_candidate}/{model_candidate}"
+
         candidate_keys = ("element", "value", "route", "target")
         for key in candidate_keys:
             value = args.get(key)

--- a/tests/unit/commands/oneoff_command_args_parsing_test.py
+++ b/tests/unit/commands/oneoff_command_args_parsing_test.py
@@ -32,3 +32,15 @@ def test_oneoff_accepts_value_arg() -> None:
     assert result.success is True
     assert session.state.backend_config.oneoff_backend == "gemini"
     assert session.state.backend_config.oneoff_model == "gemini-pro"
+
+
+def test_oneoff_accepts_backend_and_model_args() -> None:
+    command, session = _make_command_and_session()
+
+    result = asyncio.run(
+        command.execute({"backend": "openrouter", "model": "gpt-4"}, session)
+    )
+
+    assert result.success is True
+    assert session.state.backend_config.oneoff_backend == "openrouter"
+    assert session.state.backend_config.oneoff_model == "gpt-4"


### PR DESCRIPTION
## Summary
- allow the oneoff command to accept separate backend and model arguments
- add a regression test covering backend/model pair parsing for the oneoff command

## Testing
- python -m pytest --override-ini addopts='' tests/unit/commands/oneoff_command_args_parsing_test.py
- python -m pytest --override-ini addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e6329921608333b76de44b6e31ab0f