### PR TITLE
Add tests for loop detection command registry

### DIFF
--- a/tests/unit/commands/loop_detection_commands/test_loop_detection_command_registry.py
+++ b/tests/unit/commands/loop_detection_commands/test_loop_detection_command_registry.py
@@ -1,0 +1,60 @@
+"""Tests for the loop detection command registry helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.core.domain.commands.loop_detection_commands import (
+    LoopDetectionCommand,
+    ToolLoopDetectionCommand,
+    ToolLoopMaxRepeatsCommand,
+    ToolLoopModeCommand,
+    ToolLoopTTLCommand,
+    get_loop_detection_command,
+    get_loop_detection_commands,
+)
+
+
+@pytest.mark.parametrize(
+    ("command_name", "expected_class"),
+    [
+        ("LoopDetectionCommand", LoopDetectionCommand),
+        ("ToolLoopDetectionCommand", ToolLoopDetectionCommand),
+        ("ToolLoopMaxRepeatsCommand", ToolLoopMaxRepeatsCommand),
+        ("ToolLoopModeCommand", ToolLoopModeCommand),
+        ("ToolLoopTTLCommand", ToolLoopTTLCommand),
+    ],
+)
+def test_get_loop_detection_command_returns_registered_class(
+    command_name: str, expected_class: type[LoopDetectionCommand]
+) -> None:
+    """The registry should return the concrete command class for each name."""
+
+    command_cls = get_loop_detection_command(command_name)
+
+    assert command_cls is expected_class
+
+
+def test_get_loop_detection_command_raises_value_error_for_unknown_name() -> None:
+    """An informative ``ValueError`` should be raised for unknown commands."""
+
+    with pytest.raises(ValueError, match="Unknown loop detection command: unknown"):
+        get_loop_detection_command("unknown")
+
+
+def test_get_loop_detection_commands_returns_copy_of_registry() -> None:
+    """The registry function should return a defensive copy of the commands map."""
+
+    first_result = get_loop_detection_commands()
+    first_result["new"] = LoopDetectionCommand
+
+    second_result = get_loop_detection_commands()
+
+    assert "new" not in second_result
+    assert set(second_result) == {
+        "LoopDetectionCommand",
+        "ToolLoopDetectionCommand",
+        "ToolLoopMaxRepeatsCommand",
+        "ToolLoopModeCommand",
+        "ToolLoopTTLCommand",
+    }


### PR DESCRIPTION
## Summary
- add targeted unit tests that exercise the loop detection command registry helpers
- cover success lookups, error handling, and defensive copying behavior

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/commands/loop_detection_commands/test_loop_detection_command_registry.py *(fails: No such file or directory)*
- python -m pytest tests/unit/commands/loop_detection_commands/test_loop_detection_command_registry.py *(fails: missing optional pytest plugins specified by addopts)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e3884db08333bb3aeec6c3b55ab6