### PR TITLE
Improve session resolver fallback to respect DI

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -462,7 +462,26 @@ def get_anthropic_controller(service_provider: IServiceProvider) -> AnthropicCon
                         DefaultSessionResolver,
                     )
 
-                    session_resolver = DefaultSessionResolver(None)  # type: ignore[arg-type]
+                    session_resolver = service_provider.get_service(
+                        DefaultSessionResolver
+                    )
+                    if session_resolver is None:
+                        from src.core.config.app_config import AppConfig
+
+                        config = service_provider.get_service(AppConfig)
+                        session_resolver = DefaultSessionResolver(config)
+                        try:
+                            from src.core.di.services import get_service_collection
+
+                            services = get_service_collection()
+                            services.add_instance(
+                                DefaultSessionResolver, session_resolver
+                            )
+                            services.add_instance(
+                                cast(type, ISessionResolver), session_resolver
+                            )
+                        except Exception:
+                            pass
 
                 # Get agent response formatter for ResponseManager
                 from src.core.interfaces.agent_response_formatter_interface import (

--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -577,7 +577,26 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
                             DefaultSessionResolver,
                         )
 
-                        session_resolver = DefaultSessionResolver(None)  # type: ignore[arg-type]
+                        session_resolver = service_provider.get_service(
+                            DefaultSessionResolver
+                        )
+                        if session_resolver is None:
+                            from src.core.config.app_config import AppConfig
+
+                            config = service_provider.get_service(AppConfig)
+                            session_resolver = DefaultSessionResolver(config)
+                            try:
+                                from src.core.di.services import get_service_collection
+
+                                services = get_service_collection()
+                                services.add_instance(
+                                    DefaultSessionResolver, session_resolver
+                                )
+                                services.add_instance(
+                                    ISessionResolver, session_resolver  # type: ignore[type-abstract]
+                                )
+                            except Exception:
+                                pass
 
                     # Get agent response formatter for ResponseManager
                     from src.core.interfaces.agent_response_formatter_interface import (

--- a/src/core/app/controllers/responses_controller.py
+++ b/src/core/app/controllers/responses_controller.py
@@ -937,7 +937,26 @@ def get_responses_controller(service_provider: IServiceProvider) -> ResponsesCon
                             DefaultSessionResolver,
                         )
 
-                        session_resolver = DefaultSessionResolver(None)  # type: ignore[arg-type]
+                        session_resolver = service_provider.get_service(
+                            DefaultSessionResolver
+                        )
+                        if session_resolver is None:
+                            from src.core.config.app_config import AppConfig
+
+                            config = service_provider.get_service(AppConfig)
+                            session_resolver = DefaultSessionResolver(config)
+                            try:
+                                from src.core.di.services import get_service_collection
+
+                                services = get_service_collection()
+                                services.add_instance(
+                                    DefaultSessionResolver, session_resolver
+                                )
+                                services.add_instance(
+                                    ISessionResolver, session_resolver  # type: ignore[type-abstract]
+                                )
+                            except Exception:
+                                pass
 
                     # Get agent response formatter for ResponseManager
                     from src.core.interfaces.agent_response_formatter_interface import (


### PR DESCRIPTION
## Summary
- ensure chat, Anthropic, and responses controllers first reuse the DI-registered session resolver
- fall back to building a DefaultSessionResolver with AppConfig resolved from the container and register it for future requests

## Testing
- python -m pytest tests/unit/core/app/controllers/test_responses_controller.py
- python -m pytest *(fails: environment lacks optional dev tooling/fixtures required for formatting and snapshot tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e8c09aab848333aed2bd5ae44eeefe