### PR TITLE
Fix Anthropic streaming stop event

### DIFF
--- a/src/anthropic_converters.py
+++ b/src/anthropic_converters.py
@@ -556,7 +556,8 @@ def openai_stream_to_anthropic_stream(chunk_data: str) -> str:
 
     try:
         if payload_str.strip() == "[DONE]":
-            return chunk_data  # pass through - not currently asserted on
+            stop_payload = {"type": "message_stop"}
+            return "event: message_stop\n" f"data: {json.dumps(stop_payload)}\n\n"
 
         openai_chunk: dict[str, Any] = json.loads(payload_str)
         choice = openai_chunk.get("choices", [{}])[0]

--- a/tests/chat_completions_tests/test_anthropic_frontend.py
+++ b/tests/chat_completions_tests/test_anthropic_frontend.py
@@ -242,6 +242,7 @@ def test_anthropic_messages_streaming_frontend(anthropic_client):
                 text += chunk
             # Check that we get Anthropic streaming format
             assert "content_block_delta" in text or "delta" in text
+            assert "event: message_stop" in text
             mock_process.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- convert OpenAI [DONE] streaming sentinel into an Anthropic `message_stop` event
- add a regression test ensuring Anthropic streaming responses include the `message_stop` event

## Testing
- python -m pytest -o addopts='' tests/chat_completions_tests/test_anthropic_frontend.py::test_anthropic_messages_streaming_frontend
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e90a4efe6083339247e1ca103b0fa5