### PR TITLE
Fix hybrid loop detector detection method

### DIFF
--- a/src/loop_detection/hybrid_detector.py
+++ b/src/loop_detection/hybrid_detector.py
@@ -322,6 +322,12 @@ class HybridLoopDetector(ILoopDetector):
             else:
                 pattern_length = len(event.pattern)
 
+            short_chunk_size = self.short_detector.content_chunk_size
+            if pattern_length <= short_chunk_size:
+                detection_method = "short_pattern"
+            else:
+                detection_method = "long_pattern"
+
             return LoopDetectionResult(
                 has_loop=True,
                 pattern=event.pattern,
@@ -329,9 +335,7 @@ class HybridLoopDetector(ILoopDetector):
                 details={
                     "pattern_length": pattern_length,
                     "total_repeated_chars": event.total_length,
-                    "detection_method": (
-                        "short_pattern" if event.total_length < 500 else "long_pattern"
-                    ),
+                    "detection_method": detection_method,
                 },
             )
         finally:

--- a/tests/unit/loop_detection/test_hybrid_loop_result_details.py
+++ b/tests/unit/loop_detection/test_hybrid_loop_result_details.py
@@ -33,3 +33,30 @@ async def test_long_pattern_details_report_actual_length() -> None:
         result.details["total_repeated_chars"]
         == result.repetitions * result.details["pattern_length"]
     )
+
+
+@pytest.mark.asyncio
+async def test_short_pattern_detection_method_flagged_correctly() -> None:
+    """Short pattern detections should report the short_pattern method."""
+
+    detector = HybridLoopDetector(
+        short_detector_config={
+            "content_chunk_size": 10,
+            "content_loop_threshold": 3,
+            "max_history_length": 200,
+        },
+        long_detector_config={
+            # Push the long detector threshold high enough to stay inactive.
+            "min_pattern_length": 200,
+        },
+    )
+
+    repeated_chunk = "abcdefghij"
+    content = repeated_chunk * 3
+
+    result = await detector.check_for_loops(content)
+
+    assert result.has_loop is True
+    assert result.details is not None
+    assert result.details["detection_method"] == "short_pattern"
+    assert result.details["pattern_length"] == len(repeated_chunk)


### PR DESCRIPTION
## Summary
- ensure HybridLoopDetector classifies detection_method using the configured short detector chunk size
- add a regression test that exercises short pattern detection and verifies the reported method

## Testing
- python -m pytest --override-ini addopts="" tests/unit/loop_detection/test_hybrid_loop_result_details.py
- python -m pytest --override-ini addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e6e2f655fc83339e3e4b89a878f07f