### PR TITLE
Fix Gemini CLI detector state snapshot mutation

### DIFF
--- a/src/loop_detection/gemini_cli_detector.py
+++ b/src/loop_detection/gemini_cli_detector.py
@@ -442,7 +442,10 @@ class GeminiCliLoopDetector(ILoopDetector):
         """Save current state for restoration."""
         return {
             "stream_content_history": self.stream_content_history,
-            "content_stats": self.content_stats.copy(),
+            "content_stats": {
+                hash_hex: indices.copy()
+                for hash_hex, indices in self.content_stats.items()
+            },
             "last_content_index": self.last_content_index,
             "loop_detected": self.loop_detected,
             "in_code_block": self.in_code_block,

--- a/tests/unit/loop_detection/test_gemini_cli_detector_state.py
+++ b/tests/unit/loop_detection/test_gemini_cli_detector_state.py
@@ -1,0 +1,36 @@
+"""State management tests for :mod:`src.loop_detection.gemini_cli_detector`."""
+
+from src.loop_detection.gemini_cli_detector import GeminiCliLoopDetector
+
+
+class TestGeminiCliLoopDetectorState:
+    """Ensure internal state snapshots remain isolated from mutations."""
+
+    def test_save_state_does_not_share_internal_lists(self) -> None:
+        """Saving state should produce independent copies of tracked indices."""
+
+        detector = GeminiCliLoopDetector(
+            content_loop_threshold=5,
+            content_chunk_size=3,
+            max_history_length=100,
+        )
+
+        # Populate tracking structures with repeated content but stay below the
+        # detection threshold so processing continues to update the same hashes.
+        detector.process_chunk("abcabcabc")
+
+        saved_state = detector._save_state()
+        original_stats = {
+            hash_hex: indices.copy() for hash_hex, indices in saved_state["content_stats"].items()
+        }
+        assert original_stats  # Sanity check: ensure we actually captured history.
+
+        # Process more content that extends the previously observed hashes. If
+        # the saved state retained references to the original lists it would be
+        # mutated by these updates.
+        detector.process_chunk("abcabcabc")
+
+        assert saved_state["content_stats"] == original_stats
+
+        detector._restore_state(saved_state)
+        assert detector.content_stats == original_stats


### PR DESCRIPTION
## Summary
- ensure the Gemini CLI loop detector saves independent copies of tracked chunk indices when capturing state snapshots
- add a regression test covering state restoration to guarantee saved snapshots are not mutated by subsequent processing

## Testing
- python -m pytest --override-ini addopts="" tests/unit/loop_detection/test_gemini_cli_detector_state.py
- python -m pytest --override-ini addopts="" *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis, and pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e2f655fc83339e3e4b89a878f07f