### PR TITLE
Handle DI core registration failures

### DIFF
--- a/src/core/di/services.py
+++ b/src/core/di/services.py
@@ -142,10 +142,18 @@ def get_service_collection() -> ServiceCollection:
         # order-dependent failures. register_core_services is idempotent.
         try:
             register_core_services(_service_collection, None)
-        except Exception:
+        except Exception as exc:
             logging.getLogger(__name__).exception(
                 "Failed to register core services into global service collection"
             )
+            _service_collection = None
+            raise ServiceResolutionError(
+                "Failed to register core services",
+                details={
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+            ) from exc
     return _service_collection
 
 


### PR DESCRIPTION
## Summary
- raise a ServiceResolutionError when initial core service registration fails and clear the cached collection
- cover the failure scenario with a dedicated unit test for get_service_collection

## Testing
- python -m pytest tests/unit/core/di/test_service_registration.py
- python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68e6e3530f048333a4fd8866580e2ab0