### PR TITLE
Fix Gemini thinking budget zero handling

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -456,9 +456,10 @@ class GeminiBackend(LLMBackend):
         generation_config = payload.setdefault("generationConfig", {})
 
         # thinking budget
-        if getattr(request_data, "thinking_budget", None):
+        thinking_budget = getattr(request_data, "thinking_budget", None)
+        if thinking_budget is not None:
             thinking_config = generation_config.setdefault("thinkingConfig", {})
-            thinking_config["thinkingBudget"] = request_data.thinking_budget  # type: ignore[index]
+            thinking_config["thinkingBudget"] = thinking_budget  # type: ignore[index]
 
         # top_k
         if getattr(request_data, "top_k", None) is not None:

--- a/tests/unit/connectors/test_precision_payload_mapping.py
+++ b/tests/unit/connectors/test_precision_payload_mapping.py
@@ -132,6 +132,24 @@ def test_gemini_public_generation_config_clamping_and_topk() -> None:
     assert gc.get("topK") == 50
 
 
+def test_gemini_generation_config_allows_zero_thinking_budget() -> None:
+    cfg = AppConfig()
+    backend = GeminiBackend(
+        httpx.AsyncClient(), cfg, translation_service=TranslationService()
+    )
+    payload: dict[str, Any] = {}
+    req = ChatRequest(
+        model="gemini-pro",
+        messages=_messages(),
+        thinking_budget=0,
+    )
+
+    backend._apply_generation_config(payload, req)
+
+    gc = payload.get("generationConfig", {})
+    assert gc.get("thinkingConfig", {}).get("thinkingBudget") == 0
+
+
 def test_gemini_oauth_personal_builds_topk() -> None:
     cfg = AppConfig()
     backend = GeminiOAuthPersonalConnector(


### PR DESCRIPTION
## Summary
- ensure the Gemini backend forwards explicit thinking_budget values of 0
- add a regression test that validates zero thinking budgets are preserved in the payload

## Testing
- python -m pytest -o addopts='' tests/unit/connectors/test_precision_payload_mapping.py -k zero_thinking_budget -q
- python -m pytest -o addopts='' -q *(fails: missing optional dev dependencies such as pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68e632ad24f48333bdc1911905a90327