### PR TITLE
Fix Gemini front-end multimodal conversion

### DIFF
--- a/tests/unit/test_gemini_converters.py
+++ b/tests/unit/test_gemini_converters.py
@@ -127,6 +127,50 @@ class TestMessageConversion:
         assert isinstance(file_part, MessageContentPartImage)
         assert file_part.image_url.url == "https://example.com/image.png"
 
+    def test_gemini_inline_data_non_image_placeholder(self) -> None:
+        """Non-image inline data should produce a textual placeholder."""
+        contents = [
+            Content(
+                parts=[
+                    Part(
+                        inline_data=Blob(
+                            mime_type="application/pdf", data="ZmFrZWJhc2U2NA=="
+                        )
+                    )
+                ],
+                role="user",
+            )
+        ]
+
+        messages = gemini_to_openai_messages(contents)
+
+        assert len(messages) == 1
+        assert messages[0].content == "[Attachment: inline data (application/pdf)]"
+
+    def test_gemini_file_data_non_image_placeholder(self) -> None:
+        """Non-image file data should produce a textual placeholder."""
+        contents = [
+            Content(
+                parts=[
+                    Part(
+                        file_data=FileData(
+                            mime_type="application/pdf",
+                            file_uri="https://example.com/document.pdf",
+                        )
+                    )
+                ],
+                role="user",
+            )
+        ]
+
+        messages = gemini_to_openai_messages(contents)
+
+        assert len(messages) == 1
+        assert (
+            messages[0].content
+            == "[Attachment: https://example.com/document.pdf (application/pdf)]"
+        )
+
     def test_openai_to_gemini_simple_message(self) -> None:
         """Test converting OpenAI message to Gemini content."""
         messages = [ChatMessage(role="user", content="Hello!")]


### PR DESCRIPTION
## Summary
- preserve Gemini inline and file data when translating to OpenAI chat messages
- update Gemini converter tests to cover multimodal content handling

## Testing
- python -m pytest --override-ini "addopts=" tests/unit/test_gemini_converters.py
- python -m pytest --override-ini "addopts=" (fails: missing optional test dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68e7856b5bf08333b77bb0fa46c75e98