### PR TITLE
Fix OpenRouter base URL override handling

### DIFF
--- a/src/connectors/openrouter.py
+++ b/src/connectors/openrouter.py
@@ -67,6 +67,11 @@ class OpenRouterBackend(OpenAIConnector):
         )
         key_name = cast(str, kwargs.get("key_name"))
         api_base_url = kwargs.get("openrouter_api_base_url")
+        if api_base_url is None:
+            api_base_url = kwargs.get("api_base_url")
+
+        if api_base_url is not None and not isinstance(api_base_url, str):
+            raise TypeError("api_base_url must be a string if provided")
 
         if openrouter_headers_provider is not None and not callable(
             openrouter_headers_provider
@@ -125,6 +130,10 @@ class OpenRouterBackend(OpenAIConnector):
         key_name = kwargs.pop("key_name", None)
         api_key = kwargs.pop("api_key", None)
         api_base_url = kwargs.pop("openrouter_api_base_url", None)
+        if api_base_url is None:
+            api_base_url = kwargs.pop("api_base_url", None)
+        if api_base_url is not None and not isinstance(api_base_url, str):
+            raise TypeError("api_base_url must be a string if provided")
 
         original_headers_provider = self.headers_provider
         original_key_name = self.key_name

--- a/tests/unit/openrouter_connector_tests/test_api_base_url_overrides.py
+++ b/tests/unit/openrouter_connector_tests/test_api_base_url_overrides.py
@@ -1,0 +1,85 @@
+import asyncio
+
+import httpx
+
+from src.connectors.openrouter import OpenRouterBackend
+from src.core.config.app_config import AppConfig
+from src.core.domain.chat import ChatMessage, ChatRequest
+
+
+def mock_headers_provider(_: str, api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+class RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(200, json={"id": "ok"})
+
+
+def test_initialize_accepts_generic_api_base_url() -> None:
+    transport = RecordingTransport()
+    client = httpx.AsyncClient(transport=transport)
+    config = AppConfig()
+    backend = OpenRouterBackend(client=client, config=config)
+
+    try:
+        asyncio.run(
+            backend.initialize(
+                api_key="init-key",
+                key_name="init",
+                openrouter_headers_provider=mock_headers_provider,
+                api_base_url="https://alt.invalid/api/v1",
+            )
+        )
+        assert backend.api_base_url == "https://alt.invalid/api/v1"
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_call_allows_generic_api_base_url_override() -> None:
+    transport = RecordingTransport()
+    client = httpx.AsyncClient(transport=transport)
+    config = AppConfig()
+    backend = OpenRouterBackend(client=client, config=config)
+
+    try:
+        asyncio.run(
+            backend.initialize(
+                api_key="init-key",
+                key_name="init",
+                openrouter_headers_provider=mock_headers_provider,
+            )
+        )
+
+        request = ChatRequest(
+            model="openai/gpt-4",
+            messages=[ChatMessage(role="user", content="Hello")],
+            stream=False,
+        )
+
+        asyncio.run(
+            backend.chat_completions(
+                request_data=request,
+                processed_messages=[ChatMessage(role="user", content="Hello")],
+                effective_model="openai/gpt-4",
+                openrouter_headers_provider=mock_headers_provider,
+                key_name="call-key",
+                api_key="call-api-key",
+                api_base_url="https://override.invalid/api/v1",
+            )
+        )
+
+        assert transport.requests, "Expected OpenRouter backend to issue an HTTP request"
+        requested_url = str(transport.requests[0].url)
+        assert requested_url.startswith(
+            "https://override.invalid/api/v1/chat/completions"
+        )
+    finally:
+        asyncio.run(client.aclose())


### PR DESCRIPTION
## Summary
- allow the OpenRouter backend to honor generic `api_base_url` parameters during initialization and per-request overrides
- add regression tests that exercise initialization and per-call overrides using the generic key

## Testing
- python -m pytest -c /tmp/pytest.ini tests/unit/openrouter_connector_tests/test_api_base_url_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68e632ad24f48333bdc1911905a90327