### PR TITLE
Fix hybrid loop detection method reporting

### DIFF
--- a/tests/unit/loop_detection/test_hybrid_loop_result_details.py
+++ b/tests/unit/loop_detection/test_hybrid_loop_result_details.py
@@ -33,3 +33,33 @@ async def test_long_pattern_details_report_actual_length() -> None:
         result.details["total_repeated_chars"]
         == result.repetitions * result.details["pattern_length"]
     )
+
+
+@pytest.mark.asyncio
+async def test_short_pattern_details_identify_short_detector() -> None:
+    """Ensure detection metadata flags gemini-cli short pattern detections."""
+    short_config = {
+        "content_loop_threshold": 10,
+        "content_chunk_size": 50,
+        "max_history_length": 4096,
+    }
+    long_config = {
+        "min_pattern_length": 80,
+        "max_pattern_length": 160,
+        "min_repetitions": 3,
+        "max_history": 4096,
+    }
+
+    detector = HybridLoopDetector(
+        short_detector_config=short_config,
+        long_detector_config=long_config,
+    )
+
+    repeating_chunk = "A" * short_config["content_chunk_size"]
+    content = repeating_chunk * (short_config["content_loop_threshold"] + 2)
+
+    result = await detector.check_for_loops(content)
+
+    assert result.has_loop is True
+    assert result.details is not None
+    assert result.details["detection_method"] == "short_pattern"


### PR DESCRIPTION
## Summary
- track the last detection method within `HybridLoopDetector` so synchronous checks return accurate metadata
- expose the recorded detection method in stats/state snapshots to keep diagnostics in sync
- add a regression test ensuring short-pattern loops report the gemini-cli detector in the result details

## Testing
- python -m pytest --override-ini="addopts=" tests/unit/test_hybrid_loop_detector.py -k "not async_interface"
- python -m pytest --override-ini="addopts=" *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68e78908f4e48333adeb4c90334b73fd