### PR TITLE
Fix loop detection event length calculation

### DIFF
--- a/src/loop_detection/analyzer.py
+++ b/src/loop_detection/analyzer.py
@@ -64,10 +64,11 @@ class PatternAnalyzer:
             chunk_hash = self.hasher.hash(current_chunk)
 
             if self._is_loop_detected_for_chunk(current_chunk, chunk_hash):
+                repetitions = len(self._content_stats[chunk_hash])
                 event = self._create_detection_event_from_chunk(
                     pattern=current_chunk,
-                    repetition_count=len(self._content_stats[chunk_hash]),
-                    total_length=len(self._stream_history),
+                    repetition_count=repetitions,
+                    total_length=len(current_chunk) * repetitions,
                     confidence=1.0,
                     buffer_content=full_buffer_content,
                 )

--- a/tests/unit/loop_detection/test_analyzer.py
+++ b/tests/unit/loop_detection/test_analyzer.py
@@ -116,6 +116,22 @@ def test_pattern_analyzer_loop_detection_with_noise(analyzer: PatternAnalyzer) -
     assert event.repetition_count == 3
     assert event.confidence == 1.0
 
+def test_pattern_analyzer_total_length_excludes_prior_noise(
+    analyzer: PatternAnalyzer,
+) -> None:
+    """Ensure reported total length only counts repeated pattern content."""
+
+    # Introduce non-repeating text before the actual looped pattern
+    analyzer.analyze_chunk("noise", "noise")
+
+    event = None
+    for i in range(3):
+        buffer = "noise" + "abc" * (i + 1)
+        event = analyzer.analyze_chunk("abc", buffer)
+
+    assert event is not None
+    assert event.total_length == len("abc") * 3
+
 
 def test_pattern_analyzer_reset(analyzer: PatternAnalyzer) -> None:
     analyzer.analyze_chunk("some content", "some content")


### PR DESCRIPTION
## Summary
- ensure loop detection events produced by the streaming analyzer report the actual repeated span length
- add a regression test covering noise-prefixed loops to guard the corrected behaviour

## Testing
- `python -m pytest tests/unit/loop_detection/test_analyzer.py -k total_length_excludes_prior_noise -q -o addopts=`
- `python -m pytest -o addopts=` *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e78908f4e48333adeb4c90334b73fd