### PR TITLE
Fix pytest steering for current directory runs

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -140,10 +140,6 @@ def _looks_like_full_suite(command: str) -> bool:
         ):
             return False
 
-        if stripped == ".":
-            # pytest . explicitly targets current directory
-            return False
-
     return True
 
 

--- a/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
+++ b/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
@@ -20,7 +20,7 @@ from src.core.services.tool_call_handlers.pytest_full_suite_handler import (
         ("pytest tests/unit/test_example.py", False),
         ("pytest some/test/path", False),
         ("pytest some/test/path::TestSuite::test_case", False),
-        ("pytest .", False),
+        ("pytest .", True),
         ("pytest ./tests", False),
     ],
 )
@@ -110,6 +110,17 @@ async def test_handler_passes_through_targeted_pytest() -> None:
     assert await handler.can_handle(context) is False
     result = await handler.handle(context)
     assert result.should_swallow is False
+
+
+@pytest.mark.asyncio
+async def test_handler_flags_pytest_current_directory() -> None:
+    handler = PytestFullSuiteHandler(enabled=True)
+    context = _build_context("pytest .")
+
+    assert await handler.can_handle(context) is True
+    result = await handler.handle(context)
+
+    assert result.should_swallow is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- treat `pytest .` invocations as full-suite runs in the pytest steering handler so they are intercepted like other broad executions
- expand the unit test coverage to expect the stricter detection and ensure the handler swallows current-directory runs

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest --override-ini addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e6e2b4a6c48333b8896fa8b0239a96