### PR TITLE
Fix Gemini stream chunk type check

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -176,7 +176,7 @@ class GeminiBackend(LLMBackend):
         if isinstance(raw_chunk, dict):
             return raw_chunk
 
-        if isinstance(raw_chunk, bytes | bytearray):
+        if isinstance(raw_chunk, (bytes, bytearray)):
             raw_chunk = raw_chunk.decode("utf-8", errors="ignore")
 
         if not isinstance(raw_chunk, str):


### PR DESCRIPTION
## Summary
- fix the Gemini connector's stream chunk type guard so it accepts bytes payloads

## Testing
- python -m pytest -o addopts='' tests/unit/connectors/test_gemini_stream_chunk_coercion.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e6e31abe0483339987a5ff984c1f12