### PR TITLE
Improve asynccontextmanager interface test

### DIFF
--- a/tests/unit/core/services/test_usage_tracking_interface.py
+++ b/tests/unit/core/services/test_usage_tracking_interface.py
@@ -1,10 +1,7 @@
-"""
-Tests for Usage Tracking Interface.
-
-This module tests the usage tracking interface definitions and contract compliance.
-"""
+"""Tests for the usage tracking interface definitions and contract compliance."""
 
 from abc import ABC
+import inspect
 
 from src.core.interfaces.usage_tracking_interface import IUsageTrackingService
 
@@ -65,9 +62,12 @@ class TestUsageTrackingInterfaceCompliance:
         """Test that track_request method has asynccontextmanager decorator."""
         track_request_method = IUsageTrackingService.track_request
 
-        # The method should be decorated with @asynccontextmanager
-        # This is typically indicated by the presence of the decorator
-        assert hasattr(track_request_method, "__annotations__")
+        # The asynccontextmanager decorator wraps an async generator function and
+        # preserves it on the ``__wrapped__`` attribute. Verifying this attribute
+        # exists (and is the expected async generator) ensures the decorator is
+        # actually applied.
+        assert hasattr(track_request_method, "__wrapped__")
+        assert inspect.isasyncgenfunction(track_request_method.__wrapped__)
 
     def test_track_request_return_type_annotation(self) -> None:
         """Test that track_request has proper return type annotation."""


### PR DESCRIPTION
## Summary
- update the usage tracking interface test to verify the asynccontextmanager decorator by checking for the wrapped async generator
- add the missing inspect import for the strengthened decorator assertion

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --override-ini="addopts=" tests/unit/core/services/test_usage_tracking_interface.py -k test_track_request_has_asynccontextmanager_decorator


------
https://chatgpt.com/codex/tasks/task_e_68e7cfd095148333af60717fa57888d2