### PR TITLE
Add compatibility methods to command settings service

### DIFF
--- a/src/core/services/command_settings_service.py
+++ b/src/core/services/command_settings_service.py
@@ -22,7 +22,10 @@ class CommandSettingsService(ICommandSettingsService):
     """
 
     def __init__(
-        self, default_command_prefix: str = "!/", default_api_key_redaction: bool = True
+        self,
+        default_command_prefix: str = "!/",
+        default_api_key_redaction: bool = True,
+        default_disable_interactive_commands: bool = False,
     ) -> None:
         """Initialize the command settings service.
 
@@ -32,8 +35,12 @@ class CommandSettingsService(ICommandSettingsService):
         """
         self._command_prefix = default_command_prefix
         self._api_key_redaction_enabled = default_api_key_redaction
+        self._disable_interactive_commands = default_disable_interactive_commands
         self._default_command_prefix = default_command_prefix
         self._default_api_key_redaction = default_api_key_redaction
+        self._default_disable_interactive_commands = (
+            default_disable_interactive_commands
+        )
 
     @property
     def command_prefix(self) -> str:
@@ -69,10 +76,37 @@ class CommandSettingsService(ICommandSettingsService):
         self._api_key_redaction_enabled = value
         logger.debug(f"API key redaction {'enabled' if value else 'disabled'}")
 
+    @property
+    def disable_interactive_commands(self) -> bool:
+        """Get whether interactive commands are disabled."""
+        return self._disable_interactive_commands
+
+    @disable_interactive_commands.setter
+    def disable_interactive_commands(self, value: bool) -> None:
+        """Set whether interactive commands are disabled."""
+        self.set_disable_interactive_commands(value)
+
+    def get_command_prefix(self) -> str:
+        """Compatibility getter for legacy command settings access."""
+        return self._command_prefix
+
+    def get_api_key_redaction_enabled(self) -> bool:
+        """Compatibility getter for legacy command settings access."""
+        return self._api_key_redaction_enabled
+
+    def get_disable_interactive_commands(self) -> bool:
+        """Compatibility getter for legacy command settings access."""
+        return self._disable_interactive_commands
+
+    def set_disable_interactive_commands(self, disabled: bool) -> None:
+        """Update disable-interactive-commands flag for compatibility users."""
+        self._disable_interactive_commands = bool(disabled)
+
     def reset_to_defaults(self) -> None:
         """Reset all settings to their default values."""
         self._command_prefix = self._default_command_prefix
         self._api_key_redaction_enabled = self._default_api_key_redaction
+        self._disable_interactive_commands = self._default_disable_interactive_commands
         logger.debug("Command settings reset to defaults")
 
 

--- a/tests/unit/core/services/test_command_settings_service.py
+++ b/tests/unit/core/services/test_command_settings_service.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from src.core.services.command_settings_service import CommandSettingsService
+
+
+class TestCommandSettingsService:
+    def test_compatibility_getters_reflect_current_values(self) -> None:
+        service = CommandSettingsService(
+            default_command_prefix="$/",
+            default_api_key_redaction=False,
+            default_disable_interactive_commands=True,
+        )
+
+        assert service.get_command_prefix() == "$/"
+        assert service.get_api_key_redaction_enabled() is False
+        assert service.get_disable_interactive_commands() is True
+
+        service.command_prefix = "#/"
+        service.api_key_redaction_enabled = True
+        service.disable_interactive_commands = False
+
+        assert service.get_command_prefix() == "#/"
+        assert service.get_api_key_redaction_enabled() is True
+        assert service.get_disable_interactive_commands() is False
+
+    def test_reset_to_defaults_restores_original_values(self) -> None:
+        service = CommandSettingsService(
+            default_command_prefix="!/",
+            default_api_key_redaction=True,
+            default_disable_interactive_commands=False,
+        )
+
+        service.command_prefix = "#/"
+        service.api_key_redaction_enabled = False
+        service.disable_interactive_commands = True
+
+        service.reset_to_defaults()
+
+        assert service.command_prefix == "!/"
+        assert service.api_key_redaction_enabled is True
+        assert service.disable_interactive_commands is False
+        assert service.get_command_prefix() == "!/"
+        assert service.get_api_key_redaction_enabled() is True
+        assert service.get_disable_interactive_commands() is False
+


### PR DESCRIPTION
## Summary
- add legacy-friendly getter and setter helpers to the command settings service so existing code can read and update the disable-interactive-commands flag without errors
- expose compatibility accessors for command prefix and redaction settings while keeping reset-to-defaults in sync
- cover the new behaviour with targeted unit tests for CommandSettingsService

## Testing
- python -m pytest tests/unit/core/services/test_command_settings_service.py
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6e27bfb5c833385377e0c7cfacba1