### PR TITLE
Fix OpenAI connector identity header leakage

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -215,11 +215,12 @@ class OpenAIConnector(LLMBackend):
         payload = await self._prepare_payload(
             domain_request, processed_messages, effective_model
         )
+        # Always reset identity for each request to avoid leaking headers between calls
+        self.identity = identity
+
         headers = kwargs.pop("headers_override", None)
         if headers is None:
             try:
-                if identity:
-                    self.identity = identity
                 headers = self.get_headers()
             except Exception:
                 headers = None
@@ -538,11 +539,11 @@ class OpenAIConnector(LLMBackend):
         headers_override = kwargs.pop("headers_override", None)
         resolved_headers: dict[str, str] | None = None
 
+        # Reset identity to the current request context so headers do not leak across calls
+        self.identity = identity
+
         if headers_override is not None:
             resolved_headers = dict(headers_override)
-
-        if identity:
-            self.identity = identity
 
         base_headers: dict[str, str] | None
         try:


### PR DESCRIPTION
## Summary
- reset the OpenAI connector's identity reference at the start of each request to prevent leaking prior identity headers
- add a regression test that ensures identity-specific headers are cleared between chat completion invocations

## Testing
- `pytest --override-ini addopts="" tests/unit/openai_connector_tests/test_streaming_response.py::test_identity_headers_reset_between_calls`
- `pytest --override-ini addopts=""` *(fails: missing optional test dependencies like pytest-asyncio/pytest-httpx in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e632ad24f48333bdc1911905a90327