### PR TITLE
Handle whitespace inputs for loop detection command

### DIFF
--- a/src/core/domain/commands/loop_detection_commands/loop_detection_command.py
+++ b/src/core/domain/commands/loop_detection_commands/loop_detection_command.py
@@ -41,7 +41,11 @@ class LoopDetectionCommand(StatelessCommandBase, BaseCommand):
         """Enable or disable loop detection."""
         # Defaults to enabled=True if no value is provided, e.g., !/loop-detection()
         enabled_arg = args.get("enabled", "true")
-        enabled = str(enabled_arg).lower() in ("true", "yes", "1", "on")
+        if isinstance(enabled_arg, bool):
+            enabled = enabled_arg
+        else:
+            normalized_value = str(enabled_arg).strip().lower()
+            enabled = normalized_value in ("true", "yes", "1", "on")
 
         try:
             loop_config = session.state.loop_config.with_loop_detection_enabled(enabled)

--- a/tests/unit/core/domain/commands/loop_detection_commands/test_loop_detection_command.py
+++ b/tests/unit/core/domain/commands/loop_detection_commands/test_loop_detection_command.py
@@ -106,8 +106,11 @@ def test_command_metadata_describes_loop_detection() -> None:
         ("YeS", True),
         ("1", True),
         ("on", True),
+        (True, True),
+        (" true ", True),
         ("0", False),
         ("no", False),
+        (" Off ", False),
         (False, False),
     ],
 )


### PR DESCRIPTION
## Summary
- normalize loop detection command argument parsing to handle boolean objects and whitespace
- extend loop detection command tests to cover additional truthy and falsy inputs

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/domain/commands/loop_detection_commands/test_loop_detection_command.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e6e38e0e5883339f7a6483f594b97b