### PR TITLE
Fix hybrid loop detector mixed pattern test

### DIFF
--- a/tests/unit/test_hybrid_loop_detector.py
+++ b/tests/unit/test_hybrid_loop_detector.py
@@ -132,8 +132,13 @@ Fixtures:
                 break
 
         # Should detect either the short or long pattern
+        assert (
+            detection_event is not None
+        ), "Expected at least one loop detection for mixed patterns"
+
         stats = detector.get_stats()
-        assert stats["total_events"] >= 0  # May have detected something
+        assert stats["total_events"] > 0
+        assert detection_event.repetition_count >= 2
 
     def test_performance_with_large_content(self):
         """Test that the detector performs well with larger content volumes."""


### PR DESCRIPTION
## Summary
- update the mixed pattern hybrid loop detector test to require an actual detection event
- assert the total event counter increments and the repetition count is meaningful

## Testing
- python -m pytest -o addopts="" tests/unit/test_hybrid_loop_detector.py::TestHybridLoopDetector::test_mixed_pattern_types

------
https://chatgpt.com/codex/tasks/task_e_68e7cf14aa408333afaee14057a21d8a