### PR TITLE
Fix session resolver respecting request IDs

### DIFF
--- a/src/core/services/session_resolver_service.py
+++ b/src/core/services/session_resolver_service.py
@@ -113,6 +113,10 @@ class DefaultSessionResolver(ISessionResolver):
         if isinstance(cookie_value, str) and cookie_value:
             session_id = cookie_value
 
+        if session_id:
+            context.session_id = session_id
+            return session_id
+
         # Fall back to configured default session ID if available
         if self._configured_default_id:
             context.session_id = self._configured_default_id

--- a/tests/unit/core/services/test_session_resolver_service.py
+++ b/tests/unit/core/services/test_session_resolver_service.py
@@ -73,3 +73,26 @@ async def test_resolver_uses_configured_default_when_available() -> None:
 
     assert session_id == "pre-set"
     assert context.session_id == "pre-set"
+
+
+@pytest.mark.asyncio
+async def test_resolver_respects_request_provided_session_id_before_default() -> None:
+    class ConfigWithSession:
+        def __init__(self) -> None:
+            self.session = type(
+                "SessionConfig", (), {"default_session_id": "fallback"}
+            )()
+
+    resolver = DefaultSessionResolver(ConfigWithSession())
+
+    context = RequestContext(
+        headers={"x-session-id": "user-123"},
+        cookies={},
+        state={},
+        app_state={},
+    )
+
+    session_id = await resolver.resolve_session_id(context)
+
+    assert session_id == "user-123"
+    assert context.session_id == "user-123"


### PR DESCRIPTION
## Summary
- update the default session resolver to persist and return request-provided session identifiers before falling back to configured defaults
- add a regression test covering header-provided session IDs when a default session ID exists

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_session_resolver_service.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e90a673c6c8333a054ba2952e623f0