### PR TITLE
Fix invalid isinstance union usage in exception adapter

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -64,7 +64,7 @@ def map_domain_exception_to_http_exception(exc: LLMProxyError) -> HTTPException:
     # Map specific exception types to specific status codes
     if isinstance(exc, AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
-    elif isinstance(exc, ConfigurationError | InvalidRequestError):
+    elif isinstance(exc, (ConfigurationError, InvalidRequestError)):
         status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, ServiceUnavailableError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- correct the FastAPI exception adapter to use a tuple when checking for configuration and invalid request errors
- ensure configuration and invalid request exceptions map to HTTP 400 responses without raising a TypeError

## Testing
- python -m pytest -o addopts= -p no:xdist -p no:asyncio tests/unit/test_transport_adapters.py
- python -m pytest -o addopts= -p no:xdist -p no:asyncio *(fails: missing optional dev dependencies such as pytest-asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e90ab12bb08333abb0d38f469613d6