### PR TITLE
Fix BackendConfigProvider dict type guard

### DIFF
--- a/src/core/services/backend_config_provider.py
+++ b/src/core/services/backend_config_provider.py
@@ -61,7 +61,7 @@ class BackendConfigProvider(IBackendConfigProvider):
             # Try dict-style access
             try:
                 cfg = self._app_config.backends.get(lookup_name)
-                if cfg is not None and isinstance(cfg, BackendConfig | dict):
+                if cfg is not None and isinstance(cfg, (BackendConfig, dict)):
                     if isinstance(cfg, dict):
                         cfg = BackendConfig(**cfg)
                     found_configs.append((lookup_name, cfg, "dict"))


### PR DESCRIPTION
## Summary
- fix the dictionary type guard in BackendConfigProvider so dict-based backend definitions are detected without raising

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/core/test_backend_config_provider.py *(fails: interpreter not present in repository environment)*
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -c /tmp/pytest.ini tests/unit/core/test_backend_config_provider.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -c /tmp/pytest.ini *(fails: optional pytest plugins not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e632f16c5c83338759011b2f07d91f