### PR TITLE
Fix prompt rewriting for structured chat content

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -25,17 +25,35 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                 continue
 
             role = message.get("role")
+            prompt_type = role if isinstance(role, str) else ""
             original_content = message.get("content")
 
-            if not isinstance(original_content, str):
+            if isinstance(original_content, str):
+                rewritten_content = self.rewriter.rewrite_prompt(
+                    original_content, prompt_type
+                )
+                if original_content != rewritten_content:
+                    message["content"] = rewritten_content
+                    is_rewritten = True
                 continue
 
-            rewritten_content = self.rewriter.rewrite_prompt(
-                original_content, role if isinstance(role, str) else ""
-            )
-            if original_content != rewritten_content:
-                message["content"] = rewritten_content
-                is_rewritten = True
+            if not isinstance(original_content, list):
+                continue
+
+            for block in original_content:
+                if not isinstance(block, dict):
+                    continue
+
+                text_value = block.get("text")
+                if not isinstance(text_value, str):
+                    continue
+
+                rewritten_text = self.rewriter.rewrite_prompt(
+                    text_value, prompt_type
+                )
+                if rewritten_text != text_value:
+                    block["text"] = rewritten_text
+                    is_rewritten = True
 
         return is_rewritten
 


### PR DESCRIPTION
## Summary
- ensure request-side prompt rewriting also processes text blocks inside structured chat message payloads
- add regression coverage confirming structured messages are rewritten while non-text blocks remain untouched

## Testing
- python -m pytest -o addopts="" tests/integration/test_content_rewriting_middleware.py -k structured_text
- python -m pytest -o addopts="" *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e630c911f08333abbdc557b04bfec1