### PR TITLE
Preserve Anthropic metadata user during OpenAI translation

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -109,6 +109,18 @@ def anthropic_to_openai_request(
         "stop": anthropic_request.stop_sequences,
         "stream": anthropic_request.stream or False,
     }
+    if anthropic_request.metadata:
+        try:
+            metadata_dict = (
+                anthropic_request.metadata
+                if isinstance(anthropic_request.metadata, dict)
+                else dict(anthropic_request.metadata)
+            )
+        except Exception:
+            metadata_dict = {}
+        user_id = metadata_dict.get("user_id") or metadata_dict.get("user")
+        if user_id is not None:
+            result["user"] = str(user_id)
     if anthropic_request.tools:
         converted_tools = [
             tool_def


### PR DESCRIPTION
## Summary
- map Anthropic metadata.user_id (or user) into the OpenAI-compatible request payload
- add regression tests covering metadata propagation and passthrough block serialization in the Anthropic converters

## Testing
- python -m pytest tests/unit/anthropic_frontend_tests/test_anthropic_converters.py -k metadata -q --override-ini="addopts="
- python -m pytest --override-ini="addopts=" # fails: missing optional test dependencies (pytest-asyncio, respx, pytest_httpx, hypothesis, pytest_mock)


------
https://chatgpt.com/codex/tasks/task_e_68e795a1f89483339d638d07905648cb