### PR TITLE
Handle config service DI resolution errors

### DIFF
--- a/src/core/app/controllers/models_controller.py
+++ b/src/core/app/controllers/models_controller.py
@@ -114,7 +114,7 @@ def get_config_service() -> IConfig:
 
         service_provider = get_service_provider()
         return service_provider.get_required_service(IConfig)  # type: ignore[type-abstract,no-any-return]
-    except KeyError as e:
+    except (KeyError, ServiceResolutionError) as e:
         logger.debug(
             "IConfig not registered in global provider: %s; trying request context",
             e,


### PR DESCRIPTION
## Summary
- allow `get_config_service` to treat `ServiceResolutionError` the same as missing DI registrations so the controller can fall back to request or default config sources
- add regression coverage ensuring the configuration fallback still works when DI resolution fails
- extend persistence tests to check that invalid JSON raises the expected parsing error

## Testing
- python -m pytest -o addopts='' tests/unit/core/app/controllers/test_models_controller.py::test_get_config_service_handles_service_resolution_error
- python -m pytest -o addopts='' tests/unit/test_config_persistence.py::test_load_raises_json_parsing_error_for_invalid_json
- python -m pytest -o addopts=''

------
https://chatgpt.com/codex/tasks/task_e_68e90ab12bb08333abb0d38f469613d6