### PR TITLE
Fix Anthropic connector header merging

### DIFF
--- a/src/connectors/anthropic.py
+++ b/src/connectors/anthropic.py
@@ -163,11 +163,16 @@ class AnthropicBackend(LLMBackend):
             project=project,
         )
 
-        request_headers = headers or {
+        request_headers = {
             self.auth_header_name: effective_api_key,
             "anthropic-version": ANTHROPIC_VERSION_HEADER,
             "content-type": "application/json",
         }
+        if headers:
+            # Merge any caller-supplied headers without losing mandatory
+            # authentication defaults.  Copy the mapping to avoid mutating the
+            # caller-owned dictionary.
+            request_headers.update(headers)
         if identity:
             request_headers.update(identity.get_resolved_headers(None))
 

--- a/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
+++ b/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
@@ -160,6 +160,48 @@ async def test_chat_completions_with_system_message(
 
 
 @pytest.mark.asyncio
+async def test_chat_completions_merges_custom_headers(
+    anthropic_backend: AnthropicBackend, httpx_mock: HTTPXMock
+) -> None:
+    """Caller-provided headers should supplement, not replace, defaults."""
+
+    httpx_mock.add_response(
+        url=f"{TEST_ANTHROPIC_API_BASE_URL}/messages",
+        method="POST",
+        json={
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello"}],
+            "model": "claude-3-haiku-20240307",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        },
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    request = ChatRequest(
+        model="anthropic:claude-3-haiku-20240307",
+        messages=[ChatMessage(role="user", content="Hello")],
+        stream=False,
+    )
+
+    await anthropic_backend.chat_completions(
+        request_data=request,
+        processed_messages=[ChatMessage(role="user", content="Hello")],
+        effective_model="claude-3-haiku-20240307",
+        headers={"x-custom": "value"},
+    )
+
+    sent_request = httpx_mock.get_request()
+    assert sent_request is not None
+    assert sent_request.headers["x-api-key"] == "test_key"
+    assert sent_request.headers["anthropic-version"] == ANTHROPIC_VERSION_HEADER
+    assert sent_request.headers["x-custom"] == "value"
+
+
+@pytest.mark.asyncio
 async def test_chat_completions_merges_metadata(
     anthropic_backend: AnthropicBackend, httpx_mock: HTTPXMock
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure the Anthropic backend always injects authentication and version headers even when custom headers are provided
- add a regression test covering header merging so future changes keep the behavior intact

## Testing
- python -m pytest --override-ini addopts="" tests/unit/anthropic_connector_tests/test_domain_to_connector.py::test_chat_completions_merges_custom_headers -q *(fails: missing pytest_asyncio dependency in environment)*
- python -m pytest --override-ini addopts="" -k anthropic_connector -q *(fails: multiple missing test dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e2c736808333b42e5db683438675