### PR TITLE
Preserve Model command result details

### DIFF
--- a/src/core/commands/handlers/model_command_handler.py
+++ b/src/core/commands/handlers/model_command_handler.py
@@ -50,9 +50,9 @@ class ModelCommandHandler(ICommandHandler):
 
         if self._command_service is not None:
             return CommandResult(
-                name=result.name,
-                success=True,
-                message="Model command executed",
+                name=result.name or self.command_name,
+                success=result.success,
+                message=result.message,
                 data=getattr(result, "data", None),
                 new_state=getattr(result, "new_state", None),
             )

--- a/tests/unit/commands/test_unit_model_command_handler.py
+++ b/tests/unit/commands/test_unit_model_command_handler.py
@@ -46,3 +46,16 @@ def test_model_command_handler_unsets_model() -> None:
     assert result.message == "Model unset"
     assert result.new_state is not None
     assert result.new_state.backend_config.model is None
+
+
+def test_model_command_handler_preserves_message_with_service() -> None:
+    handler = ModelCommandHandler(command_service=object())
+    session = Session(session_id="test-session")
+    command = Command(name="model", args={"name": "gpt-4-turbo"})
+
+    result = asyncio.run(handler.handle(command, session))
+
+    assert result.success is True
+    assert result.message == "Model changed to gpt-4-turbo"
+    assert result.new_state is not None
+    assert result.new_state.backend_config.model == "gpt-4-turbo"


### PR DESCRIPTION
## Summary
- ensure the interactive model command handler keeps the domain result details when a command service is injected
- add a regression unit test covering the command service scenario to prevent message regressions

## Testing
- pytest -n0 tests/unit/commands/test_unit_model_command_handler.py -q
- pytest -n0 *(fails: missing optional test dependencies such as pytest_httpx, respx, hypothesis, freezegun, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e27bfb5c833385377e0c7cfacba1