### PR TITLE
Fix streaming JSON processor flush fallback for missing values

### DIFF
--- a/src/core/services/streaming/json_repair_processor.py
+++ b/src/core/services/streaming/json_repair_processor.py
@@ -190,6 +190,7 @@ class JsonRepairProcessor(IStreamProcessor):
             buf = self._buffer
             if not self._in_string and buf.rstrip().endswith(":"):
                 buf = buf + " null"
+                self._buffer = buf
             repaired_final = self._service.repair_and_validate_json(
                 buf, schema=self._schema, strict=self._strict_mode
             )

--- a/tests/unit/json_repair_processor_test.py
+++ b/tests/unit/json_repair_processor_test.py
@@ -32,3 +32,17 @@ def test_json_repair_processor_flushes_raw_buffer_when_repair_returns_none() -> 
     result = asyncio.run(processor.process(chunk))
 
     assert result.content == '{"foo": "bar"}'
+
+
+def test_json_repair_processor_appends_null_when_value_missing() -> None:
+    processor = JsonRepairProcessor(
+        repair_service=FailingJsonRepairService(),
+        buffer_cap_bytes=1024,
+        strict_mode=False,
+    )
+
+    chunk = StreamingContent(content='{"foo":', is_done=True)
+
+    result = asyncio.run(processor.process(chunk))
+
+    assert result.content == '{"foo": null'


### PR DESCRIPTION
## Summary
- ensure the streaming JSON repair processor preserves filler values when flushing incomplete key/value pairs
- add a regression test covering the flush path when the repair service cannot fix the payload

## Testing
- python -m pytest -o addopts="" tests/unit/json_repair_processor_test.py
- python -m pytest -o addopts="" *(fails: missing optional test dependencies such as pytest_asyncio, pytest_httpx, respx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e3021b908333a22f09c12f67e7fe