### PR TITLE
Fix invalid isinstance union usage in exception adapter

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -64,7 +64,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- fix map_domain_exception_to_http_exception to use a tuple for configuration and invalid request errors so isinstance works at runtime

## Testing
- python -m pytest -c /tmp/pytest.ini tests/unit/test_transport_adapters.py

------
https://chatgpt.com/codex/tasks/task_e_68e6e3530f048333a4fd8866580e2ab0