### PR TITLE
Fix missing message_start event in Anthropic stream conversion

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -214,6 +214,27 @@ def openai_to_anthropic_stream_chunk(chunk_data: str, id: str, model: str) -> st
         choice: dict[str, Any] = openai_chunk.get("choices", [{}])[0]
         delta: dict[str, Any] = choice.get("delta", {})
 
+        # Role delta -> emit message_start event so Anthropic clients receive
+        # the metadata that frames the rest of the stream.  Without this the
+        # very first OpenAI chunk (which only contains the assistant role)
+        # would be silently dropped, leaving Anthropic front-ends without a
+        # message header and breaking downstream parsing.
+        if delta.get("role"):
+            payload = {
+                "type": "message_start",
+                "index": 0,
+                "message": {
+                    "id": id,
+                    "type": "message",
+                    "role": delta["role"],
+                    "model": model,
+                },
+            }
+            return (
+                "event: message_start\n"
+                f"data: {json.dumps(payload)}\n\n"
+            )
+
         # Content delta
         if delta.get("content"):
             content = _normalize_text_content(delta["content"])

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
@@ -3,6 +3,7 @@ Unit tests for Anthropic front-end converters.
 Tests the conversion between Anthropic and OpenAI API formats.
 """
 
+import json
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -259,6 +260,22 @@ class TestAnthropicConverters:
 
         assert "content_block_delta" in anthropic_chunk
         assert "Hello" in anthropic_chunk
+
+    def test_openai_to_anthropic_stream_chunk_role_event(self) -> None:
+        """Role-only deltas should produce a message_start event."""
+        chunk = '{"id": "chatcmpl-123", "choices": [{"delta": {"role": "assistant"}}]}'
+
+        anthropic_chunk = openai_to_anthropic_stream_chunk(
+            chunk, "chatcmpl-123", "claude"
+        )
+
+        lines = [line for line in anthropic_chunk.splitlines() if line]
+        assert lines[0] == "event: message_start"
+
+        payload = json.loads(lines[1].split("data: ", 1)[1])
+        assert payload["message"]["role"] == "assistant"
+        assert payload["message"]["id"] == "chatcmpl-123"
+        assert payload["message"]["model"] == "claude"
 
     def test_map_finish_reason(self) -> None:
         """Test finish reason mapping."""


### PR DESCRIPTION
## Summary
- emit Anthropic-compatible message_start events when an OpenAI stream chunk only carries the assistant role metadata
- cover the regression with a dedicated unit test for the Anthropic frontend stream converter

## Testing
- python -m pytest tests/unit/anthropic_frontend_tests/test_anthropic_converters.py -k role_event -q *(fails: requires repository-specific pytest plugins that are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e2c736808333b42e5db683438675