### PR TITLE
Fix OpenAI processed message normalization

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -281,7 +281,7 @@ class OpenAIConnector(LLMBackend):
                     return getattr(message, key, None)
 
                 def _normalize_content(value: Any) -> Any:
-                    if isinstance(value, list | tuple):
+                    if isinstance(value, (list, tuple)):
                         normalized_parts: list[Any] = []
                         for part in value:
                             if hasattr(part, "model_dump") and callable(


### PR DESCRIPTION
## Summary
- fix OpenAI payload normalization by using tuple checks when flattening processed message content
- add a regression test ensuring list-based message content is forwarded to the OpenAI payload without being dropped

## Testing
- python3 -m pytest tests/unit/connectors/test_precision_payload_mapping.py
- python3 -m pytest *(fails: ruff linting and other pre-existing suite checks)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e31abe0483339987a5ff984c1f12