### PR TITLE
Fix detection method labeling in hybrid loop detector

### DIFF
--- a/src/loop_detection/hybrid_detector.py
+++ b/src/loop_detection/hybrid_detector.py
@@ -222,6 +222,7 @@ class HybridLoopDetector(ILoopDetector):
         # State tracking
         self._is_enabled = True
         self._loop_events: list[LoopDetectionEvent] = []
+        self._last_detection_method: str | None = None
 
         if logger.isEnabledFor(logging.INFO):
             logger.info(
@@ -243,10 +244,13 @@ class HybridLoopDetector(ILoopDetector):
         if not self._is_enabled or not chunk:
             return None
 
+        self._last_detection_method = None
+
         # Check short patterns first (faster, more common)
         short_event = self.short_detector.process_chunk(chunk)
         if short_event:
             self._loop_events.append(short_event)
+            self._last_detection_method = "short_pattern"
             return short_event
 
         # Check long patterns (only if short patterns didn't trigger)
@@ -266,6 +270,7 @@ class HybridLoopDetector(ILoopDetector):
                 timestamp=time.time(),
             )
             self._loop_events.append(event)
+            self._last_detection_method = "long_pattern"
 
             if logger.isEnabledFor(logging.WARNING):
                 logger.warning(
@@ -310,6 +315,8 @@ class HybridLoopDetector(ILoopDetector):
             else:
                 pattern_length = len(event.pattern)
 
+            detection_method = self._last_detection_method or "unknown"
+
             return LoopDetectionResult(
                 has_loop=True,
                 pattern=event.pattern,
@@ -317,9 +324,7 @@ class HybridLoopDetector(ILoopDetector):
                 details={
                     "pattern_length": pattern_length,
                     "total_repeated_chars": event.total_length,
-                    "detection_method": (
-                        "short_pattern" if event.total_length < 500 else "long_pattern"
-                    ),
+                    "detection_method": detection_method,
                 },
             )
         finally:
@@ -349,6 +354,7 @@ class HybridLoopDetector(ILoopDetector):
         self.short_detector.reset()
         self.long_detector.reset()
         self._loop_events.clear()
+        self._last_detection_method = None
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Hybrid loop detector state reset")
 
@@ -417,6 +423,7 @@ class HybridLoopDetector(ILoopDetector):
             "short_detector_state": self.short_detector._save_state(),
             "long_detector_content": self.long_detector.content,
             "loop_events": self._loop_events.copy(),
+            "last_detection_method": self._last_detection_method,
         }
 
     def _restore_state(self, state: dict[str, Any]) -> None:
@@ -424,3 +431,4 @@ class HybridLoopDetector(ILoopDetector):
         self.short_detector._restore_state(state["short_detector_state"])
         self.long_detector.content = state["long_detector_content"]
         self._loop_events = state["loop_events"]
+        self._last_detection_method = state.get("last_detection_method")

--- a/tests/unit/loop_detection/test_hybrid_loop_result_details.py
+++ b/tests/unit/loop_detection/test_hybrid_loop_result_details.py
@@ -33,3 +33,20 @@ async def test_long_pattern_details_report_actual_length() -> None:
         result.details["total_repeated_chars"]
         == result.repetitions * result.details["pattern_length"]
     )
+    assert result.details["detection_method"] == "long_pattern"
+
+
+@pytest.mark.asyncio
+async def test_short_pattern_reports_short_detection_method() -> None:
+    """Ensure short pattern detection reports the proper detection method."""
+    detector = HybridLoopDetector()
+
+    chunk = "A" * detector.short_detector.content_chunk_size
+    repetitions = detector.short_detector.content_loop_threshold + 2
+    content = chunk * repetitions
+
+    result = await detector.check_for_loops(content)
+
+    assert result.has_loop is True
+    assert result.details is not None
+    assert result.details["detection_method"] == "short_pattern"


### PR DESCRIPTION
## Summary
- track the last detection method used by the hybrid loop detector so result metadata reflects the actual detector path
- add regression coverage ensuring both long- and short-pattern detections report the correct method label

## Testing
- python -m pytest -o addopts="" tests/unit/loop_detection/test_hybrid_loop_result_details.py *(fails: async plugin not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e78908f4e48333adeb4c90334b73fd