### PR TITLE
Fix responses controller DI resolution

### DIFF
--- a/tests/unit/core/app/controllers/test_responses_controller_di.py
+++ b/tests/unit/core/app/controllers/test_responses_controller_di.py
@@ -1,0 +1,92 @@
+"""Unit tests for DI compliance in responses controller factory."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from src.core.app.controllers.responses_controller import (
+    ResponsesController,
+    get_responses_controller,
+)
+from src.core.common.exceptions import InitializationError
+from src.core.di.container import ServiceCollection
+from src.core.interfaces.di_interface import IServiceProvider
+from src.core.interfaces.request_processor_interface import IRequestProcessor
+from src.core.domain.request_context import RequestContext
+
+
+class StubRequestProcessor(IRequestProcessor):
+    """Minimal IRequestProcessor implementation for testing."""
+
+    async def process_request(
+        self,
+        context: RequestContext,
+        request_data: Any,
+    ) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture()
+def service_provider() -> IServiceProvider:
+    """Create a service provider with basic translation registration."""
+
+    from src.core.interfaces.translation_service_interface import (
+        ITranslationService,
+    )
+    from src.core.services.translation_service import TranslationService
+
+    services = ServiceCollection()
+    translation_service = TranslationService()
+    services.add_instance(TranslationService, translation_service)
+    services.add_instance(cast(type, ITranslationService), translation_service)  # type: ignore[type-abstract]
+    return services.build_service_provider()
+
+
+def test_get_responses_controller_requires_request_processor(
+    service_provider: IServiceProvider,
+) -> None:
+    """The factory should fail fast when IRequestProcessor is missing."""
+
+    with pytest.raises(InitializationError):
+        get_responses_controller(service_provider)
+
+
+def test_get_responses_controller_uses_di_instances(
+    service_provider: IServiceProvider,
+) -> None:
+    """The factory should return the same instances registered in DI."""
+
+    from src.core.interfaces.translation_service_interface import (
+        ITranslationService,
+    )
+    from src.core.services.translation_service import TranslationService
+
+    services = ServiceCollection()
+
+    translation_service = service_provider.get_required_service(TranslationService)
+    services.add_instance(TranslationService, translation_service)
+    services.add_instance(
+        cast(type, ITranslationService),
+        translation_service,
+    )  # type: ignore[type-abstract]
+
+    processor = StubRequestProcessor()
+    services.add_instance(StubRequestProcessor, processor)
+    services.add_instance(
+        cast(type, IRequestProcessor),
+        processor,
+    )  # type: ignore[type-abstract]
+
+    provider_with_processor = services.build_service_provider()
+
+    controller = get_responses_controller(provider_with_processor)
+
+    assert isinstance(controller, ResponsesController)
+    assert getattr(controller, "_processor") is processor
+    assert (
+        getattr(controller, "_translation_service")
+        is provider_with_processor.get_required_service(TranslationService)
+    )
+

--- a/tests/unit/core/app/controllers/test_responses_controller_di.py
+++ b/tests/unit/core/app/controllers/test_responses_controller_di.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 from typing import Any, cast
 
 import pytest
-
 from src.core.app.controllers.responses_controller import (
     ResponsesController,
     get_responses_controller,
 )
 from src.core.common.exceptions import InitializationError
 from src.core.di.container import ServiceCollection
+from src.core.domain.request_context import RequestContext
 from src.core.interfaces.di_interface import IServiceProvider
 from src.core.interfaces.request_processor_interface import IRequestProcessor
-from src.core.domain.request_context import RequestContext
 
 
 class StubRequestProcessor(IRequestProcessor):
@@ -84,9 +83,9 @@ def test_get_responses_controller_uses_di_instances(
     controller = get_responses_controller(provider_with_processor)
 
     assert isinstance(controller, ResponsesController)
-    assert getattr(controller, "_processor") is processor
+    assert controller._processor is processor
     assert (
-        getattr(controller, "_translation_service")
+        controller._translation_service
         is provider_with_processor.get_required_service(TranslationService)
     )
 


### PR DESCRIPTION
## Summary
- ensure the Responses controller factory resolves its dependencies strictly through the DI container and raises clear initialization errors when services are missing
- add unit tests that verify the factory relies on DI-managed instances and refuses to construct controllers when the request processor is absent

## Testing
- python -m pytest -c /tmp/pytest_min.ini tests/unit/core/app/controllers/test_responses_controller_di.py
- python -m pytest -c /tmp/pytest_min.ini *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e8cc48f48333b258096e7995e0d8