### PR TITLE
Fix versioned API existence test

### DIFF
--- a/tests/integration/test_versioned_api.py
+++ b/tests/integration/test_versioned_api.py
@@ -164,18 +164,20 @@ async def initialized_app(app: FastAPI):
 
 
 def test_versioned_endpoint_exists(client: TestClient):
-    """Test that the versioned endpoint exists."""
-    # Should not return 404
+    """The chat completions endpoint should authenticate and return a response."""
     response = client.post(
         "/v1/chat/completions",
         json={
             "model": "test-model",
             "messages": [{"role": "user", "content": "Test message"}],
         },
+        headers={"Authorization": "Bearer test-proxy-key"},
     )
 
-    # We expect an error due to missing services, but not a 404
-    assert response.status_code != 404
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model"] == "test-model"
+    assert body["choices"][0]["message"]["role"] == "assistant"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update the versioned API integration test to include the expected authorization header
- assert for a successful response and basic response structure to ensure the endpoint behaves correctly

## Testing
- Not run (pytest configuration requires pytest-xdist, which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7cfd095148333af60717fa57888d2