### PR TITLE
Fix Gemini streaming finish reason mapping

### DIFF
--- a/src/gemini_converters.py
+++ b/src/gemini_converters.py
@@ -341,13 +341,20 @@ def _gemini_candidate_to_openai_chunk(candidate: dict[str, Any]) -> str | None:
 
         # Extract finish reason
         if "finishReason" in candidate:
-            finish_reason = candidate["finishReason"].lower()
-            if finish_reason == "stop":
-                choice["finish_reason"] = "stop"
-            elif finish_reason == "max_tokens":
-                choice["finish_reason"] = "length"
-            elif finish_reason == "tool_calls":
-                choice["finish_reason"] = "tool_calls"
+            finish_reason_value = candidate["finishReason"]
+            if isinstance(finish_reason_value, str):
+                finish_reason = finish_reason_value.lower()
+                finish_reason_map = {
+                    "stop": "stop",
+                    "max_tokens": "length",
+                    "tool_calls": "tool_calls",
+                    "function_call": "function_call",
+                    "safety": "content_filter",
+                    "recitation": "content_filter",
+                }
+                mapped_reason = finish_reason_map.get(finish_reason)
+                if mapped_reason is not None:
+                    choice["finish_reason"] = mapped_reason
 
         openai_chunk["choices"].append(choice)
         return f"data: {json.dumps(openai_chunk)}\n\n"

--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -16,6 +16,7 @@ from src.core.domain.chat import (
 from src.gemini_converters import (
     gemini_to_openai_messages,
     gemini_to_openai_request,
+    gemini_to_openai_stream_chunk,
     openai_to_gemini_contents,
     openai_to_gemini_response,
     openai_to_gemini_stream_chunk,
@@ -164,6 +165,44 @@ class TestMessageConversion:
         data = json.loads(payload)
 
         assert data["candidates"][0]["content"]["parts"][0]["text"] == "Hello"
+
+    def test_gemini_stream_chunk_maps_function_call_finish_reason(self) -> None:
+        """Gemini streaming finish reasons should map to OpenAI equivalents."""
+        chunk = {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Done"}]},
+                    "finishReason": "FUNCTION_CALL",
+                    "index": 0,
+                }
+            ]
+        }
+
+        converted = gemini_to_openai_stream_chunk(f"data: {json.dumps(chunk)}\n\n")
+        assert converted.startswith("data: ")
+
+        payload = converted[6:].strip()
+        data = json.loads(payload)
+
+        assert data["choices"][0]["finish_reason"] == "function_call"
+
+    def test_gemini_stream_chunk_maps_safety_finish_reason(self) -> None:
+        """Safety stops should map to OpenAI content_filter finish reason."""
+        chunk = {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Filtered"}]},
+                    "finishReason": "SAFETY",
+                    "index": 0,
+                }
+            ]
+        }
+
+        converted = gemini_to_openai_stream_chunk(f"data: {json.dumps(chunk)}\n\n")
+        payload = converted[6:].strip()
+        data = json.loads(payload)
+
+        assert data["choices"][0]["finish_reason"] == "content_filter"
 
     def test_gemini_request_tools_are_converted(self) -> None:
         """Gemini tool declarations should be translated to OpenAI tool definitions."""


### PR DESCRIPTION
## Summary
- ensure `gemini_to_openai_stream_chunk` maps Gemini finish reasons like `FUNCTION_CALL` and `SAFETY` to the correct OpenAI `finish_reason`
- add unit coverage for streaming finish-reason conversions in the Gemini converter tests

## Testing
- uv run pytest tests/unit/test_gemini_converters.py
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6e2e771bc8333a2aed02e310878ca