### PR TITLE
Default Gemini backend API key header

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -52,12 +52,17 @@ class GeminiBackend(LLMBackend):
     async def initialize(self, **kwargs: Any) -> None:
         """Store configuration for lazy initialization."""
         self.gemini_api_base_url = kwargs.get("gemini_api_base_url")
-        self.key_name = kwargs.get("key_name")
+        configured_key_name = kwargs.get("key_name")
+        if configured_key_name:
+            self.key_name = str(configured_key_name)
+        else:
+            # Default to the standard Google API key header when none is provided.
+            self.key_name = "x-goog-api-key"
         self.api_key = kwargs.get("api_key")
 
-        if not self.gemini_api_base_url or not self.key_name or not self.api_key:
+        if not self.gemini_api_base_url or not self.api_key:
             raise ValueError(
-                "gemini_api_base_url, key_name, and api_key are required for GeminiBackend"
+                "gemini_api_base_url and api_key are required for GeminiBackend"
             )
 
         # Don't make HTTP calls during initialization

--- a/tests/unit/connectors/test_gemini_header_resolution.py
+++ b/tests/unit/connectors/test_gemini_header_resolution.py
@@ -28,6 +28,20 @@ async def test_resolve_gemini_api_config_uses_custom_header_name() -> None:
 
 
 @pytest.mark.asyncio
+async def test_initialize_defaults_google_header() -> None:
+    backend = GeminiBackend(
+        httpx.AsyncClient(), AppConfig(), translation_service=TranslationService()
+    )
+
+    await backend.initialize(
+        gemini_api_base_url="https://generativelanguage.googleapis.com",
+        api_key="api-token",
+    )
+
+    assert backend.key_name == "x-goog-api-key"
+
+
+@pytest.mark.asyncio
 async def test_list_models_respects_key_name(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = GeminiBackend(
         httpx.AsyncClient(), AppConfig(), translation_service=TranslationService()


### PR DESCRIPTION
## Summary
- allow the Gemini backend to fall back to the standard x-goog-api-key header when no custom key name is supplied
- add a regression test to cover initialization without an explicit header override

## Testing
- python -m pytest -o addopts="" tests/unit/connectors/test_gemini_header_resolution.py
- python -m pytest -o addopts=""
  - fails: missing optional test dependencies in the execution environment (pytest_asyncio, pytest_httpx, respx, hypothesis)


------
https://chatgpt.com/codex/tasks/task_e_68e90ace1df483338c4216c2b2b13079