### PR TITLE
Ensure ChatController resolves TranslationService via DI

### DIFF
--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -6,6 +6,7 @@ Handles all chat completion related API endpoints.
 
 import asyncio
 import logging
+from typing import cast
 
 from fastapi import HTTPException, Request, Response
 
@@ -16,6 +17,7 @@ from src.core.interfaces.di_interface import IServiceProvider
 from src.core.interfaces.request_processor_interface import IRequestProcessor
 from src.core.interfaces.response_manager_interface import IResponseManager
 from src.core.interfaces.session_manager_interface import ISessionManager
+from src.core.interfaces.translation_service_interface import ITranslationService
 from src.core.transport.fastapi.exception_adapters import (
     map_domain_exception_to_http_exception,
 )
@@ -30,13 +32,75 @@ logger = logging.getLogger(__name__)
 class ChatController:
     """Controller for chat-related endpoints."""
 
-    def __init__(self, request_processor: IRequestProcessor) -> None:
+    def __init__(
+        self,
+        request_processor: IRequestProcessor,
+        translation_service: ITranslationService | None = None,
+    ) -> None:
         """Initialize the controller.
 
         Args:
             request_processor: The request processor service
         """
         self._processor = request_processor
+        self._translation_service = (
+            translation_service
+            if translation_service is not None
+            else self._resolve_translation_service_from_provider(None)
+        )
+
+    @staticmethod
+    def _resolve_translation_service_from_provider(
+        provider: IServiceProvider | None,
+    ) -> ITranslationService:
+        """Resolve TranslationService through DI when available."""
+
+        from src.core.services.translation_service import TranslationService
+
+        def _try_get(
+            svc_provider: IServiceProvider,
+            key: object,
+        ) -> ITranslationService | None:
+            try:
+                service = svc_provider.get_service(key)
+            except Exception as exc:  # pragma: no cover - diagnostic fallback
+                logger.debug(
+                    "Translation service lookup failed for %s: %s",
+                    getattr(key, "__name__", repr(key)),
+                    exc,
+                    exc_info=True,
+                )
+                return None
+            if service is None:
+                return None
+            return cast(ITranslationService, service)
+
+        if provider is not None:
+            resolved = _try_get(provider, cast(type, ITranslationService))
+            if resolved is not None:
+                return resolved
+            resolved = _try_get(provider, TranslationService)
+            if resolved is not None:
+                return resolved
+
+        try:
+            from src.core.di.services import get_service_provider
+
+            global_provider = get_service_provider()
+        except Exception as exc:  # pragma: no cover - diagnostic fallback
+            logger.debug(
+                "Global TranslationService resolution failed: %s", exc, exc_info=True
+            )
+        else:
+            if global_provider is not provider:
+                resolved = _try_get(global_provider, cast(type, ITranslationService))
+                if resolved is not None:
+                    return resolved
+                resolved = _try_get(global_provider, TranslationService)
+                if resolved is not None:
+                    return resolved
+
+        return TranslationService()
 
     async def handle_chat_completion(
         self,
@@ -86,10 +150,6 @@ class ChatController:
                     from src.core.app.controllers.anthropic_controller import (
                         get_anthropic_controller,
                     )
-                    from src.core.services.translation_service import (
-                        TranslationService,
-                    )
-
                     # Normalize message content to str for AnthropicMessage
                     anth_messages = []
                     for m in domain_request.messages:
@@ -135,9 +195,13 @@ class ChatController:
                         return anth_response  # type: ignore[return-value]
 
                     # Convert Anthropic JSON to domain then to OpenAI shape
-                    ts = TranslationService()
-                    domain_resp = ts.to_domain_response(anth_json, "anthropic")
-                    openai_json = ts.from_domain_to_openai_response(domain_resp)
+                    translation_service = self._translation_service
+                    domain_resp = translation_service.to_domain_response(
+                        anth_json, "anthropic"
+                    )
+                    openai_json = translation_service.from_domain_to_openai_response(
+                        domain_resp
+                    )
 
                     from fastapi import Response as _Response
 
@@ -633,6 +697,12 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
         if request_processor is None:
             raise InitializationError("Could not find or create RequestProcessor")
 
-        return ChatController(request_processor)
+        translation_service = ChatController._resolve_translation_service_from_provider(
+            service_provider
+        )
+        return ChatController(
+            request_processor,
+            translation_service=translation_service,
+        )
     except Exception as e:
         raise InitializationError(f"Failed to create ChatController: {e}") from e

--- a/src/core/app/stages/controller.py
+++ b/src/core/app/stages/controller.py
@@ -77,7 +77,13 @@ class ControllerStage(InitializationStage):
             request_processor: IRequestProcessor = provider.get_required_service(
                 cast(type, IRequestProcessor)
             )
-            return ChatController(request_processor)
+            translation_service = ChatController._resolve_translation_service_from_provider(
+                provider
+            )
+            return ChatController(
+                request_processor,
+                translation_service=translation_service,
+            )
 
         # Register as singleton
         services.add_singleton(


### PR DESCRIPTION
## Summary
- add TranslationService dependency handling to `ChatController`, resolving it from the DI container and reusing the instance for Anthropic fallback conversions
- update the controller stage factory to supply the DI-managed translation service when constructing `ChatController`

## Testing
- `python -m pytest tests/integration/test_direct_controllers.py`
- `python -m pytest` *(fails: snapshot fixtures and redaction expectations missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8c09aab848333aed2bd5ae44eeefe