### PR TITLE
Clarify FastAPI import usage in loop prevention tests

### DIFF
--- a/tests/unit/test_loop_prevention.py
+++ b/tests/unit/test_loop_prevention.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI  # Required for instantiating FastAPI apps in these tests
 from fastapi.testclient import TestClient
 from src.core.app.middleware.loop_prevention_middleware import LoopPreventionMiddleware
 from src.core.security.loop_prevention import (


### PR DESCRIPTION
## Summary
- document the FastAPI import in the loop prevention tests so the FastAPI application object is always available during middleware checks

## Testing
- python -m pytest -o addopts='' tests/unit/test_loop_prevention.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e6e2f655fc83339e3e4b89a878f07f