### PR TITLE
Handle invalid config payloads

### DIFF
--- a/src/core/persistence.py
+++ b/src/core/persistence.py
@@ -75,6 +75,16 @@ class ConfigManager:
             raise ConfigurationError(
                 f"An unexpected error occurred while loading config file {self.path.name}."
             ) from e
+        if not isinstance(data, dict):
+            logger.error(
+                "Invalid config file structure in %s: expected object but got %s",
+                self.path,
+                type(data).__name__,
+            )
+            raise ConfigurationError(
+                f"Config file {self.path.name} must contain a JSON object."
+            )
+
         self.apply(data)
 
     def _apply_default_backend(self, backend_value: Any) -> None:

--- a/tests/unit/test_config_persistence.py
+++ b/tests/unit/test_config_persistence.py
@@ -144,6 +144,18 @@ def test_invalid_persisted_backend(tmp_path, monkeypatch, functional_backend: st
     monkeypatch.delenv("LLM_BACKEND", raising=False)
 
 
+def test_load_rejects_non_object_json(tmp_path):
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("[]", encoding="utf-8")
+
+    manager = ConfigManager(FastAPI(), str(cfg_path))
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        manager.load()
+
+    assert "JSON object" in str(exc_info.value)
+
+
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )


### PR DESCRIPTION
## Summary
- guard ConfigManager.load against non-object JSON payloads by raising a ConfigurationError with a clear message
- add regression coverage ensuring invalid persistence files surface the new error

## Testing
- python -m pytest -o addopts='' tests/unit/test_config_persistence.py tests/unit/test_strict_modes_di.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e90ab12bb08333abb0d38f469613d6