### PR TITLE
Add per-session API key redaction overrides

### DIFF
--- a/src/core/domain/commands/set_command.py
+++ b/src/core/domain/commands/set_command.py
@@ -354,8 +354,7 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 state,
             )
 
-        # Update state through secure DI interface
-        self.update_state_setting("api_key_redaction_enabled", bool(enabled))
+        updated_state = state.with_api_key_redaction_enabled(bool(enabled))
 
         return (
             CommandResult(
@@ -363,7 +362,7 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 message=f"API key redaction in prompts {'enabled' if enabled else 'disabled'}",
                 data={"redact-api-keys-in-prompts": enabled},
             ),
-            state,
+            updated_state,
         )
 
     def _is_static_routing_enabled(self) -> bool:

--- a/src/core/domain/commands/unset_command.py
+++ b/src/core/domain/commands/unset_command.py
@@ -167,15 +167,14 @@ class UnsetCommand(StatefulCommandBase, BaseCommand):
     def _unset_redact_api_keys(
         self, state: ISessionState, context: Any
     ) -> tuple[CommandResult, ISessionState]:
-        # Update state through secure DI interface
-        self.update_state_setting("api_key_redaction_enabled", True)
+        updated_state = state.with_api_key_redaction_enabled(None)
 
         result = CommandResult(
             success=True,
-            message="API key redaction reset to default (enabled)",
-            data={"redact-api-keys-in-prompts": True},
+            message="API key redaction reset to default",
+            data={"redact-api-keys-in-prompts": None},
         )
