### PR TITLE
Handle boolean subschemas in JSON repair validation

### DIFF
--- a/tests/unit/core/services/test_json_repair_service.py
+++ b/tests/unit/core/services/test_json_repair_service.py
@@ -69,3 +69,18 @@ def test_repair_and_validate_json_parse_failure_strict(
 ) -> None:
     with pytest.raises(JSONParsingError):
         json_repair_service.repair_and_validate_json("not-json", strict=True)
+
+
+def test_validate_response_schema_allows_boolean_subschemas(
+    json_repair_service: JsonRepairService,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "any_value": True,
+            "forbidden": False,
+            "typed": {"type": "string"},
+        },
+    }
+
+    assert json_repair_service.validate_response_schema(schema)


### PR DESCRIPTION
## Summary
- guard JsonRepairService schema validation against boolean and non-dict property definitions so JSON Schema boolean subschemas no longer raise errors
- add coverage ensuring validate_response_schema accepts schemas with boolean property definitions

## Testing
- python -m pytest tests/unit/core/services/test_json_repair_service.py -q --override-ini addopts=""
- python -m pytest --override-ini addopts="" *(fails: ModuleNotFoundError for optional test dependencies such as pytest_asyncio, respx, hypothesis, pytest_httpx, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6327e2730833399a5a8e90c4aeeee