### PR TITLE
Fix PREPEND duplication when rewriting Responses output text

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -128,9 +128,12 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
         is_rewritten = False
 
         outputs = payload.get("output")
+        aggregated_texts: list[str | None] = []
+
         if isinstance(outputs, list):
             for item in outputs:
                 if not isinstance(item, dict):
+                    aggregated_texts.append(None)
                     continue
 
                 content = item.get("content")
@@ -139,11 +142,14 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                     if rewritten != content:
                         item["content"] = rewritten
                         is_rewritten = True
+                    aggregated_texts.append(rewritten)
                     continue
 
                 if not isinstance(content, list):
+                    aggregated_texts.append(None)
                     continue
 
+                aggregated_parts: list[str] = []
                 for block in content:
                     if not isinstance(block, dict):
                         continue
@@ -156,17 +162,39 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                     if rewritten_text != text_value:
                         block["text"] = rewritten_text
                         is_rewritten = True
+                    aggregated_parts.append(rewritten_text)
+
+                aggregated_texts.append(
+                    "".join(aggregated_parts) if aggregated_parts else None
+                )
 
         output_text = payload.get("output_text")
         if isinstance(output_text, list):
-            for index, text_value in enumerate(output_text):
-                if not isinstance(text_value, str):
-                    continue
+            if aggregated_texts and len(aggregated_texts) == len(output_text):
+                for index, text_value in enumerate(output_text):
+                    if not isinstance(text_value, str):
+                        continue
 
-                rewritten_text = self.rewriter.rewrite_reply(text_value)
-                if rewritten_text != text_value:
-                    payload["output_text"][index] = rewritten_text
-                    is_rewritten = True
+                    aggregated_text = aggregated_texts[index]
+                    if aggregated_text is None:
+                        rewritten_text = self.rewriter.rewrite_reply(text_value)
+                        if rewritten_text != text_value:
+                            payload["output_text"][index] = rewritten_text
+                            is_rewritten = True
+                        continue
+
+                    if aggregated_text != text_value:
+                        payload["output_text"][index] = aggregated_text
+                        is_rewritten = True
+            else:
+                for index, text_value in enumerate(output_text):
+                    if not isinstance(text_value, str):
+                        continue
+
+                    rewritten_text = self.rewriter.rewrite_reply(text_value)
+                    if rewritten_text != text_value:
+                        payload["output_text"][index] = rewritten_text
+                        is_rewritten = True
 
         return is_rewritten
 

--- a/tests/integration/test_content_rewriting_middleware.py
+++ b/tests/integration/test_content_rewriting_middleware.py
@@ -644,6 +644,81 @@ class TestContentRewritingMiddleware(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_inbound_responses_output_prepend_rules_apply_once(self):
+        """Ensure PREPEND rules are not applied twice to output text."""
+
+        async def run_test():
+            os.makedirs(
+                os.path.join(self.test_config_dir, "replies", "005"),
+                exist_ok=True,
+            )
+            with open(
+                os.path.join(self.test_config_dir, "replies", "005", "SEARCH.txt"),
+                "w",
+            ) as f:
+                f.write("Original snippet")
+            with open(
+                os.path.join(self.test_config_dir, "replies", "005", "PREPEND.txt"),
+                "w",
+            ) as f:
+                f.write("Prefix: ")
+
+            rewriter = ContentRewriterService(config_path=self.test_config_dir)
+            middleware = ContentRewritingMiddleware(app=None, rewriter=rewriter)
+
+            response_payload = {
+                "output": [
+                    {
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Original snippet",
+                            }
+                        ]
+                    }
+                ],
+                "output_text": ["Original snippet"],
+            }
+
+            async def call_next(request):
+                return Response(
+                    content=json.dumps(response_payload),
+                    media_type="application/json",
+                )
+
+            async def receive():
+                return {"type": "http.request", "body": b""}
+
+            request = Request(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "headers": Headers({"content-type": "application/json"}).raw,
+                    "http_version": "1.1",
+                    "server": ("testserver", 80),
+                    "client": ("testclient", 123),
+                    "scheme": "http",
+                    "root_path": "",
+                    "path": "/test",
+                    "raw_path": b"/test",
+                    "query_string": b"",
+                },
+                receive=receive,
+            )
+
+            response = await middleware.dispatch(request, call_next)
+            body = json.loads(response.body)
+
+            self.assertEqual(
+                body["output"][0]["content"][0]["text"],
+                "Prefix: Original snippet",
+            )
+            self.assertEqual(body["output_text"][0], "Prefix: Original snippet")
+
+        import asyncio
+
+        asyncio.run(run_test())
+
     def test_streaming_reply_rewriting_preserves_background(self):
         """Ensure background tasks attached to streaming responses are preserved."""
 


### PR DESCRIPTION
## Summary
- track rewritten text for each Responses API output entry so aggregated `output_text` updates reuse the same value instead of reapplying replacement rules
- update the middleware so `output_text` falls back to direct rewriting only when aggregated text is unavailable
- add an integration test covering PREPEND rules to ensure the rewritten `output_text` is only prefixed once

## Testing
- `python -m pytest tests/integration/test_content_rewriting_middleware.py::TestContentRewritingMiddleware::test_inbound_responses_output_prepend_rules_apply_once`
- `python -m pytest` *(fails: missing optional test dependencies such as respx, pytest_httpx, hypothesis, freezegun, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e29983e88333912bf80606a7c02d