### PR TITLE
Handle missing finish reasons in Gemini translation

### DIFF
--- a/src/core/domain/gemini_translation.py
+++ b/src/core/domain/gemini_translation.py
@@ -164,12 +164,18 @@ def canonical_response_to_gemini_response(
                 message = choice.get("message", {})
                 content = message.get("content", "")
 
+                finish_reason = choice.get("finish_reason")
+                if isinstance(finish_reason, str) and finish_reason:
+                    finish_reason_value = finish_reason.upper()
+                else:
+                    finish_reason_value = "STOP"
+
                 candidate = {
                     "content": {
                         "parts": [{"text": content}],
                         "role": "model",  # Always use 'model' role for Gemini responses
                     },
-                    "finishReason": choice.get("finish_reason", "STOP").upper(),
+                    "finishReason": finish_reason_value,
                     "index": idx,
                 }
 

--- a/tests/unit/core/domain/test_gemini_translation.py
+++ b/tests/unit/core/domain/test_gemini_translation.py
@@ -236,6 +236,29 @@ class TestCanonicalResponseToGemini:
         # Check finish reason
         assert gemini_response["candidates"][0]["finishReason"] == "TOOL_CALLS"
 
+    def test_response_with_missing_finish_reason(self) -> None:
+        """Test conversion when finish_reason is missing or None."""
+        response = {
+            "id": "chatcmpl-456",
+            "object": "chat.completion",
+            "created": 1677652299,
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Partial response without finish reason.",
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+
+        gemini_response = canonical_response_to_gemini_response(response)
+
+        assert gemini_response["candidates"][0]["finishReason"] == "STOP"
+
 
 class TestTranslationIntegration:
     """Integration tests for the Translation class."""


### PR DESCRIPTION
## Summary
- guard Gemini response translation against missing or null finish reasons so the formatter always emits a STOP marker
- extend the Gemini translation unit tests to cover responses without finish_reason

## Testing
- python -m pytest -o addopts="" tests/unit/core/domain/test_gemini_translation.py -k finish_reason
- python -m pytest -o addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68e7856b5bf08333b77bb0fa46c75e98