### PR TITLE
Fix Anthropic streaming response format

### DIFF
--- a/tests/chat_completions_tests/test_anthropic_frontend.py
+++ b/tests/chat_completions_tests/test_anthropic_frontend.py
@@ -175,11 +175,12 @@ def test_anthropic_messages_streaming_frontend(anthropic_client):
         ) as res:
             # For streaming, we should get a 200 response
             assert res.status_code == 200
-            text = ""
-            for chunk in res.iter_text():
-                text += chunk
+            assert res.headers.get("content-type", "").startswith("text/event-stream")
+            text = "".join(res.iter_text())
             # Check that we get Anthropic streaming format
-            assert "content_block_delta" in text or "delta" in text
+            assert "message_start" in text
+            assert "content_block_delta" in text
+            assert "message_delta" in text
             mock_process.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- convert streaming responses returned through the Anthropic frontend into Anthropic-formatted server-sent events
- tighten the Anthropic frontend streaming test to assert the correct SSE content type and message markers

## Testing
- python -m pytest -o addopts='' tests/chat_completions_tests/test_anthropic_frontend.py::test_anthropic_messages_streaming_frontend
- python -m pytest -o addopts='' *(fails: missing pytest_asyncio, respx, pytest_httpx, pytest_mock, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e7888fd070833387f1f43f8de12b52