### PR TITLE
Fix OpenAI Responses translation to use correct source format

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -625,7 +625,7 @@ class OpenAIConnector(LLMBackend):
         # Convert to domain response first, then back to ensure consistency
         # We'll treat the Responses API response as a special case of OpenAI response
         domain_response = self.translation_service.to_domain_response(
-            response_data, "openai"
+            response_data, "openai-responses"
         )
 
         # Convert back to Responses API format for the final response


### PR DESCRIPTION
## Summary
- ensure the OpenAI connector uses the Responses translation path when normalizing /v1/responses replies

## Testing
- `python -m pytest tests/unit/connectors/test_openai_responses_connector.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e630b1a3b083338ac2ecfe4fe38499