### PR TITLE
Fix Gemini backend response usage propagation

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -648,15 +648,20 @@ class GeminiBackend(LLMBackend):
                     code="gemini_error",
                     status_code=response.status_code,
                 )
+
             data = response.json()
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Gemini response headers: %s", dict(response.headers))
+
+            domain_response = self.translation_service.to_domain_response(
+                data, source_format="gemini"
+            )
+
             return ResponseEnvelope(
-                content=self.translation_service.to_domain_response(
-                    data, source_format="gemini"
-                ),
+                content=domain_response,
                 headers=dict(response.headers),
                 status_code=response.status_code,
+                usage=domain_response.usage,
             )
         except httpx.RequestError as e:
             if logger.isEnabledFor(logging.ERROR):


### PR DESCRIPTION
## Summary
- ensure Gemini connector includes usage metadata when returning non-streaming responses so downstream processors retain token accounting information

## Testing
- `pytest tests/unit/connectors/test_gemini_header_resolution.py -q`
- `pytest -q` *(fails: environment lacks optional dev dependencies and quality gates)*

------
https://chatgpt.com/codex/tasks/task_e_68e90a84a96083338fba852489d64227