### PR TITLE
Fix chat content rewriting for multimodal messages

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -27,15 +27,32 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
             role = message.get("role")
             original_content = message.get("content")
 
-            if not isinstance(original_content, str):
+            if isinstance(original_content, str):
+                rewritten_content = self.rewriter.rewrite_prompt(
+                    original_content, role if isinstance(role, str) else ""
+                )
+                if original_content != rewritten_content:
+                    message["content"] = rewritten_content
+                    is_rewritten = True
                 continue
 
-            rewritten_content = self.rewriter.rewrite_prompt(
-                original_content, role if isinstance(role, str) else ""
-            )
-            if original_content != rewritten_content:
-                message["content"] = rewritten_content
-                is_rewritten = True
+            if not isinstance(original_content, list):
+                continue
+
+            for block in original_content:
+                if not isinstance(block, dict):
+                    continue
+
+                text_value = block.get("text")
+                if not isinstance(text_value, str):
+                    continue
+
+                rewritten_text = self.rewriter.rewrite_prompt(
+                    text_value, role if isinstance(role, str) else ""
+                )
+                if rewritten_text != text_value:
+                    block["text"] = rewritten_text
+                    is_rewritten = True
 
         return is_rewritten
 


### PR DESCRIPTION
## Summary
- update the content rewriting middleware to rewrite text blocks inside chat message content lists
- add an integration test that covers rewriting for multimodal chat message payloads

## Testing
- python -m pytest tests/integration/test_content_rewriting_middleware.py
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6e29983e88333912bf80606a7c02d