### PR TITLE
Fix CLI log level override and add regression test

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -177,8 +177,8 @@ def build_cli_parser() -> argparse.ArgumentParser:
         "--log-level",
         dest="log_level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        default="INFO",
-        help="Set the logging level (e.g., INFO, DEBUG)",
+        default=None,
+        help="Set the logging level (default: use config or INFO)",
     )
 
     # Feature flags

--- a/tests/unit/test_cli_di.py
+++ b/tests/unit/test_cli_di.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from src.constants import DEFAULT_COMMAND_PREFIX
 from src.core.app.test_builder import build_test_app as app_main_build_app
 from src.core.cli import apply_cli_args, main, parse_cli_args
-from src.core.config.app_config import AppConfig, load_config
+from src.core.config.app_config import AppConfig, LogLevel, load_config
 from src.core.interfaces.session_service_interface import ISessionService
 
 from tests.utils.test_di_utils import get_required_service_from_app
@@ -142,6 +142,17 @@ def test_apply_cli_args_preserves_config_log_file(tmp_path: Path) -> None:
         applied = apply_cli_args(args)
 
     assert applied.logging.log_file == str(existing_log)
+
+
+def test_apply_cli_args_respects_existing_log_level() -> None:
+    config = AppConfig()
+    config.logging.level = LogLevel.DEBUG
+
+    with patch("src.core.cli.load_config", return_value=config):
+        args = parse_cli_args([])
+        applied = apply_cli_args(args)
+
+    assert applied.logging.level is LogLevel.DEBUG
 
 
 def test_main_log_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure the CLI no longer overwrites configured log levels when no --log-level flag is provided
- add a regression test to confirm apply_cli_args preserves an existing logging level

## Testing
- pytest tests/unit/test_cli_di.py::test_apply_cli_args_respects_existing_log_level -n 0
- pytest -n 0 *(fails: missing optional test dependencies such as respx/pytest_httpx/hypothesis/freezegun/pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e2a7fa688333a4ac0711e7251bb9