### PR TITLE
Fix FastAPI exception adapter configuration error union check

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -64,7 +64,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- replace the invalid union expression in the FastAPI exception adapter with a tuple so isinstance checks run correctly
- ensure configuration and invalid request errors continue to map to HTTP 400 without raising a TypeError

## Testing
- python -m pytest -p no:xdist --override-ini="addopts=" tests/unit/test_transport_adapters.py -k map_domain_exception_to_http_exception
- python -m pytest -p no:xdist --override-ini="addopts=" *(fails: missing optional dev dependencies such as pytest_asyncio, pytest_httpx, respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e3530f048333a4fd8866580e2ab0