### PR TITLE
Fix Anthropic controller to resolve app state from DI container

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -18,7 +18,11 @@ from src.anthropic_converters import (
     openai_to_anthropic_response,
 )
 from src.anthropic_models import AnthropicMessagesRequest
-from src.core.common.exceptions import InitializationError, LLMProxyError
+from src.core.common.exceptions import (
+    InitializationError,
+    LLMProxyError,
+    ServiceResolutionError,
+)
 from src.core.interfaces.di_interface import IServiceProvider
 from src.core.interfaces.request_processor_interface import IRequestProcessor
 from src.core.interfaces.session_resolver_interface import ISessionResolver
@@ -441,7 +445,14 @@ def get_anthropic_controller(service_provider: IServiceProvider) -> AnthropicCon
                         ApplicationStateService,
                     )
 
-                    app_state = ApplicationStateService()
+                    try:
+                        app_state = service_provider.get_required_service(
+                            ApplicationStateService
+                        )
+                    except ServiceResolutionError as exc:
+                        raise InitializationError(
+                            "ApplicationStateService is not registered in the DI container"
+                        ) from exc
                 backend_processor: BackendProcessor = BackendProcessor(
                     backend, session, app_state
                 )


### PR DESCRIPTION
## Summary
- resolve `ApplicationStateService` for the Anthropic controller through the DI container instead of constructing it manually
- raise a clear initialization error when the application state service is not available in DI

## Testing
- `./.venv/Scripts/python.exe -m pytest tests/unit/test_di_container_usage.py` *(fails: `.venv/Scripts/python.exe` is unavailable in the container environment)*
- `python -m pytest tests/unit/test_di_container_usage.py` *(fails: pytest extras from pyproject addopts are not installed in the base interpreter)*
- `python -m pytest` *(fails: pytest extras from pyproject addopts are not installed in the base interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_68e909fe1fd0833387a4a52625c7ad7c