### PR TITLE
Fix pytest full suite handler detection for mixed-case tool names

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -220,7 +220,9 @@ class PytestFullSuiteHandler(IToolCallHandler):
         )
 
     def _extract_pytest_command(self, context: ToolCallContext) -> str | None:
-        tool_name = context.tool_name or ""
+        tool_name_raw = context.tool_name or ""
+        tool_name = tool_name_raw.strip()
+        normalized_tool_name = tool_name.lower()
         arguments = context.tool_arguments
 
         shell_tools = {
@@ -235,7 +237,7 @@ class PytestFullSuiteHandler(IToolCallHandler):
 
         command = _extract_command(arguments)
 
-        if tool_name in shell_tools:
+        if normalized_tool_name in shell_tools:
             return command
 
         # Some providers map pytest directly as function name
@@ -243,7 +245,7 @@ class PytestFullSuiteHandler(IToolCallHandler):
             return command or tool_name
 
         if command and _PYTEST_ROOT_PATTERN.search(command):
-            prefix = tool_name.strip()
+            prefix = tool_name
             if prefix:
                 return f"{prefix} {command}".strip()
             return command


### PR DESCRIPTION
## Summary
- normalize shell tool names in the pytest full suite handler so mixed-case tool identifiers are detected

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68e6e30e7fb88333a13357af08eca4c0