### PR TITLE
Fix pytest full suite handler tuple isinstance usage

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -60,7 +60,7 @@ def _extract_command(arguments: Any) -> str | None:
         command = arguments.get("command") or arguments.get("cmd")
         if isinstance(command, str) and command.strip():
             return command
-        if isinstance(command, list | tuple) and command:
+        if isinstance(command, (list, tuple)) and command:
             return " ".join(str(item) for item in command)
 
         for key in ("input", "body", "data"):
@@ -71,7 +71,7 @@ def _extract_command(arguments: Any) -> str | None:
                 sub = inner.get("command") or inner.get("cmd")
                 if isinstance(sub, str) and sub.strip():
                     return sub
-                if isinstance(sub, list | tuple) and sub:
+                if isinstance(sub, (list, tuple)) and sub:
                     return " ".join(str(item) for item in sub)
 
         args_list = arguments.get("args")


### PR DESCRIPTION
## Summary
- fix the pytest full suite handler to use a tuple of types with `isinstance`
  when inspecting list-based command arguments so detection works without raising
  `TypeError`

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest -o addopts="" *(fails: missing optional test dependencies such as pytest-asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e30e7fb88333a13357af08eca4c0