### PR TITLE
Fix session-scoped API key redaction handling

### DIFF
--- a/src/core/domain/commands/set_command.py
+++ b/src/core/domain/commands/set_command.py
@@ -354,8 +354,7 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 state,
             )
 
-        # Update state through secure DI interface
-        self.update_state_setting("api_key_redaction_enabled", bool(enabled))
+        updated_state = state.with_redact_api_keys_in_prompts(enabled)
 
         return (
             CommandResult(
@@ -363,7 +362,7 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 message=f"API key redaction in prompts {'enabled' if enabled else 'disabled'}",
                 data={"redact-api-keys-in-prompts": enabled},
             ),
-            state,
+            updated_state,
         )
 
     def _is_static_routing_enabled(self) -> bool:

--- a/src/core/domain/commands/unset_command.py
+++ b/src/core/domain/commands/unset_command.py
@@ -167,15 +167,14 @@ class UnsetCommand(StatefulCommandBase, BaseCommand):
     def _unset_redact_api_keys(
         self, state: ISessionState, context: Any
     ) -> tuple[CommandResult, ISessionState]:
-        # Update state through secure DI interface
-        self.update_state_setting("api_key_redaction_enabled", True)
+        updated_state = state.with_redact_api_keys_in_prompts(True)
 
         result = CommandResult(
             success=True,
             message="API key redaction reset to default (enabled)",
             data={"redact-api-keys-in-prompts": True},
         )
-        return result, state  # No state change in session
+        return result, updated_state
 
     def _unset_command_prefix(
         self, state: ISessionState, context: Any

--- a/src/core/interfaces/domain_entities_interface.py
+++ b/src/core/interfaces/domain_entities_interface.py
@@ -120,6 +120,10 @@ class ISessionStateMutator(ABC):
     def with_is_cline_agent(self, is_cline: bool) -> ISessionState:
         """Create a new state with updated is_cline_agent flag."""
 
+    @abstractmethod
+    def with_redact_api_keys_in_prompts(self, enabled: bool) -> ISessionState:
+        """Create a new state with updated API key redaction flag."""
+
 
 class ISessionState(IValueObject, ISessionStateMutator):
     """Interface for session state value objects."""
@@ -236,6 +240,11 @@ class ISessionState(IValueObject, ISessionStateMutator):
     @abstractmethod
     def pytest_compression_min_lines(self) -> int:
         """Get minimum line threshold for pytest compression."""
+
+    @property
+    @abstractmethod
+    def redact_api_keys_in_prompts(self) -> bool:
+        """Get whether API keys should be redacted for this session."""
 
     @abstractmethod
     def with_pytest_compression_enabled(self, enabled: bool) -> ISessionState:

--- a/src/core/services/request_processor_service.py
+++ b/src/core/services/request_processor_service.py
@@ -356,6 +356,20 @@ class RequestProcessor(IRequestProcessor):
                     should_redact = True
 
                 if should_redact:
+                    try:
+                        session_redaction_enabled = bool(
+                            getattr(
+                                getattr(session, "state", None),
+                                "redact_api_keys_in_prompts",
+                                True,
+                            )
+                        )
+                    except Exception:
+                        session_redaction_enabled = True
+                    if not session_redaction_enabled:
+                        should_redact = False
+
+                if should_redact:
                     api_keys = discover_api_keys_from_config_and_env(app_config)
                     # Command prefix can be None; RedactionMiddleware has a default
                     command_prefix = None

--- a/tests/unit/commands/test_unit_unset_command.py
+++ b/tests/unit/commands/test_unit_unset_command.py
@@ -84,3 +84,14 @@ def test_unset_project(command: UnsetCommand, initial_state: SessionState):
     assert result.success is True
     assert result.message == "Project reset to default"
     assert new_state.project is None
+
+
+def test_unset_redact_api_keys_updates_session_state(
+    command: UnsetCommand, initial_state: SessionState
+) -> None:
+    starting_state = initial_state.with_redact_api_keys_in_prompts(False)
+
+    result, new_state = command._unset_redact_api_keys(starting_state, {})
+
+    assert result.success is True
+    assert new_state.redact_api_keys_in_prompts is True


### PR DESCRIPTION
## Summary
- treat API key redaction toggles from the set/unset commands as session-scoped state instead of mutating global application settings
- add per-session storage for the redaction flag and ensure the request processor skips redaction only when a session disables it
- cover the updated behavior with unit tests for the set and unset commands

## Testing
- `python -m pytest --override-ini addopts='' tests/unit/commands/test_unit_set_command.py tests/unit/commands/test_unit_unset_command.py`
- `python -m pytest --override-ini addopts=''` *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, pytest_mock, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e7950a4cc0833399dd13d6f271c20d