### PR TITLE
Handle developer prompts in content rewriting

### DIFF
--- a/src/core/services/content_rewriter_service.py
+++ b/src/core/services/content_rewriter_service.py
@@ -144,9 +144,11 @@ class ContentRewriterService:
 
     def rewrite_prompt(self, prompt: str, prompt_type: str) -> str:
         """Rewrites a prompt based on its type."""
-        if prompt_type == "system":
+        normalized_type = (prompt_type or "").lower()
+
+        if normalized_type in {"system", "developer"}:
             rules = self.prompt_system_rules
-        elif prompt_type == "user":
+        elif normalized_type == "user":
             rules = self.prompt_user_rules
         else:
             return prompt


### PR DESCRIPTION
## Summary
- treat developer role prompts as system prompts when applying content rewrite rules
- add an integration test to ensure developer prompts are rewritten with system rules

## Testing
- python -m pytest tests/integration/test_content_rewriting_middleware.py::TestContentRewritingMiddleware::test_outbound_developer_prompt_rewriting
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6e29983e88333912bf80606a7c02d