### PR TITLE
Fix Gemini backend non-streaming serialization

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -552,12 +552,14 @@ class GeminiBackend(LLMBackend):
             data = response.json()
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Gemini response headers: %s", dict(response.headers))
+            domain_response = self.translation_service.to_domain_response(
+                data, source_format="gemini"
+            )
             return ResponseEnvelope(
-                content=self.translation_service.to_domain_response(
-                    data, source_format="gemini"
-                ),
+                content=domain_response.model_dump(),
                 headers=dict(response.headers),
                 status_code=response.status_code,
+                usage=domain_response.usage,
             )
         except httpx.RequestError as e:
             if logger.isEnabledFor(logging.ERROR):

--- a/tests/unit/connectors/test_gemini_backend_response_envelope.py
+++ b/tests/unit/connectors/test_gemini_backend_response_envelope.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from src.connectors.gemini import GeminiBackend
+from src.core.config.app_config import AppConfig
+from src.core.domain.responses import ResponseEnvelope
+from src.core.services.translation_service import TranslationService
+
+
+@pytest.mark.asyncio
+async def test_handle_non_streaming_response_serializes_domain_response() -> None:
+    """Ensure GeminiBackend returns JSON-serializable content with usage metadata."""
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    connector = GeminiBackend(
+        client=mock_client,
+        config=AppConfig(),
+        translation_service=TranslationService(),
+    )
+
+    gemini_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello, world!"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 3,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 8,
+        },
+    }
+
+    mock_http_response = MagicMock()
+    mock_http_response.status_code = 200
+    mock_http_response.json.return_value = gemini_response
+    mock_http_response.headers = {"content-type": "application/json"}
+
+    mock_client.post.return_value = mock_http_response
+
+    envelope = await connector._handle_gemini_non_streaming_response(
+        "https://example.googleapis.com/v1beta/models/gemini-pro",
+        {"contents": []},
+        {"x-goog-api-key": "test"},
+        "gemini-pro",
+    )
+
+    assert isinstance(envelope, ResponseEnvelope)
+    assert isinstance(envelope.content, dict)
+    assert envelope.content["choices"][0]["message"]["content"] == "Hello, world!"
+    assert envelope.usage == {
+        "prompt_tokens": 3,
+        "completion_tokens": 5,
+        "total_tokens": 8,
+    }


### PR DESCRIPTION
## Summary
- ensure the Gemini backend serializes domain responses before building the ResponseEnvelope and preserves usage data
- add a regression test covering the ResponseEnvelope contract for Gemini non-streaming responses

## Testing
- python -m pytest -o addopts='' tests/unit/connectors/test_gemini_backend_response_envelope.py
- python -m pytest -o addopts='' *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e632cb97608333855cfddba77999fd