### PR TITLE
Fix Anthropic front-end user metadata propagation

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -37,6 +37,20 @@ def anthropic_to_openai_request(
         "stop": anthropic_request.stop_sequences,
         "stream": anthropic_request.stream or False,
     }
+
+    # Propagate user metadata when available so downstream services can
+    # maintain per-user accounting. Anthropic typically exposes the user
+    # identifier through the ``metadata`` payload.
+    metadata = anthropic_request.metadata
+    if isinstance(metadata, dict):
+        user_candidate = (
+            metadata.get("user_id")
+            or metadata.get("user")
+            or metadata.get("client_user_id")
+        )
+        if isinstance(user_candidate, str) and user_candidate.strip():
+            result["user"] = user_candidate.strip()
+
     return result
 
 

--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -106,6 +106,21 @@ class AnthropicController:
                     for msg in openai_request_data.get("messages", [])
                 ]
 
+            user_value = openai_request_data.get("user")
+            if not isinstance(user_value, str) or not user_value.strip():
+                metadata = anthropic_request.metadata
+                user_value = None
+                if isinstance(metadata, dict):
+                    metadata_user = (
+                        metadata.get("user_id")
+                        or metadata.get("user")
+                        or metadata.get("client_user_id")
+                    )
+                    if isinstance(metadata_user, str) and metadata_user.strip():
+                        user_value = metadata_user.strip()
+            else:
+                user_value = user_value.strip()
+
             chat_request = ChatRequest(
                 messages=messages,
                 model=openai_request_data.get("model", ""),
@@ -116,6 +131,7 @@ class AnthropicController:
                 frequency_penalty=openai_request_data.get("frequency_penalty", 0.0),
                 presence_penalty=openai_request_data.get("presence_penalty", 0.0),
                 stop=openai_request_data.get("stop"),
+                user=user_value,
             )
 
             # Process the request using the request processor

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_controller.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_controller.py
@@ -1,0 +1,66 @@
+"""Unit tests for the Anthropic controller."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import Request, Response
+
+from src.anthropic_models import AnthropicMessage, AnthropicMessagesRequest
+from src.core.app.controllers.anthropic_controller import AnthropicController
+from src.core.domain.responses import ResponseEnvelope
+
+
+def test_handle_messages_propagates_user_metadata() -> None:
+    """Ensure metadata.user_id is forwarded to the domain ChatRequest."""
+
+    envelope_content = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+    }
+
+    processor = MagicMock()
+    processor.process_request = AsyncMock(
+        return_value=ResponseEnvelope(
+            content=envelope_content,
+            headers={},
+            status_code=200,
+            media_type="application/json",
+        )
+    )
+
+    controller = AnthropicController(processor)
+    request = MagicMock(spec=Request)
+
+    async def invoke() -> Response:
+        with patch(
+            "src.core.app.controllers.anthropic_controller.fastapi_to_domain_request_context",
+            return_value=MagicMock(),
+        ):
+            return await controller.handle_anthropic_messages(
+                request,
+                AnthropicMessagesRequest(
+                    model="claude-3-sonnet-20240229",
+                    messages=[AnthropicMessage(role="user", content="Hello")],
+                    metadata={"user_id": "user-123"},
+                    max_tokens=64,
+                ),
+            )
+
+    response = asyncio.run(invoke())
+
+    awaited_call = processor.process_request.await_args
+    chat_request = awaited_call.args[1]
+
+    assert chat_request.user == "user-123"
+    assert response.status_code == 200
+    # Response body should be valid JSON after Anthropic conversion
+    assert json.loads(response.body)

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_converters.py
@@ -99,6 +99,19 @@ class TestAnthropicConverters:
         assert openai_req["stop"] == ["STOP", "END"]
         assert openai_req["stream"] is True
 
+    def test_anthropic_to_openai_request_transfers_user_metadata(self) -> None:
+        """Ensure user metadata is propagated to the OpenAI request."""
+
+        anthropic_req = AnthropicMessagesRequest(
+            model="claude-3-sonnet-20240229",
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            metadata={"user_id": "user-123", "extra": "value"},
+        )
+
+        openai_req = anthropic_to_openai_request(anthropic_req)
+
+        assert openai_req["user"] == "user-123"
+
     def test_openai_to_anthropic_response_basic(self) -> None:
         """Test basic OpenAI to Anthropic response conversion."""
         openai_response = {

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_router.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_router.py
@@ -4,6 +4,8 @@ Tests the FastAPI endpoints for /v1/messages and /v1/models.
 This test has been updated to use AnthropicController instead of the legacy anthropic_router.
 """
 
+import asyncio
+
 import pytest
 
 # Create a router for testing
@@ -124,10 +126,9 @@ class TestAnthropicRouter:
         assert "owned_by" in first_model
         assert first_model["owned_by"] == "anthropic"
 
-    @pytest.mark.asyncio
-    async def test_anthropic_models_function(self):
+    def test_anthropic_models_function(self):
         """Test the anthropic_models function directly."""
-        result = await anthropic_models()
+        result = asyncio.run(anthropic_models())
 
         assert result["object"] == "list"
         assert len(result["data"]) > 0
@@ -145,8 +146,7 @@ class TestAnthropicRouter:
         # Check that we get an error response (implementation may vary)
         assert response.status_code in [501, 404, 422]
 
-    @pytest.mark.asyncio
-    async def test_anthropic_messages_function_validation(self):
+    def test_anthropic_messages_function_validation(self):
         """Test the anthropic_messages function with valid input."""
         # Test the current implementation which returns a 501 Not Implemented response
         from unittest.mock import MagicMock
@@ -165,7 +165,7 @@ class TestAnthropicRouter:
         )
 
         # Call the function with proper arguments
-        response = await anthropic_messages(request_body, mock_request)
+        response = asyncio.run(anthropic_messages(request_body, mock_request))
 
         # Assert that we got a response (currently returns 501 Not Implemented)
         assert isinstance(response, Response)


### PR DESCRIPTION
## Summary
- propagate Anthropic metadata user identifiers through the OpenAI translation path and into the domain ChatRequest
- add coverage ensuring the controller forwards metadata.user_id and converters expose it
- adapt Anthropic front-end tests to run synchronously without pytest-asyncio dependency

## Testing
- python -m pytest tests/unit/anthropic_frontend_tests -o addopts=""
- python -m pytest -o addopts="" *(fails: missing pytest_asyncio/respx/pytest_httpx/pytest_mock/hypothesis dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7888fd070833387f1f43f8de12b52