### PR TITLE
Fix Gemini streaming chunk conversion

### DIFF
--- a/src/core/app/controllers/__init__.py
+++ b/src/core/app/controllers/__init__.py
@@ -605,7 +605,11 @@ def register_versioned_endpoints(app: FastAPI) -> None:
 
             from fastapi.responses import StreamingResponse
 
+            from src.core.domain.gemini_translation import (
+                canonical_response_to_gemini_response,
+            )
             from src.core.interfaces.backend_service_interface import IBackendService
+            from src.core.interfaces.response_processor_interface import ProcessedResponse
             from src.core.services.translation_service import TranslationService
 
             # Add model to request data if not present
@@ -643,53 +647,45 @@ def register_versioned_endpoints(app: FastAPI) -> None:
                         # Process streaming response
                         async for chunk in result.content:
                             try:
-                                # Convert OpenAI streaming format to Gemini streaming format
-                                if isinstance(chunk, dict):
-                                    # Use the translation function to convert the chunk
-                                    from src.core.domain.translation import Translation
+                                processed_chunk: ProcessedResponse
+                                if isinstance(chunk, ProcessedResponse):
+                                    processed_chunk = chunk
+                                else:
+                                    processed_chunk = ProcessedResponse(content=chunk)
 
-                                    gemini_chunk = (
-                                        Translation.gemini_to_domain_stream_chunk(chunk)
+                                chunk_payload = processed_chunk.content
+                                if isinstance(chunk_payload, (bytes, bytearray)):
+                                    chunk_payload = chunk_payload.decode(
+                                        "utf-8", errors="ignore"
                                     )
 
-                                    # Extract content from the converted chunk
-                                    content = ""
-                                    if (
-                                        gemini_chunk.get("choices")
-                                        and "delta" in gemini_chunk["choices"][0]
-                                    ):
-                                        content = gemini_chunk["choices"][0][
-                                            "delta"
-                                        ].get("content", "")
+                                if chunk_payload is None:
+                                    continue
 
-                                    # Create Gemini format chunk
-                                    gemini_format = {
-                                        "candidates": [
-                                            {
-                                                "content": {
-                                                    "parts": [{"text": content}],
-                                                    "role": "model",
-                                                },
-                                                "index": 0,
-                                            }
+                                if isinstance(chunk_payload, str):
+                                    canonical_chunk = {
+                                        "choices": [
+                                            {"delta": {"content": chunk_payload}}
                                         ]
                                     }
-
-                                    # Format as SSE
-                                    yield f"data: {json.dumps(gemini_format)}\n\n".encode()
+                                elif isinstance(chunk_payload, dict):
+                                    canonical_chunk = chunk_payload
                                 else:
-                                    # Handle string chunks
-                                    gemini_format = {
-                                        "candidates": [
+                                    canonical_chunk = {
+                                        "choices": [
                                             {
-                                                "content": {
-                                                    "parts": [{"text": str(chunk)}],
-                                                    "role": "model",
-                                                },
-                                                "index": 0,
+                                                "delta": {
+                                                    "content": str(chunk_payload)
+                                                }
                                             }
                                         ]
                                     }
+
+                                gemini_format = canonical_response_to_gemini_response(
+                                    canonical_chunk, is_streaming=True
+                                )
+
+                                if gemini_format:
                                     yield f"data: {json.dumps(gemini_format)}\n\n".encode()
                             except Exception as chunk_error:
                                 logger.error(f"Error processing chunk: {chunk_error}")


### PR DESCRIPTION
## Summary
- normalize Gemini streaming controller to translate ProcessedResponse chunks into proper Gemini SSE payloads before emitting events
- expand the Gemini API compatibility streaming test to assert SSE output generated from canonical streaming chunks

## Testing
- python -m pytest -o addopts= tests/unit/chat_completions_tests/test_gemini_api_compatibility_di.py::TestGeminiStreamGenerateContent::test_stream_generate_content
- python -m pytest -o addopts= *(fails: missing pytest_asyncio, pytest_httpx, respx, hypothesis, pytest_mock in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e795b971d08333a9a62c48b5a48de7