### PR TITLE
Fix redact_dict test to assert actual redaction

### DIFF
--- a/tests/unit/core/test_logging_utils.py
+++ b/tests/unit/core/test_logging_utils.py
@@ -53,7 +53,8 @@ class TestRedaction:
 
         result = redact_dict(data)
 
-        assert result["api_key"] != "sk_12345678"  # Redacted
+        # Ensure the sensitive value is no longer the original string
+        assert result["api_key"] != data["api_key"]  # Redacted
         assert result["name"] == "test"  # Not redacted
         assert result["config"]["password"] != "secret123"  # Redacted
         assert result["config"]["public"] == "public_value"  # Not redacted


### PR DESCRIPTION
## Summary
- correct the redact_dict test to compare the redacted API key against the original value, ensuring redaction is verified

## Testing
- python -m pytest -c /tmp/pytest.ini tests/unit/core/test_logging_utils.py::TestRedaction::test_redact_dict

------
https://chatgpt.com/codex/tasks/task_e_68e7cf14aa408333afaee14057a21d8a