### PR TITLE
Fix Gemini reasoning effort translation

### DIFF
--- a/tests/integration/test_custom_model_parameters.py
+++ b/tests/integration/test_custom_model_parameters.py
@@ -229,10 +229,11 @@ class TestCustomModelParameters:
         payload = json.loads(sent_request.content)
         assert "generationConfig" in payload
         assert "thinkingConfig" in payload["generationConfig"]
-        assert "reasoning_effort" in payload["generationConfig"]["thinkingConfig"]
-        assert (
-            payload["generationConfig"]["thinkingConfig"]["reasoning_effort"] == "high"
-        )
+        thinking_config = payload["generationConfig"]["thinkingConfig"]
+        assert "thinkingBudget" in thinking_config
+        assert thinking_config["thinkingBudget"] == -1
+        assert thinking_config.get("includeThoughts") is True
+        assert "reasoning_effort" not in thinking_config
 
     @pytest.mark.asyncio
     async def test_anthropic_reasoning_effort_parameter(


### PR DESCRIPTION
## Summary
- convert Gemini connector reasoning_effort handling to emit thinkingBudget with includeThoughts
- strip invalid reasoning_effort keys from merged generationConfig overrides
- update the custom model parameters test to assert the Gemini payload uses thinkingBudget

## Testing
- pytest -o addopts="" tests/integration/test_custom_model_parameters.py::TestCustomModelParameters::test_gemini_reasoning_effort_parameter
- pytest -o addopts="" *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e3273ddc83338928dd8cc589c5d7