### PR TITLE
Ensure structured output middleware rethrows unexpected errors in strict mode

### DIFF
--- a/src/core/services/structured_output_middleware.py
+++ b/src/core/services/structured_output_middleware.py
@@ -175,7 +175,8 @@ class StructuredOutputMiddleware(IResponseMiddleware):
 
         except Exception as e:
             logger.error(
-                f"Unexpected error in structured output middleware for session {session_id}: {e}"
+                f"Unexpected error in structured output middleware for session {session_id}: {e}",
+                exc_info=True,
             )
 
             # Add error information to the response metadata
@@ -202,7 +203,10 @@ class StructuredOutputMiddleware(IResponseMiddleware):
                     metadata=metadata,
                 )
 
-            # Always return the original response for unexpected errors
+            if strict_validation:
+                raise
+
+            # Always return the original response for unexpected errors in non-strict mode
             return response
 
     def _extract_content(self, response: Any) -> str | None:

--- a/tests/unit/core/services/test_structured_output_middleware.py
+++ b/tests/unit/core/services/test_structured_output_middleware.py
@@ -1,0 +1,40 @@
+"""Tests for StructuredOutputMiddleware error handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.core.services.structured_output_middleware import StructuredOutputMiddleware
+
+
+class DummyJsonRepairService:
+    """A dummy repair service that raises an unexpected error."""
+
+    def process_structured_response(self, **_: object) -> tuple[str, dict[str, object] | None]:
+        raise RuntimeError("boom")
+
+
+class DummyResponse:
+    """Response object with content and metadata attributes."""
+
+    def __init__(self) -> None:
+        self.content = "{}"
+        self.metadata: dict[str, object] | None = {}
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_raises_when_strict_validation_enabled() -> None:
+    middleware = StructuredOutputMiddleware(DummyJsonRepairService())
+    response = DummyResponse()
+    context = {
+        "response_schema": {"type": "object"},
+        "strict_schema_validation": True,
+    }
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await middleware.process(
+            response=response,
+            session_id="session-123",
+            context=context,
+        )
+


### PR DESCRIPTION
## Summary
- ensure structured output middleware logs unexpected failures with stack traces and re-raises them when strict validation is enabled
- add a regression test verifying that unexpected errors propagate when strict schema validation is requested

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_structured_output_middleware.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e6e3530f048333a4fd8866580e2ab0