### PR TITLE
Fix configuration error mapping in FastAPI adapter

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -60,7 +60,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- fix the FastAPI exception adapter to use a tuple when checking for configuration and invalid request errors

## Testing
- python -m pytest -c /dev/null tests/unit/test_transport_adapters.py
- python -m pytest -c /dev/null

------
https://chatgpt.com/codex/tasks/task_e_68e632f16c5c83338759011b2f07d91f