### PR TITLE
Preserve tool call metadata in Anthropic controller

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -97,14 +97,27 @@ class AnthropicController:
             # Convert the dict to a ChatRequest object
             from src.core.domain.chat import ChatMessage, ChatRequest
 
-            messages = []
-            if "messages" in openai_request_data:
-                messages = [
-                    ChatMessage(
-                        role=msg.get("role", "user"), content=msg.get("content", "")
-                    )
-                    for msg in openai_request_data.get("messages", [])
-                ]
+            messages: list[ChatMessage] = []
+            for msg in openai_request_data.get("messages", []):
+                content_value = msg.get("content", "")
+                message_kwargs: dict[str, Any] = {
+                    "role": msg.get("role", "user"),
+                    "content": content_value,
+                }
+
+                name_value = msg.get("name")
+                if name_value is not None:
+                    message_kwargs["name"] = name_value
+
+                tool_calls_value = msg.get("tool_calls")
+                if tool_calls_value:
+                    message_kwargs["tool_calls"] = tool_calls_value
+
+                tool_call_id_value = msg.get("tool_call_id")
+                if tool_call_id_value:
+                    message_kwargs["tool_call_id"] = tool_call_id_value
+
+                messages.append(ChatMessage(**message_kwargs))
 
             chat_request = ChatRequest(
                 messages=messages,

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_controller.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_controller.py
@@ -1,0 +1,112 @@
+"""Tests for the AnthropicController request handling logic."""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, Request, Response
+
+from src.anthropic_models import AnthropicMessage, AnthropicMessagesRequest
+from src.core.app.controllers.anthropic_controller import AnthropicController
+
+
+@pytest.mark.asyncio
+async def test_controller_preserves_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure tool call metadata survives conversion to the domain ChatRequest."""
+
+    processor = SimpleNamespace(process_request=AsyncMock())
+    processor.process_request.return_value = object()
+    controller = AnthropicController(processor)
+
+    fake_context = object()
+    monkeypatch.setattr(
+        "src.core.app.controllers.anthropic_controller.fastapi_to_domain_request_context",
+        lambda *_args, **_kwargs: fake_context,
+    )
+
+    response_payload = {
+        "id": "chatcmpl-1",
+        "model": "gpt-test",
+        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    }
+    fastapi_response = Response(
+        content=json.dumps(response_payload),
+        media_type="application/json",
+    )
+
+    monkeypatch.setattr(
+        "src.core.app.controllers.anthropic_controller.domain_response_to_fastapi",
+        lambda _resp: fastapi_response,
+    )
+
+    app = FastAPI()
+    scope: dict[str, Any] = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/anthropic/v1/messages",
+        "raw_path": b"/anthropic/v1/messages",
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 12345),
+        "server": ("testserver", 80),
+        "app": app,
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive)  # type: ignore[arg-type]
+
+    anthropic_request = AnthropicMessagesRequest(
+        model="claude-3-sonnet-20240229",
+        max_tokens=128,
+        messages=[
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "call_123",
+                        "name": "weather",
+                        "input": {"location": "San Francisco"},
+                    }
+                ],
+            ),
+            AnthropicMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": [{"type": "text", "text": "Result text"}],
+                    }
+                ],
+            ),
+        ],
+    )
+
+    await controller.handle_anthropic_messages(request, anthropic_request)
+
+    assert processor.process_request.await_count == 1
+    await_args = processor.process_request.await_args
+    chat_request = await_args.args[1]
+
+    assert len(chat_request.messages) == 2
+
+    first_message = chat_request.messages[0]
+    assert first_message.role == "assistant"
+    assert first_message.tool_calls is not None
+    assert first_message.tool_calls[0].id == "call_123"
+    assert json.loads(first_message.tool_calls[0].function.arguments) == {
+        "location": "San Francisco"
+    }
+
+    second_message = chat_request.messages[1]
+    assert second_message.role == "tool"
+    assert second_message.tool_call_id == "call_123"
+    assert second_message.content == "Result text"


### PR DESCRIPTION
## Summary
- ensure the Anthropic controller forwards tool call metadata when translating messages for the core processor
- add a regression test covering tool call and tool result translation through the controller layer

## Testing
- python -m pytest -o addopts= tests/unit/anthropic_frontend_tests/test_anthropic_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68e795a1f89483339d638d07905648cb