-        return result, state  # No state change in session
+        return result, updated_state
 
     def _unset_command_prefix(
         self, state: ISessionState, context: Any

--- a/src/core/interfaces/domain_entities_interface.py
+++ b/src/core/interfaces/domain_entities_interface.py
@@ -251,6 +251,17 @@ class ISessionState(IValueObject, ISessionStateMutator):
     def with_pytest_compression_min_lines(self, min_lines: int) -> ISessionState:
         """Create a new state with updated pytest_compression_min_lines value."""
 
+    @property
+    @abstractmethod
+    def api_key_redaction_enabled(self) -> bool | None:
+        """Get the session-specific API key redaction override."""
+
+    @abstractmethod
+    def with_api_key_redaction_enabled(
+        self, enabled: bool | None
+    ) -> ISessionState:
+        """Create a new state with updated API key redaction flag."""
+
     @abstractmethod
     def with_planning_phase_config(self, config: IPlanningPhaseConfig) -> ISessionState:
         """Create a new state with updated planning phase configuration."""

--- a/tests/unit/commands/test_set_command.py
+++ b/tests/unit/commands/test_set_command.py
@@ -160,3 +160,27 @@ async def test_handle_project_success(command: SetCommand, mock_session: Mock):
     assert result.success is True
     assert result.message == "Project changed to test_project"
     assert new_state.project == "test_project"
+
+
+@pytest.mark.asyncio
+async def test_handle_redact_api_keys_updates_state(
+    command: SetCommand, mock_session: Mock
+) -> None:
+    result, new_state = await command._handle_redact_api_keys_in_prompts(
+        "false", mock_session.state, {}
+    )
+
+    assert result.success is True
+    assert new_state.api_key_redaction_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_handle_redact_api_keys_enables_state(
+    command: SetCommand, mock_session: Mock
+) -> None:
+    result, new_state = await command._handle_redact_api_keys_in_prompts(
+        "true", mock_session.state, {}
+    )
+
+    assert result.success is True
+    assert new_state.api_key_redaction_enabled is True

--- a/tests/unit/commands/test_unit_unset_command.py
+++ b/tests/unit/commands/test_unit_unset_command.py
@@ -84,3 +84,12 @@ def test_unset_project(command: UnsetCommand, initial_state: SessionState):
     assert result.success is True
     assert result.message == "Project reset to default"
     assert new_state.project is None
+
+
+def test_unset_redact_api_keys(command: UnsetCommand, initial_state: SessionState):
+    state_with_override = initial_state.with_api_key_redaction_enabled(False)
+
+    result, new_state = command._unset_redact_api_keys(state_with_override, {})
+
+    assert result.success is True
+    assert new_state.api_key_redaction_enabled is None

--- a/tests/unit/core/test_request_processor.py
+++ b/tests/unit/core/test_request_processor.py
@@ -10,6 +10,7 @@ from src.core.domain.chat import ChatMessage, ChatRequest
 from src.core.domain.commands import CommandResult
 from src.core.domain.processed_result import ProcessedResult
 from src.core.domain.request_context import RequestContext
+from src.core.domain.session import Session
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.interfaces.application_state_interface import IApplicationState
 from src.core.interfaces.domain_entities_interface import ISessionState
@@ -144,6 +145,163 @@ async def test_process_request_basic(session_service: MockSessionService) -> Non
     session_manager.get_session.assert_called_once_with("test-session")
     session_manager.update_session_agent.assert_called_once()
     session_manager.update_session_history.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_request_processor_skips_redaction_when_session_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command_processor = MockCommandProcessor()
+    session_manager = AsyncMock()
+    backend_request_manager = AsyncMock()
+    response_manager = AsyncMock()
+
+    session = Session(session_id="test-session")
+    session.state = session.state.with_api_key_redaction_enabled(False)
+
+    session_manager.resolve_session_id.return_value = "test-session"
+    session_manager.get_session.return_value = session
+    session_manager.update_session_agent.return_value = session
+    session_manager.update_session_history.return_value = None
+
+    request_data = create_mock_request()
+
+    command_processor.add_result(
+        ProcessedResult(
+            modified_messages=request_data.messages,
+            command_executed=False,
+            command_results=[],
+        )
+    )
+
+    response = TestDataBuilder.create_chat_response("Hello there!")
+    backend_request_manager.prepare_backend_request.return_value = request_data
+    backend_request_manager.process_backend_request.return_value = response
+
+    from unittest.mock import MagicMock
+
+    from src.core.config.app_config import AppConfig
+    from src.core.interfaces.application_state_interface import IApplicationState
+
+    app_config = AppConfig()
+    app_config.auth.redact_api_keys_in_prompts = True
+
+    mock_app_state = MagicMock(spec=IApplicationState)
+    mock_app_state.get_setting.return_value = app_config
+    mock_app_state.get_disable_commands.return_value = False
+
+    instantiation_count = 0
+
+    class TrackingRedactionMiddleware:
+        def __init__(self, *args, **kwargs) -> None:
+            nonlocal instantiation_count
+            instantiation_count += 1
+
+        async def process(
+            self, request: ChatRequest, context: dict[str, Any] | None = None
+        ) -> ChatRequest:
+            return request
+
+    monkeypatch.setattr(
+        "src.core.services.redaction_middleware.RedactionMiddleware",
+        TrackingRedactionMiddleware,
+    )
+    monkeypatch.setattr(
+        "src.core.common.logging_utils.discover_api_keys_from_config_and_env",
+        lambda _cfg: [],
+    )
+
+    processor = RequestProcessor(
+        command_processor,
+        session_manager,
+        backend_request_manager,
+        response_manager,
+        app_state=mock_app_state,
+    )
+
+    await processor.process_request(MockRequestContext(), request_data)
+
+    assert instantiation_count == 0
+
+
+@pytest.mark.asyncio
+async def test_request_processor_applies_redaction_when_session_enables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command_processor = MockCommandProcessor()
+    session_manager = AsyncMock()
+    backend_request_manager = AsyncMock()
+    response_manager = AsyncMock()
+
+    session = Session(session_id="test-session")
+    session.state = session.state.with_api_key_redaction_enabled(True)
+
+    session_manager.resolve_session_id.return_value = "test-session"
+    session_manager.get_session.return_value = session
+    session_manager.update_session_agent.return_value = session
+    session_manager.update_session_history.return_value = None
+
+    request_data = create_mock_request()
+
+    command_processor.add_result(
+        ProcessedResult(
+            modified_messages=request_data.messages,
+            command_executed=False,
+            command_results=[],
+        )
+    )
+
+    response = TestDataBuilder.create_chat_response("Hello there!")
+    backend_request_manager.prepare_backend_request.return_value = request_data
+    backend_request_manager.process_backend_request.return_value = response
+
+    from unittest.mock import MagicMock
+
+    from src.core.config.app_config import AppConfig
+    from src.core.interfaces.application_state_interface import IApplicationState
+
+    app_config = AppConfig()
+    app_config.auth.redact_api_keys_in_prompts = False
+
+    mock_app_state = MagicMock(spec=IApplicationState)
+    mock_app_state.get_setting.return_value = app_config
+    mock_app_state.get_disable_commands.return_value = False
+
+    instantiation_count = 0
+    processed_requests: list[ChatRequest] = []
+
+    class TrackingRedactionMiddleware:
+        def __init__(self, *args, **kwargs) -> None:
+            nonlocal instantiation_count
+            instantiation_count += 1
+
+        async def process(
+            self, request: ChatRequest, context: dict[str, Any] | None = None
+        ) -> ChatRequest:
+            processed_requests.append(request)
+            return request
+
+    monkeypatch.setattr(
+        "src.core.services.redaction_middleware.RedactionMiddleware",
+        TrackingRedactionMiddleware,
+    )
+    monkeypatch.setattr(
+        "src.core.common.logging_utils.discover_api_keys_from_config_and_env",
+        lambda _cfg: [],
+    )
+
+    processor = RequestProcessor(
+        command_processor,
+        session_manager,
+        backend_request_manager,
+        response_manager,
+        app_state=mock_app_state,
+    )
+
+    await processor.process_request(MockRequestContext(), request_data)
+
+    assert instantiation_count == 1
+    assert processed_requests
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extend the session state model and adapter to carry an API key redaction override and return adapter instances when mutating it
- scope the !/set and !/unset redaction parameters to per-session state instead of mutating global app configuration
- let the request processor honor session overrides before falling back to global configuration and cover the behaviour with targeted unit tests

## Testing
- pytest --override-ini addopts="" tests/unit/commands/test_set_command.py tests/unit/commands/test_unit_unset_command.py tests/unit/core/test_request_processor.py
- pytest --override-ini addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68e7950a4cc0833399dd13d6f271c20d