### PR TITLE
Reset streaming buffers between requests

### DIFF
--- a/src/core/interfaces/streaming_response_processor_interface.py
+++ b/src/core/interfaces/streaming_response_processor_interface.py
@@ -25,3 +25,7 @@ class IStreamNormalizer(ABC):
         Returns:
             An async iterator of the processed stream in the requested format
         """
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset any processor state before handling a new stream."""

--- a/src/core/services/streaming/stream_normalizer.py
+++ b/src/core/services/streaming/stream_normalizer.py
@@ -24,6 +24,21 @@ class StreamNormalizer(IStreamNormalizer):
         """
         self._processors = list(processors) if processors is not None else []
 
+    def reset(self) -> None:
+        """Reset any stateful processors prior to processing a new stream."""
+        for processor in self._processors:
+            reset_method = getattr(processor, "reset", None)
+            if callable(reset_method):
+                try:
+                    reset_method()
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    logger.debug(
+                        "Failed to reset stream processor %s: %s",
+                        type(processor).__name__,
+                        exc,
+                        exc_info=True,
+                    )
+
     async def process_stream(
         self, stream: AsyncIterator[Any], output_format: str = "bytes"
     ) -> AsyncGenerator[StreamingContent | bytes, None]:

--- a/tests/unit/core/services/streaming/test_content_accumulation_processor.py
+++ b/tests/unit/core/services/streaming/test_content_accumulation_processor.py
@@ -133,3 +133,19 @@ async def test_content_accumulation_processor_empty_initial_stream(
     # Assert
     assert processed_final_chunk.content == ""
     assert processed_final_chunk.is_done is True
+
+
+@pytest.mark.asyncio
+async def test_content_accumulation_processor_reset_method_clears_buffer(
+    content_accumulation_processor,
+):
+    chunk = StreamingContent(content="stale")
+    await content_accumulation_processor.process(chunk)
+
+    content_accumulation_processor.reset()
+
+    final_chunk = StreamingContent(content="fresh", is_done=True)
+    processed_final_chunk = await content_accumulation_processor.process(final_chunk)
+
+    assert processed_final_chunk.content == "fresh"
+    assert processed_final_chunk.is_done is True


### PR DESCRIPTION
## Summary
- add a reset hook to the stream normalizer so stateful processors clear between streaming sessions
- expose a reset method on the content accumulation processor and invoke it from the response processor to avoid leaking buffered text
- cover the new behavior with unit tests that guard against cross-session accumulation

## Testing
- pytest -o addopts='' tests/unit/core/services/test_response_processor_service.py tests/unit/core/services/streaming/test_content_accumulation_processor.py
- pytest -o addopts='' *(fails: missing optional dependencies such as pytest_asyncio, respx, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68e90a673c6c8333a054ba2952e623f0