### PR TITLE
Respect loop detector analysis interval

### DIFF
--- a/src/loop_detection/detector.py
+++ b/src/loop_detection/detector.py
@@ -81,12 +81,18 @@ class LoopDetector(ILoopDetector):
         self.buffer.append(chunk)
         self.total_processed += chunk_len
 
+        # Respect the configured analysis interval to avoid redundant heavy checks.
+        if self.config.analysis_interval > 0 and self._last_analysis_position >= 0:
+            processed_since_last = self.total_processed - self._last_analysis_position
+            if processed_since_last < self.config.analysis_interval:
+                return None
+
         # Analyze for loops using the new PatternAnalyzer
         event = self.analyzer.analyze_chunk(chunk, self.buffer.get_content())
+        self._last_analysis_position = self.total_processed
         if event is not None:
             # Update state to avoid retriggering immediately
             self.last_detection_position = self.total_processed
-            self._last_analysis_position = self.total_processed
             self._history.append(event)
             # Trigger callback if provided
             if self.on_loop_detected:


### PR DESCRIPTION
## Summary
- skip expensive loop analysis until the configured interval worth of characters have been processed
- update last-analysis tracking immediately after each analysis pass
- add a unit test ensuring the loop detector honours the analysis interval configuration

## Testing
- python -m pytest tests/unit/loop_detection/test_detector_comprehensive.py -o addopts=
- python -m pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e6e2f655fc83339e3e4b89a878f07f