### PR TITLE
Fix Anthropic streaming to convert SSE chunks

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException, Request, Response
 
 from src.anthropic_converters import (
     anthropic_to_openai_request,
+    openai_stream_to_anthropic_stream,
     openai_to_anthropic_response,
 )
 from src.anthropic_models import AnthropicMessagesRequest
@@ -237,15 +238,43 @@ class AnthropicController:
                 if isinstance(adapted_response, StreamingResponse):
                     # Ensure Anthropic streaming endpoints advertise proper SSE headers
                     sse_content_type = "text/event-stream; charset=utf-8"
-                    adapted_response.media_type = sse_content_type
 
-                    # `StreamingResponse.headers` returns a MutableHeaders mapping
-                    # which may already include values from upstream responses.
-                    # Update in-place so existing references stay in sync.
-                    adapted_response.headers["content-type"] = sse_content_type
-                    adapted_response.headers.setdefault("cache-control", "no-cache")
-                    adapted_response.headers.setdefault("connection", "keep-alive")
-                    return adapted_response
+                    original_iterator = adapted_response.body_iterator
+
+                    def _convert_chunk(chunk: bytes | str) -> bytes:
+                        text_chunk = (
+                            chunk.decode("utf-8", errors="ignore")
+                            if isinstance(chunk, (bytes, bytearray, memoryview))
+                            else str(chunk)
+                        )
+                        converted = openai_stream_to_anthropic_stream(text_chunk)
+                        if isinstance(converted, bytes):
+                            return converted
+                        return str(converted).encode("utf-8")
+
+                    async def _anthropic_stream() -> AsyncIterator[bytes]:
+                        """Convert OpenAI-formatted SSE chunks to Anthropic format."""
+
+                        iterator = original_iterator
+                        if hasattr(iterator, "__aiter__"):
+                            async for chunk in iterator:  # type: ignore[assignment]
+                                yield _convert_chunk(chunk)
+                        else:
+                            for chunk in iterator:  # type: ignore[assignment]
+                                yield _convert_chunk(chunk)
+
+                    headers = dict(adapted_response.headers)
+                    headers["content-type"] = sse_content_type
+                    headers.setdefault("cache-control", "no-cache")
+                    headers.setdefault("connection", "keep-alive")
+
+                    return StreamingResponse(
+                        _anthropic_stream(),
+                        media_type=sse_content_type,
+                        status_code=getattr(adapted_response, "status_code", 200),
+                        headers=headers,
+                        background=adapted_response.background,
+                    )
                 else:
                     # If somehow we got a non-streaming response but streaming was requested,
                     # convert it to a simple streaming response

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_controller_streaming.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_controller_streaming.py
@@ -1,0 +1,92 @@
+"""Tests for AnthropicController streaming conversions."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from src.anthropic_converters import AnthropicMessage, AnthropicMessagesRequest
+from src.core.app.controllers.anthropic_controller import AnthropicController
+from src.core.domain.responses import StreamingResponseEnvelope
+from src.core.interfaces.request_processor_interface import IRequestProcessor
+from src.core.interfaces.response_processor_interface import ProcessedResponse
+
+
+class _StreamingProcessor(IRequestProcessor):
+    """Return a streaming response that emits OpenAI-formatted SSE chunks."""
+
+    async def process_request(
+        self,
+        context: Any,
+        request_data: Any,
+    ) -> StreamingResponseEnvelope:
+        async def _stream() -> AsyncIterator[ProcessedResponse]:
+            yield ProcessedResponse(
+                content='data: {"choices": [{"delta": {"role": "assistant"}}]}\n\n'
+            )
+            yield ProcessedResponse(
+                content='data: {"choices": [{"delta": {"content": [{"type": "text", "text": "Hello"}]}}]}\n\n'
+            )
+            yield ProcessedResponse(
+                content='data: {"choices": [{"finish_reason": "stop"}]}\n\n'
+            )
+            yield ProcessedResponse(content='data: [DONE]\n\n')
+
+        return StreamingResponseEnvelope(content=_stream())
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_converted_to_anthropic() -> None:
+    """Ensure streaming responses are converted to Anthropic SSE format."""
+
+    controller = AnthropicController(_StreamingProcessor())
+
+    app = FastAPI()
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/messages",
+        "headers": [],
+        "query_string": b"",
+        "client": ("127.0.0.1", 12345),
+        "app": app,
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive)
+    anthropic_request = AnthropicMessagesRequest(
+        model="claude-3-sonnet-20240229",
+        messages=[AnthropicMessage(role="user", content="Hi")],
+        stream=True,
+    )
+
+    response = await controller.handle_anthropic_messages(request, anthropic_request)
+
+    assert isinstance(response, StreamingResponse)
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:  # type: ignore[assignment]
+        chunks.append(chunk.decode("utf-8"))
+
+    assert len(chunks) == 4
+
+    prefix = "data: "
+    first_payload = json.loads(chunks[0][len(prefix) :])
+    assert first_payload["type"] == "message_start"
+    assert first_payload["message"] == {"role": "assistant"}
+
+    second_payload = json.loads(chunks[1][len(prefix) :])
+    assert second_payload["type"] == "content_block_delta"
+    assert second_payload["delta"]["text"] == "Hello"
+
+    third_payload = json.loads(chunks[2][len(prefix) :])
+    assert third_payload["type"] == "message_delta"
+    assert third_payload["delta"]["stop_reason"] == "end_turn"
+
+    assert chunks[3] == "data: [DONE]\n\n"


### PR DESCRIPTION
## Summary
- convert OpenAI-formatted streaming chunks to Anthropic SSE events inside `AnthropicController`
- add a focused unit test that exercises the streaming conversion end-to-end

## Testing
- python -m pytest -o addopts='' tests/unit/anthropic_frontend_tests/test_anthropic_controller_streaming.py
- python -m pytest -o addopts='' tests/unit/anthropic_frontend_tests
- python -m pytest -o addopts='' *(fails: missing optional test dependencies such as pytest-asyncio, respx, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e2c736808333b42e5db683438675