### PR TITLE
Fix Retry-After headers for elapsed rate limit timestamps

### DIFF
--- a/src/core/adapters/exception_adapters.py
+++ b/src/core/adapters/exception_adapters.py
@@ -31,8 +31,9 @@ def _build_retry_after_header(reset_at: float | None) -> dict[str, str] | None:
         return None
 
     now = time.time()
-    delay_seconds = reset_at - now if reset_at > now else reset_at
+    delay_seconds = reset_at - now
     if delay_seconds <= 0:
+        # Timestamp already elapsed; instruct clients they can retry immediately.
         return {"Retry-After": "0"}
 
     return {"Retry-After": str(math.ceil(delay_seconds))}

--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -36,8 +36,9 @@ def _build_retry_after_header(reset_at: float | None) -> dict[str, str] | None:
         return None
 
     now = time.time()
-    delay_seconds = reset_at - now if reset_at > now else reset_at
+    delay_seconds = reset_at - now
     if delay_seconds <= 0:
+        # If the timestamp has already passed, signal that clients can retry now.
         return {"Retry-After": "0"}
 
     return {"Retry-After": str(math.ceil(delay_seconds))}

--- a/tests/unit/test_transport_adapters.py
+++ b/tests/unit/test_transport_adapters.py
@@ -223,3 +223,7 @@ class TestExceptionAdapters:
         http_exc = map_domain_exception_to_http_exception(rate_error)
         assert http_exc.status_code == 429
         assert http_exc.headers == {"Retry-After": "61"}
+
+        expired_rate_error = RateLimitExceededError("slow down", reset_at=450.0)
+        http_exc = map_domain_exception_to_http_exception(expired_rate_error)
+        assert http_exc.headers == {"Retry-After": "0"}


### PR DESCRIPTION
## Summary
- compute Retry-After headers using the elapsed difference so expired timestamps yield an immediate retry value
- update both FastAPI and legacy adapter logic and add unit tests covering elapsed reset times

## Testing
- `./.venv/Scripts/python.exe -m pytest tests/unit/core/adapters/test_exception_adapters.py`
- `./.venv/Scripts/python.exe -m pytest tests/unit/test_transport_adapters.py`
- `./.venv/Scripts/python.exe -m pytest` *(fails: known suite issues including ruff/mypy quality gates and backend startup validation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e632f16c5c83338759011b2f07d91f