### PR TITLE
Fix chat controller translation service resolution

### DIFF
--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -100,7 +100,12 @@ class ChatController:
                 if resolved is not None:
                     return resolved
 
-        return TranslationService()
+        message = "TranslationService is not registered in the service provider"
+        logger.error(message)
+        raise InitializationError(
+            message,
+            details={"service": "TranslationService"},
+        )
 
     async def handle_chat_completion(
         self,

--- a/tests/integration/test_direct_controllers.py
+++ b/tests/integration/test_direct_controllers.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from src.core.app.controllers import get_chat_controller_if_available
 from src.core.app.controllers.chat_controller import ChatController
+from src.core.services.translation_service import TranslationService
 
 
 @pytest.fixture
@@ -67,7 +68,10 @@ async def setup_app(app: FastAPI) -> AsyncGenerator[dict[str, Any], None]:
 
     mock_controller.handle_chat_completion = mock_handle_chat_completion
     # Use the real ChatController with our mock request processor
-    real_controller = ChatController(mock_request_processor)
+    translation_service = TranslationService()
+    real_controller = ChatController(
+        mock_request_processor, translation_service=translation_service
+    )
     mock_provider.get_service.side_effect = lambda cls: (
         real_controller if cls == ChatController else mock_request_processor
     )

--- a/tests/integration/test_versioned_api.py
+++ b/tests/integration/test_versioned_api.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from src.core.app.test_builder import build_test_app as build_app
 from src.core.domain.chat import ChatResponse
 from src.core.interfaces.backend_service_interface import IBackendService
+from src.core.services.translation_service import TranslationService
 
 
 @pytest.fixture
@@ -153,7 +154,13 @@ async def initialized_app(app: FastAPI):
                     # Also create ChatController and register it
                     from src.core.app.controllers.chat_controller import ChatController
 
-                    chat_controller = ChatController(request_processor)
+                    translation_service = provider.get_service(TranslationService)
+                    if translation_service is None:
+                        translation_service = TranslationService()
+                    chat_controller = ChatController(
+                        request_processor,
+                        translation_service=translation_service,
+                    )
                     provider._singleton_instances[ChatController] = chat_controller
                 except Exception as e:
                     print(f"Error creating RequestProcessor or ChatController: {e}")


### PR DESCRIPTION
## Summary
- prevent ChatController from instantiating TranslationService manually and raise an initialization error when the DI container cannot provide it
- update integration tests to supply a translation service instance when constructing ChatController manually

## Testing
- python -m pytest -o addopts="" tests/integration/test_direct_controllers.py tests/integration/test_versioned_api.py *(fails: pytest-asyncio plugin not installed in environment)*
- python -m pytest -o addopts="" *(fails: pytest-asyncio, respx, pytest_httpx, and hypothesis plugins are unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e909fe1fd0833387a4a52625c7ad7c