### PR TITLE
Fix failover route injection in backend service

### DIFF
--- a/src/core/services/backend_service.py
+++ b/src/core/services/backend_service.py
@@ -78,7 +78,9 @@ class BackendService(IBackendService):
         # Ensure config is properly typed for type checking
         _typed_config = cast(AppConfig, config)
 
-        self._failover_service: FailoverService = FailoverService(failover_routes={})
+        self._failover_service: FailoverService = FailoverService(
+            failover_routes=self._failover_routes
+        )
         if failover_coordinator is None:
             logger.warning(
                 "BackendService: No IFailoverCoordinator provided; using default FailoverCoordinator. "


### PR DESCRIPTION
## Summary
- ensure BackendService hands configured failover routes to the FailoverService so injected routes are honored

## Testing
- python -m pytest tests/unit/core/test_backend_service_enhanced.py::TestBackendServiceFailover::test_simple_failover --override-ini="addopts=" -q
- python -m pytest --override-ini="addopts=" --maxfail=1 -q


------
https://chatgpt.com/codex/tasks/task_e_68e90ace1df483338c4216c2b2b13079