### PR TITLE
Fix Responses controller translation service injection

### DIFF
--- a/src/core/app/stages/controller.py
+++ b/src/core/app/stages/controller.py
@@ -167,10 +167,24 @@ class ControllerStage(InitializationStage):
             """Factory function for creating ResponsesController."""
             from typing import cast
 
+            from src.core.interfaces.translation_service_interface import (
+                ITranslationService,
+            )
+            from src.core.services.translation_service import TranslationService
+
             request_processor: IRequestProcessor = provider.get_required_service(
                 cast(type, IRequestProcessor)
             )
-            return ResponsesController(request_processor)
+            translation_service = provider.get_service(
+                cast(type, ITranslationService)
+            )
+            if translation_service is None:
+                translation_service = provider.get_service(TranslationService)
+
+            return ResponsesController(
+                request_processor,
+                translation_service=translation_service,
+            )
 
         # Register as singleton
         services.add_singleton(

--- a/tests/unit/core/app/controllers/test_responses_controller.py
+++ b/tests/unit/core/app/controllers/test_responses_controller.py
@@ -1,7 +1,47 @@
 """Unit tests for the ResponsesController front-end logic."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
+from fastapi import Request
+
 from src.core.app.controllers.responses_controller import ResponsesController
+from src.core.domain.chat import (
+    ChatCompletionChoice,
+    ChatCompletionChoiceMessage,
+    ChatMessage,
+    ChatResponse,
+)
+from src.core.domain.responses import ResponseEnvelope
+from src.core.domain.responses_api import JsonSchema, ResponseFormat, ResponsesRequest
+
+
+class StubTranslationService:
+    """Translation service stub capturing usage for assertions."""
+
+    def __init__(self) -> None:
+        self.request_used = False
+        self.response_used = False
+        self._domain_request = SimpleNamespace(model="gpt-test", stream=False)
+
+    def to_domain_request(self, request: object, source_format: str) -> object:
+        self.request_used = True
+        return self._domain_request
+
+    def from_domain_to_responses_response(self, response: ChatResponse) -> dict[str, object]:
+        self.response_used = True
+        return {
+            "id": response.id,
+            "object": "response",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "converted"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
 
 
 class TestResponsesControllerSchemaValidation:
@@ -39,3 +79,62 @@ class TestResponsesControllerSchemaValidation:
 
         with pytest.raises(ValueError):
             ResponsesController._validate_json_schema(schema)
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_request_uses_injected_translation_service() -> None:
+    """The controller should honor the DI-provided translation service."""
+
+    translation_service = StubTranslationService()
+    processor = AsyncMock()
+
+    choice = ChatCompletionChoice(
+        index=0,
+        message=ChatCompletionChoiceMessage(role="assistant", content="hi"),
+        finish_reason="stop",
+    )
+    chat_response = ChatResponse(
+        id="resp-123",
+        created=0,
+        model="gpt-test",
+        choices=[choice],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+    processor.process_request.return_value = ResponseEnvelope(content=chat_response)
+
+    controller = ResponsesController(processor, translation_service=translation_service)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/responses",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "app": SimpleNamespace(state=SimpleNamespace()),
+    }
+
+    async def receive() -> dict[str, object]:  # pragma: no cover - invoked by Request
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive=receive)
+    request.state.request_id = "test-request"
+
+    schema = JsonSchema(
+        name="TestSchema",
+        schema={
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+            "required": ["foo"],
+        },
+    )
+    responses_request = ResponsesRequest(
+        model="gpt-test",
+        messages=[ChatMessage(role="user", content="hello")],
+        response_format=ResponseFormat(json_schema=schema),
+    )
+
+    response = await controller.handle_responses_request(request, responses_request)
+
+    assert translation_service.request_used is True
+    assert translation_service.response_used is True
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- resolve the Responses controller through DI with the translation service so custom converters are honored
- add a focused unit test that verifies the controller uses the injected translation service when translating requests and responses

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/core/app/controllers/test_responses_controller.py *(fails: repository configuration requires pytest-xdist which is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e33715e0833391896087ce5ca1d3