### PR TITLE
Ensure fallback BackendRequestManager respects wire capture dependency

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -480,8 +480,17 @@ def get_anthropic_controller(service_provider: IServiceProvider) -> AnthropicCon
                     agent_response_formatter = AgentResponseFormatter()
 
                 session_manager = SessionManager(session, session_resolver)
+
+                from src.core.interfaces.wire_capture_interface import (
+                    IWireCapture,
+                )
+
+                wire_capture = service_provider.get_service(IWireCapture)  # type: ignore[type-abstract]
+
                 backend_request_manager = BackendRequestManager(
-                    backend_processor, response_proc
+                    backend_processor,
+                    response_proc,
+                    wire_capture=wire_capture,
                 )
                 response_manager = ResponseManager(agent_response_formatter)
 

--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -593,8 +593,17 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
                         agent_response_formatter = AgentResponseFormatter()
 
                     session_manager = SessionManager(concrete_session, session_resolver)
+
+                    from src.core.interfaces.wire_capture_interface import (
+                        IWireCapture,
+                    )
+
+                    wire_capture = service_provider.get_service(IWireCapture)  # type: ignore[type-abstract]
+
                     backend_request_manager = BackendRequestManager(
-                        backend_processor, concrete_response_proc
+                        backend_processor,
+                        concrete_response_proc,
+                        wire_capture=wire_capture,
                     )
                     response_manager = ResponseManager(agent_response_formatter)
 

--- a/src/core/app/controllers/responses_controller.py
+++ b/src/core/app/controllers/responses_controller.py
@@ -953,8 +953,17 @@ def get_responses_controller(service_provider: IServiceProvider) -> ResponsesCon
                         agent_response_formatter = AgentResponseFormatter()
 
                     session_manager = SessionManager(concrete_session, session_resolver)
+
+                    from src.core.interfaces.wire_capture_interface import (
+                        IWireCapture,
+                    )
+
+                    wire_capture = service_provider.get_service(IWireCapture)  # type: ignore[type-abstract]
+
                     backend_request_manager = BackendRequestManager(
-                        backend_processor, concrete_response_proc
+                        backend_processor,
+                        concrete_response_proc,
+                        wire_capture=wire_capture,
                     )
                     response_manager = ResponseManager(agent_response_formatter)
 


### PR DESCRIPTION
## Summary
- ensure fallback controller wiring resolves IWireCapture from the service provider before creating BackendRequestManager instances
- pass the resolved wire capture into the manually constructed BackendRequestManager so DI-only dependencies are honored

## Testing
- pytest -q *(fails: requires --asyncio-mode / xdist plugins that are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e8cc48f48333b258096e7995e0d8