### PR TITLE
Fix logging redaction test to validate API key masking

### DIFF
--- a/tests/unit/core/test_logging_utils.py
+++ b/tests/unit/core/test_logging_utils.py
@@ -53,7 +53,8 @@ class TestRedaction:
 
         result = redact_dict(data)
 
-        assert result["api_key"] != "sk_12345678"  # Redacted
+        assert result["api_key"] != data["api_key"]  # Redacted
+        assert "***" in result["api_key"]
         assert result["name"] == "test"  # Not redacted
         assert result["config"]["password"] != "secret123"  # Redacted
         assert result["config"]["public"] == "public_value"  # Not redacted


### PR DESCRIPTION
## Summary
- ensure the redact_dict test checks that API keys are actually masked

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7cf14aa408333afaee14057a21d8a