### PR TITLE
Fix default backend service alias implementation

### DIFF
--- a/src/core/interfaces/backend_service.py
+++ b/src/core/interfaces/backend_service.py
@@ -53,7 +53,6 @@ class IBackendService(ABC):
             A tuple of (is_valid, error_message)
         """
 
-    @abstractmethod
     async def chat_completions(
         self,
         request: ChatRequest,
@@ -63,4 +62,19 @@ class IBackendService(ABC):
         context: RequestContext | None = None,
         **kwargs: Any,
     ) -> ResponseEnvelope | StreamingResponseEnvelope:
-        """Alias for :meth:`call_completion` used by legacy callers."""
+        """Alias for :meth:`call_completion` used by legacy callers.
+
+        Implementers may override this method, but by default it simply
+        delegates to :meth:`call_completion` to avoid forcing duplicate
+        implementations when only the primary entry point is customised.
+        Additional keyword arguments are accepted for backward
+        compatibility, though they are ignored by the default
+        implementation.
+        """
+
+        return await self.call_completion(
+            request,
+            stream=stream,
+            allow_failover=allow_failover,
+            context=context,
+        )


### PR DESCRIPTION
## Summary
- provide a concrete default implementation for `IBackendService.chat_completions` so it properly delegates to `call_completion`
- document the delegation behaviour to clarify that backends no longer need to implement the alias unless they customise it

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/core/services/test_backend_service_targeted.py
- ./.venv/Scripts/python.exe -m pytest *(fails: existing suite issues such as redaction, failover, lint, mypy, and smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e90ace1df483338c4216c2b2b13079