### PR TITLE
Fix Anthropic stop reason translation for domain responses

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException, Request, Response
 from src.anthropic_converters import (
     anthropic_to_openai_request,
     openai_to_anthropic_response,
+    _map_finish_reason,
 )
 from src.anthropic_models import AnthropicMessagesRequest
 from src.core.common.exceptions import InitializationError, LLMProxyError
@@ -173,13 +174,18 @@ class AnthropicController:
                         first = cr.choices[0] if cr.choices else None
                         text = first.message.content if first and first.message else ""
                         usage = cr.usage or {}
+                        stop_reason = (
+                            _map_finish_reason(first.finish_reason)
+                            if first and first.finish_reason is not None
+                            else None
+                        )
                         anthropic_response_data = {
                             "id": cr.id,
                             "type": "message",
                             "role": "assistant",
                             "content": [{"type": "text", "text": text or ""}],
                             "model": cr.model,
-                            "stop_reason": first.finish_reason if first else "stop",
+                            "stop_reason": stop_reason,
                             "stop_sequence": None,
                             "usage": {
                                 "input_tokens": usage.get("prompt_tokens", 0),


### PR DESCRIPTION
## Summary
- ensure AnthropicController maps ChatResponse finish reasons through the Anthropic stop reason mapping helper
- add a regression test covering tool call finish reasons returned from the Anthropic front-end

## Testing
- pytest --override-ini=addopts='' tests/chat_completions_tests/test_anthropic_frontend.py::test_anthropic_messages_maps_finish_reason_from_domain_response -q
- pytest --override-ini=addopts='' -q *(fails: missing optional test dependencies such as pytest-asyncio, respx, pytest_httpx, hypothesis, pytest_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e795a1f89483339d638d07905648cb