### PR TITLE
Fix Gemini reasoning effort mapping

### DIFF
--- a/tests/integration/test_custom_model_parameters.py
+++ b/tests/integration/test_custom_model_parameters.py
@@ -229,10 +229,10 @@ class TestCustomModelParameters:
         payload = json.loads(sent_request.content)
         assert "generationConfig" in payload
         assert "thinkingConfig" in payload["generationConfig"]
-        assert "reasoning_effort" in payload["generationConfig"]["thinkingConfig"]
-        assert (
-            payload["generationConfig"]["thinkingConfig"]["reasoning_effort"] == "high"
-        )
+        thinking_config = payload["generationConfig"]["thinkingConfig"]
+        assert "thinkingBudget" in thinking_config
+        assert thinking_config["thinkingBudget"] == -1
+        assert thinking_config.get("includeThoughts") is True
 
     @pytest.mark.asyncio
     async def test_anthropic_reasoning_effort_parameter(


### PR DESCRIPTION
## Summary
- map `reasoning_effort` to Gemini's `thinkingBudget` in the connector so requests remain API-compatible
- update the integration test to assert the Gemini payload exposes `thinkingBudget` and `includeThoughts`

## Testing
- `python -m pytest tests/integration/test_custom_model_parameters.py::TestCustomModelParameters::test_gemini_reasoning_effort_parameter -q -o addopts=''`
- `python -m pytest -q -o addopts=''` *(fails: missing optional dev dependencies such as pytest_asyncio, pytest_httpx, respx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e31abe0483339987a5ff984c1f12