### PR TITLE
Handle Gemini function responses in translation

### DIFF
--- a/src/core/domain/gemini_translation.py
+++ b/src/core/domain/gemini_translation.py
@@ -4,6 +4,7 @@ Gemini translation utilities.
 This module provides utilities for translating between Gemini API format and other formats.
 """
 
+import json
 from typing import Any
 
 from src.core.domain.chat import (
@@ -47,8 +48,40 @@ def gemini_content_to_chat_messages(
         # Complex case: multiple parts or non-text parts
         content_parts: list[MessageContentPartText | MessageContentPartImage] = []
         tool_calls: list[ToolCall] = []
+        tool_responses: list[ChatMessage] = []
 
         for part in parts:
+            function_response = part.get("functionResponse") or part.get(
+                "function_response"
+            )
+            if function_response:
+                response_payload = function_response.get("response")
+                if isinstance(response_payload, str):
+                    response_content = response_payload
+                else:
+                    try:
+                        response_content = json.dumps(response_payload)
+                    except (TypeError, ValueError):
+                        response_content = str(response_payload)
+
+                tool_message_kwargs: dict[str, Any] = {
+                    "role": "tool",
+                    "content": response_content,
+                }
+
+                name = function_response.get("name")
+                if isinstance(name, str) and name:
+                    tool_message_kwargs["name"] = name
+
+                tool_call_id = function_response.get("toolCallId") or function_response.get(
+                    "tool_call_id"
+                )
+                if isinstance(tool_call_id, str) and tool_call_id:
+                    tool_message_kwargs["tool_call_id"] = tool_call_id
+
+                tool_responses.append(ChatMessage(**tool_message_kwargs))
+                continue
+
             if "text" in part:
                 content_parts.append(MessageContentPartText(text=part["text"]))
                 continue
@@ -83,21 +116,25 @@ def gemini_content_to_chat_messages(
                     )
                     content_parts.append(image_part)  # type: ignore[arg-type]
 
-        if not content_parts and not tool_calls:
+        if not content_parts and not tool_calls and not tool_responses:
             continue
 
-        message_content: (
-            str | list[MessageContentPartText | MessageContentPartImage] | None
-        )
-        message_content = content_parts if content_parts else None
-
-        chat_messages.append(
-            ChatMessage(
-                role=role,
-                content=message_content,
-                tool_calls=tool_calls or None,
+        if content_parts or tool_calls:
+            message_content: (
+                str | list[MessageContentPartText | MessageContentPartImage] | None
             )
-        )
+            message_content = content_parts if content_parts else None
+
+            chat_messages.append(
+                ChatMessage(
+                    role=role,
+                    content=message_content,
+                    tool_calls=tool_calls or None,
+                )
+            )
+
+        if tool_responses:
+            chat_messages.extend(tool_responses)
 
     return chat_messages
 

--- a/tests/unit/core/domain/test_gemini_translation.py
+++ b/tests/unit/core/domain/test_gemini_translation.py
@@ -87,6 +87,33 @@ class TestGeminiContentToMessages:
         assert tool_call.function.name == "call_tool"
         assert json.loads(tool_call.function.arguments) == {"foo": "bar"}
 
+    def test_function_response_content(self) -> None:
+        """Test conversion of Gemini function responses to tool messages."""
+
+        contents = [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "functionResponse": {
+                            "name": "get_weather",
+                            "toolCallId": "call_123",
+                            "response": {"weather": "sunny"},
+                        }
+                    }
+                ],
+            }
+        ]
+
+        messages = gemini_content_to_chat_messages(contents)
+
+        assert len(messages) == 1
+        message = messages[0]
+        assert message.role == "tool"
+        assert message.name == "get_weather"
+        assert message.tool_call_id == "call_123"
+        assert message.content == json.dumps({"weather": "sunny"})
+
 
 class TestGeminiRequestToCanonical:
     """Tests for converting Gemini requests to canonical requests."""


### PR DESCRIPTION
## Summary
- ensure Gemini functionResponse parts are translated into tool role chat messages so tool outputs reach the backend
- add regression coverage for functionResponse handling in the Gemini translation utilities

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/core/domain/test_gemini_translation.py
- python -m pytest --override-ini=addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e795b971d08333a9a62c48b5a48de7