### PR TITLE
Fix Responses API input normalization

### DIFF
--- a/src/core/domain/translation.py
+++ b/src/core/domain/translation.py
@@ -199,6 +199,163 @@ class Translation(BaseTranslator):
             }
 
     @staticmethod
+    def _normalize_responses_input_to_messages(input_payload: Any) -> list[dict[str, Any]]:
+        """Coerce OpenAI Responses API input payloads into chat messages."""
+
+        def _normalize_message_entry(entry: Any) -> dict[str, Any] | None:
+            if entry is None:
+                return None
+
+            if isinstance(entry, str):
+                return {"role": "user", "content": entry}
+
+            if isinstance(entry, dict):
+                role = str(entry.get("role") or "user")
+                message: dict[str, Any] = {"role": role}
+
+                content = Translation._normalize_responses_content(entry.get("content"))
+                if content is not None:
+                    message["content"] = content
+
+                if "name" in entry and entry.get("name") is not None:
+                    message["name"] = entry["name"]
+
+                if "tool_calls" in entry and entry.get("tool_calls") is not None:
+                    message["tool_calls"] = entry["tool_calls"]
+
+                if "tool_call_id" in entry and entry.get("tool_call_id") is not None:
+                    message["tool_call_id"] = entry["tool_call_id"]
+
+                return message
+
+            # Fallback: convert to string representation
+            return {"role": "user", "content": str(entry)}
+
+        if input_payload is None:
+            return []
+
+        if isinstance(input_payload, (str, bytes)):
+            text_value = (
+                input_payload.decode("utf-8", "ignore")
+                if isinstance(input_payload, (bytes, bytearray))
+                else input_payload
+            )
+            return [{"role": "user", "content": text_value}]
+
+        if isinstance(input_payload, dict):
+            normalized = _normalize_message_entry(input_payload)
+            return [normalized] if normalized else []
+
+        if isinstance(input_payload, list | tuple):
+            messages: list[dict[str, Any]] = []
+            for item in input_payload:
+                normalized = _normalize_message_entry(item)
+                if normalized:
+                    messages.append(normalized)
+            return messages
+
+        # Unknown type - coerce to a single user message
+        return [{"role": "user", "content": str(input_payload)}]
+
+    @staticmethod
+    def _normalize_responses_content(content: Any) -> Any:
+        """Normalize Responses API content blocks into chat-compatible structures."""
+
+        def _coerce_text_value(value: Any) -> str:
+            if isinstance(value, str):
+                return value
+            if isinstance(value, (bytes, bytearray)):
+                return value.decode("utf-8", "ignore")
+            if isinstance(value, list):
+                segments: list[str] = []
+                for segment in value:
+                    if isinstance(segment, dict):
+                        segments.append(_coerce_text_value(segment.get("text")))
+                    else:
+                        segments.append(str(segment))
+                return "".join(segments)
+            if isinstance(value, dict) and "text" in value:
+                return _coerce_text_value(value.get("text"))
+            return str(value) if value is not None else ""
+
+        if content is None:
+            return None
+
+        if isinstance(content, (str, bytes, bytearray)):
+            return _coerce_text_value(content)
+
+        if isinstance(content, dict):
+            normalized_parts = Translation._normalize_responses_content_part(content)
+            if not normalized_parts:
+                return None
+            if len(normalized_parts) == 1 and normalized_parts[0].get("type") == "text":
+                return normalized_parts[0]["text"]
+            return normalized_parts
+
+        if isinstance(content, list | tuple):
+            collected_parts: list[dict[str, Any]] = []
+            for part in content:
+                if isinstance(part, dict):
+                    collected_parts.extend(
+                        Translation._normalize_responses_content_part(part)
+                    )
+                elif isinstance(part, (str, bytes, bytearray)):
+                    collected_parts.append(
+                        {"type": "text", "text": _coerce_text_value(part)}
+                    )
+            if not collected_parts:
+                return None
+            if len(collected_parts) == 1 and collected_parts[0].get("type") == "text":
+                return collected_parts[0]["text"]
+            return collected_parts
+
+        return str(content)
+
+    @staticmethod
+    def _normalize_responses_content_part(part: dict[str, Any]) -> list[dict[str, Any]]:
+        """Normalize a single Responses API content part."""
+
+        part_type = str(part.get("type") or "").lower()
+        normalized_parts: list[dict[str, Any]] = []
+
+        if part_type in {"text", "input_text", "output_text"}:
+            text_value = part.get("text")
+            if text_value is None:
+                text_value = part.get("value")
+            normalized_parts.append(
+                {"type": "text", "text": Translation._safe_string(text_value)}
+            )
+        elif "image" in part_type:
+            image_payload = (
+                part.get("image_url")
+                or part.get("imageUrl")
+                or part.get("image")
+                or part.get("image_data")
+            )
+            if isinstance(image_payload, str):
+                image_payload = {"url": image_payload}
+            if isinstance(image_payload, dict) and image_payload.get("url"):
+                normalized_parts.append({"type": "image_url", "image_url": image_payload})
+        elif part_type == "tool_call":
+            # Tool call parts are handled elsewhere in the pipeline; ignore here.
+            return []
+        else:
+            # Preserve already-normalized structures (e.g., function calls) as-is
+            normalized_parts.append(part)
+
+        return [p for p in normalized_parts if p]
+
+    @staticmethod
+    def _safe_string(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode("utf-8", "ignore")
+        return str(value)
+
+    @staticmethod
     def _map_gemini_finish_reason(finish_reason: str | None) -> str | None:
         """Map Gemini finish reasons to canonical values."""
         if finish_reason is None:
@@ -1785,38 +1942,55 @@ class Translation(BaseTranslator):
         """
         from src.core.domain.responses_api import ResponsesRequest
 
-        # Handle both dict and object formats
+        # Normalize incoming payload regardless of format (dict, model, or object)
+        def _prepare_payload(payload: dict[str, Any]) -> dict[str, Any]:
+            normalized_payload = dict(payload)
+            if "messages" not in normalized_payload and "input" in normalized_payload:
+                normalized_payload["messages"] = (
+                    Translation._normalize_responses_input_to_messages(
+                        normalized_payload["input"]
+                    )
+                )
+            return normalized_payload
+
         if isinstance(request, dict):
-            # Convert dict to ResponsesRequest for validation
-            responses_request = ResponsesRequest(**request)
+            request_payload = _prepare_payload(request)
+            responses_request = ResponsesRequest(**request_payload)
         elif hasattr(request, "model_dump"):
-            # Already a Pydantic model
+            request_payload = _prepare_payload(request.model_dump())
             responses_request = (
                 request
                 if isinstance(request, ResponsesRequest)
-                else ResponsesRequest(**request.model_dump())
+                else ResponsesRequest(**request_payload)
             )
         else:
-            # Try to extract attributes
-            responses_request = ResponsesRequest(
-                model=request.model,
-                messages=getattr(request, "messages", []),
-                response_format=request.response_format,
-                max_tokens=getattr(request, "max_tokens", None),
-                temperature=getattr(request, "temperature", None),
-                top_p=getattr(request, "top_p", None),
-                n=getattr(request, "n", None),
-                stream=getattr(request, "stream", None),
-                stop=getattr(request, "stop", None),
-                presence_penalty=getattr(request, "presence_penalty", None),
-                frequency_penalty=getattr(request, "frequency_penalty", None),
-                logit_bias=getattr(request, "logit_bias", None),
-                user=getattr(request, "user", None),
-                seed=getattr(request, "seed", None),
-                session_id=getattr(request, "session_id", None),
-                agent=getattr(request, "agent", None),
-                extra_body=getattr(request, "extra_body", None),
-            )
+            request_payload = {
+                "model": getattr(request, "model", None),
+                "messages": getattr(request, "messages", None),
+                "response_format": getattr(request, "response_format", None),
+                "max_tokens": getattr(request, "max_tokens", None),
+                "temperature": getattr(request, "temperature", None),
+                "top_p": getattr(request, "top_p", None),
+                "n": getattr(request, "n", None),
+                "stream": getattr(request, "stream", None),
+                "stop": getattr(request, "stop", None),
+                "presence_penalty": getattr(request, "presence_penalty", None),
+                "frequency_penalty": getattr(request, "frequency_penalty", None),
+                "logit_bias": getattr(request, "logit_bias", None),
+                "user": getattr(request, "user", None),
+                "seed": getattr(request, "seed", None),
+                "session_id": getattr(request, "session_id", None),
+                "agent": getattr(request, "agent", None),
+                "extra_body": getattr(request, "extra_body", None),
+            }
+
+            input_value = getattr(request, "input", None)
+            if (not request_payload.get("messages")) and input_value is not None:
+                request_payload["messages"] = (
+                    Translation._normalize_responses_input_to_messages(input_value)
+                )
+
+            responses_request = ResponsesRequest(**request_payload)
 
         # Prepare extra_body with response format
         extra_body = responses_request.extra_body or {}


### PR DESCRIPTION
## Summary
- normalize OpenAI Responses API `input` payloads into canonical chat messages before validation
- add coverage ensuring string and structured `input` values translate into domain requests

## Testing
- `python -m pytest tests/unit/core/services/test_translation_service.py::test_responses_to_domain_request_with_input_field tests/unit/core/services/test_translation_service.py::test_responses_to_domain_request_with_string_input` (pass)
- `python -m pytest` *(fails: suite has numerous pre-existing errors and snapshot mismatches; run interrupted after reporting failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e28a2708833383cb78fca79ca381