### PR TITLE
Fix streaming JSON repair metadata buffering

### DIFF
--- a/src/core/services/streaming/json_repair_processor.py
+++ b/src/core/services/streaming/json_repair_processor.py
@@ -87,12 +87,20 @@ class JsonRepairProcessor(IStreamProcessor):
             return StreamingContent(
                 content=new_text,
                 is_done=content.is_done,
+                is_cancellation=content.is_cancellation,
                 metadata=content.metadata,
                 usage=content.usage,
                 raw_data=content.raw_data,
             )
 
-        return StreamingContent(content="")
+        return StreamingContent(
+            content="",
+            is_done=content.is_done,
+            is_cancellation=content.is_cancellation,
+            metadata=content.metadata,
+            usage=content.usage,
+            raw_data=content.raw_data,
+        )
 
     def _handle_non_json_text(self, text: str, i: int, n: int) -> tuple[int, list[str]]:
         out_parts: list[str] = []

--- a/tests/unit/core/services/test_json_repair_processor.py
+++ b/tests/unit/core/services/test_json_repair_processor.py
@@ -138,3 +138,24 @@ async def test_stream_with_multiple_reparable_json_objects(
         processor, "Text1 {'a': 1,} Text2 {'b': 2,} Text3"
     )
     assert result == 'Text1 {"a": 1} Text2 {"b": 2} Text3'
+
+
+@pytest.mark.asyncio
+async def test_buffered_chunks_preserve_metadata_and_usage(
+    processor: JsonRepairProcessor,
+) -> None:
+    chunk = StreamingContent(
+        content='{"partial": ',
+        metadata={"id": "chunk-123"},
+        usage={"prompt_tokens": 4},
+        raw_data={"raw": "data"},
+    )
+
+    result = await processor.process(chunk)
+
+    assert result.content == ""
+    assert result.metadata == {"id": "chunk-123"}
+    assert result.usage == {"prompt_tokens": 4}
+    assert result.raw_data == {"raw": "data"}
+    assert not result.is_done
+    assert not result.is_cancellation


### PR DESCRIPTION
## Summary
- ensure `JsonRepairProcessor` keeps cancellation flag, metadata, usage, and raw data when emitting buffered chunks
- add a regression test covering metadata and usage retention for buffered streaming content

## Testing
- `python -m pytest -c /tmp/pytest-no-addopts.ini tests/unit/core/services/test_json_repair_processor.py`
- `python -m pytest -c /tmp/pytest-no-addopts.ini` *(fails: missing pytest_asyncio/respx/pytest_httpx/pytest_mock dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e3021b908333a22f09c12f67e7fe