### PR TITLE
Add Retry-After header for rate limit errors in middleware

### DIFF
--- a/tests/unit/app/middleware/test_exception_middleware.py
+++ b/tests/unit/app/middleware/test_exception_middleware.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.app.middleware.exception_middleware import DomainExceptionMiddleware
+from src.core.common.exceptions import RateLimitExceededError
+
+
+def test_domain_exception_middleware_sets_retry_after_header(monkeypatch):
+    app = FastAPI()
+    app.add_middleware(DomainExceptionMiddleware)
+
+    monkeypatch.setattr(
+        "src.core.app.middleware.exception_middleware.time.time",
+        lambda: 100.0,
+    )
+
+    @app.get("/limited")
+    async def limited_endpoint() -> None:
+        raise RateLimitExceededError("slow down", reset_at=160.2)
+
+    with TestClient(app) as client:
+        response = client.get("/limited")
+
+    assert response.status_code == 429
+    assert response.headers.get("retry-after") == "61"
+    body = response.json()
+    assert body["error"]["type"] == "RateLimitExceededError"
+    assert body["error"]["message"] == "slow down"


### PR DESCRIPTION
## Summary
- ensure the DomainExceptionMiddleware attaches a Retry-After header when raising rate limit exceptions
- add a focused unit test that exercises the middleware and validates the emitted header and payload

## Testing
- python -m pytest -o addopts= tests/unit/app/middleware/test_exception_middleware.py
- python -m pytest -o addopts= *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68e90ab12bb08333abb0d38f469613d6