### PR TITLE
Fix rewriting for structured chat content

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -28,6 +28,23 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
             original_content = message.get("content")
 
             if not isinstance(original_content, str):
+                if not isinstance(original_content, list):
+                    continue
+
+                for block in original_content:
+                    if not isinstance(block, dict):
+                        continue
+
+                    text_value = block.get("text")
+                    if not isinstance(text_value, str):
+                        continue
+
+                    rewritten_text = self.rewriter.rewrite_prompt(
+                        text_value, role if isinstance(role, str) else ""
+                    )
+                    if rewritten_text != text_value:
+                        block["text"] = rewritten_text
+                        is_rewritten = True
                 continue
 
             rewritten_content = self.rewriter.rewrite_prompt(
@@ -113,6 +130,21 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
 
             original_content = message.get("content")
             if not isinstance(original_content, str):
+                if not isinstance(original_content, list):
+                    continue
+
+                for block in original_content:
+                    if not isinstance(block, dict):
+                        continue
+
+                    text_value = block.get("text")
+                    if not isinstance(text_value, str):
+                        continue
+
+                    rewritten_text = self.rewriter.rewrite_reply(text_value)
+                    if rewritten_text != text_value:
+                        block["text"] = rewritten_text
+                        is_rewritten = True
                 continue
 
             rewritten_content = self.rewriter.rewrite_reply(original_content)


### PR DESCRIPTION
## Summary
- apply replacement rules to text blocks inside OpenAI chat message content lists on both request and response paths
- extend integration coverage to verify structured chat payloads rewrite only textual segments

## Testing
- python -m pytest -o addopts='' tests/integration/test_content_rewriting_middleware.py -k structured
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e630c911f08333abbdc557b04bfec1