### PR TITLE
Fix failover backend inference for implicit routes

### DIFF
--- a/src/core/services/failover_service.py
+++ b/src/core/services/failover_service.py
@@ -91,7 +91,9 @@ class FailoverService:
         for element in elements:
             try:
                 # Parse the element into backend and model
-                elem_backend, elem_model = parse_model_backend(element)
+                elem_backend, elem_model = parse_model_backend(
+                    element, default_backend=backend_type
+                )
                 attempts.append(FailoverAttempt(backend=elem_backend, model=elem_model))
             except ValueError:
                 logger.warning(


### PR DESCRIPTION
## Summary
- ensure failover attempts default to the originating backend when route entries omit an explicit backend prefix
- extend failover service unit tests to cover implicit backend inference and adjust expectations for fallback behavior

## Testing
- pytest -c /tmp/pytest_plain.ini tests/unit/core/test_failover_service.py
- pytest -c /tmp/pytest_plain.ini

------
https://chatgpt.com/codex/tasks/task_e_68e6e2e771bc8333a2aed02e310878ca