### PR TITLE
Fix canonical request detection in TranslationService

### DIFF
--- a/src/core/services/translation_service.py
+++ b/src/core/services/translation_service.py
@@ -94,7 +94,7 @@ class TranslationService:
             ChatRequest as _ChatRequest,
         )
 
-        if isinstance(request, _Canonical | _ChatRequest):
+        if isinstance(request, (_Canonical, _ChatRequest)):
             return _Canonical.model_validate(request.model_dump())
 
         if source_format == "gemini":

--- a/tests/unit/core/services/test_translation_service.py
+++ b/tests/unit/core/services/test_translation_service.py
@@ -10,6 +10,22 @@ def test_translation_service_initialization():
     assert service is not None, "TranslationService should initialize without errors."
 
 
+def test_to_domain_request_with_canonical_input():
+    service = TranslationService()
+    canonical_request = CanonicalChatRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "Ping"}],
+        }
+    )
+
+    translated = service.to_domain_request(canonical_request, "openai")
+
+    assert isinstance(translated, CanonicalChatRequest)
+    assert translated.model == canonical_request.model
+    assert translated.messages[0].content == "Ping"
+
+
 def test_to_domain_request_gemini():
     service = TranslationService()
     gemini_request = {


### PR DESCRIPTION
## Summary
- prevent TranslationService from using unsupported union syntax when checking canonical chat requests
- add regression test covering canonical input passthrough to TranslationService

## Testing
- python -m pytest tests/unit/core/services/test_translation_service.py
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e630b1a3b083338ac2ecfe4fe38499