### PR TITLE
Fix Gemini backend header name resolution

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -326,7 +326,11 @@ class GeminiBackend(LLMBackend):
     ) -> ResponseEnvelope | StreamingResponseEnvelope:
         # Resolve base configuration
         base_api_url, headers = await self._resolve_gemini_api_config(
-            gemini_api_base_url, openrouter_api_base_url, api_key, **kwargs
+            gemini_api_base_url,
+            openrouter_api_base_url,
+            api_key,
+            key_name=key_name,
+            **kwargs,
         )
         if identity:
             headers.update(identity.get_resolved_headers(None))
@@ -432,6 +436,8 @@ class GeminiBackend(LLMBackend):
         gemini_api_base_url: str | None,
         openrouter_api_base_url: str | None,
         api_key: str | None,
+        *,
+        key_name: str | None = None,
         **kwargs: Any,
     ) -> tuple[str, dict[str, str]]:
         # Prefer explicit params, then kwargs, then instance attributes set during initialize
@@ -442,12 +448,20 @@ class GeminiBackend(LLMBackend):
             or getattr(self, "gemini_api_base_url", None)
         )
         key = api_key or kwargs.get("api_key") or getattr(self, "api_key", None)
+        header_name = (
+            key_name
+            or kwargs.get("key_name")
+            or getattr(self, "key_name", None)
+            or "x-goog-api-key"
+        )
         if not base or not key:
             raise HTTPException(
                 status_code=500,
                 detail="Gemini API base URL and API key must be provided.",
             )
-        return base.rstrip("/"), ensure_loop_guard_header({"x-goog-api-key": key})
+        normalized_header = str(header_name)
+        headers = ensure_loop_guard_header({normalized_header: key})
+        return base.rstrip("/"), headers
 
     def _apply_generation_config(
         self, payload: dict[str, Any], request_data: ChatRequest
@@ -567,7 +581,10 @@ class GeminiBackend(LLMBackend):
     async def list_models(
         self, *, gemini_api_base_url: str, key_name: str, api_key: str
     ) -> dict[str, Any]:
-        headers = ensure_loop_guard_header({"x-goog-api-key": api_key})
+        if not key_name:
+            raise ValueError("key_name must be provided when listing Gemini models")
+        normalized_header = str(key_name)
+        headers = ensure_loop_guard_header({normalized_header: api_key})
         url = f"{gemini_api_base_url.rstrip('/')}/v1beta/models"
         try:
             response = await self.client.get(url, headers=headers)

--- a/tests/unit/connectors/test_gemini_header_resolution.py
+++ b/tests/unit/connectors/test_gemini_header_resolution.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.connectors.gemini import GeminiBackend
+from src.core.config.app_config import AppConfig
+from src.core.security.loop_prevention import LOOP_GUARD_HEADER, LOOP_GUARD_VALUE
+from src.core.services.translation_service import TranslationService
+
+
+@pytest.mark.asyncio
+async def test_resolve_gemini_api_config_uses_custom_header_name() -> None:
+    backend = GeminiBackend(
+        httpx.AsyncClient(), AppConfig(), translation_service=TranslationService()
+    )
+    backend.key_name = "X-Custom-Header"
+
+    base_url, headers = await backend._resolve_gemini_api_config(  # type: ignore[attr-defined]
+        "https://example.com/api/",
+        None,
+        "secret-token",
+        key_name="X-Custom-Header",
+    )
+
+    assert base_url == "https://example.com/api"
+    assert headers["X-Custom-Header"] == "secret-token"
+    assert headers[LOOP_GUARD_HEADER] == LOOP_GUARD_VALUE
+
+
+@pytest.mark.asyncio
+async def test_list_models_respects_key_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = GeminiBackend(
+        httpx.AsyncClient(), AppConfig(), translation_service=TranslationService()
+    )
+
+    captured_headers: dict[str, str] = {}
+
+    async def fake_get(url: str, *, headers: dict[str, str]) -> httpx.Response:  # type: ignore[override]
+        captured_headers.update(headers)
+        return httpx.Response(200, json={"models": []})
+
+    monkeypatch.setattr(backend.client, "get", fake_get)
+
+    result = await backend.list_models(
+        gemini_api_base_url="https://example.com",
+        key_name="X-Alt-Key",
+        api_key="another-secret",
+    )
+
+    assert captured_headers["X-Alt-Key"] == "another-secret"
+    assert captured_headers[LOOP_GUARD_HEADER] == LOOP_GUARD_VALUE
+    assert result == {"models": []}


### PR DESCRIPTION
## Summary
- ensure the Gemini connector honours the configured API key header name for chat requests and model discovery
- add regression tests covering header selection when resolving Gemini API configuration

## Testing
- python -m pytest -o addopts='' tests/unit/connectors/test_gemini_header_resolution.py
- python -m pytest -o addopts=''

------
https://chatgpt.com/codex/tasks/task_e_68e6e3273ddc83338928dd8cc589c5d7