### PR TITLE
Enforce DI-managed translation service in responses controller

### DIFF
--- a/src/core/app/controllers/responses_controller.py
+++ b/src/core/app/controllers/responses_controller.py
@@ -42,9 +42,9 @@ class ResponsesController:
         """
         self._processor = request_processor
         if translation_service is None:
-            from src.core.services.translation_service import TranslationService
-
-            translation_service = TranslationService()
+            raise InitializationError(
+                "Translation service must be provided by the DI container"
+            )
 
         self._translation_service = translation_service
 
@@ -1000,8 +1000,10 @@ def get_responses_controller(service_provider: IServiceProvider) -> ResponsesCon
             from src.core.services.translation_service import TranslationService
 
             translation_service = service_provider.get_service(TranslationService)
-            if translation_service is None:
-                translation_service = TranslationService()
+        if translation_service is None:
+            raise InitializationError(
+                "TranslationService is not registered in the service provider"
+            )
 
         return ResponsesController(
             request_processor,

--- a/src/core/app/stages/controller.py
+++ b/src/core/app/stages/controller.py
@@ -180,6 +180,12 @@ class ControllerStage(InitializationStage):
             )
             if translation_service is None:
                 translation_service = provider.get_service(TranslationService)
+            if translation_service is None:
+                from src.core.common.exceptions import InitializationError
+
+                raise InitializationError(
+                    "TranslationService is not registered in the service provider"
+                )
 
             return ResponsesController(
                 request_processor,


### PR DESCRIPTION
## Summary
- require the responses controller to receive its translation service from the DI container and surface configuration errors instead of instantiating a standalone service
- update the controller stage factory to propagate initialization failures when the translation service is missing so misconfigured environments fail fast

## Testing
- python -m pytest tests/unit/core/app/controllers/test_responses_controller.py
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8c09aab848333aed2bd5ae44eeefe