### PR TITLE
Fix isinstance unions in controllers

### DIFF
--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -220,7 +220,7 @@ class ChatController:
                                 or f"chatcmpl-{_uuid.uuid4().hex[:16]}"
                             )
                             created_ts = metadata.get("created")
-                            if isinstance(created_ts, int | float):
+                            if isinstance(created_ts, (int, float)):
                                 created_val = int(created_ts)
                             else:
                                 created_val = int(_time.time())

--- a/src/core/app/controllers/responses_controller.py
+++ b/src/core/app/controllers/responses_controller.py
@@ -604,7 +604,7 @@ class ResponsesController:
         # Validate additional properties if present
         if "additionalProperties" in schema:
             additional_props = schema["additionalProperties"]
-            if not isinstance(additional_props, bool | dict):
+            if not isinstance(additional_props, (bool, dict)):
                 raise ValueError("additionalProperties must be a boolean or schema")
 
         # Validate required fields if present


### PR DESCRIPTION
## Summary
- replace union-type isinstance checks in the chat and responses controllers with tuple-based checks so schema validation and metadata handling no longer raise TypeError at runtime

## Testing
- python -m pytest -o addopts="" tests/unit/core/app/controllers/test_responses_controller.py
- python -m pytest -o addopts="" *(fails: missing optional pytest plugins such as pytest-asyncio, pytest_httpx, respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e632e13e68833393ad98acd5eeb16d