### PR TITLE
Fix session command prefix override to avoid global state changes

### DIFF
--- a/src/core/commands/handlers/failover_command_handler.py
+++ b/src/core/commands/handlers/failover_command_handler.py
@@ -37,6 +37,13 @@ class SessionStateApplicationStateAdapter(
         self._local_state: dict[str, Any] = {}
 
     def get_command_prefix(self) -> str | None:
+        prefix = None
+        try:
+            prefix = getattr(self._session.state, "command_prefix_override", None)
+        except Exception:
+            prefix = None
+        if isinstance(prefix, str) and prefix:
+            return prefix
         return self._local_state.get("command_prefix")
 
     def get_api_key_redaction_enabled(self) -> bool:
@@ -53,6 +60,10 @@ class SessionStateApplicationStateAdapter(
 
     def set_command_prefix(self, prefix: str) -> None:
         self._local_state["command_prefix"] = prefix
+        try:
+            self._session.state = self._session.state.with_command_prefix_override(prefix)
+        except Exception:
+            pass
 
     def set_api_key_redaction_enabled(self, enabled: bool) -> None:
         self._local_state["api_key_redaction_enabled"] = enabled

--- a/src/core/commands/parser.py
+++ b/src/core/commands/parser.py
@@ -59,7 +59,9 @@ class CommandParser:
         )
         return re.compile(rf"{escaped_prefix}(?P<name>[\w-]+)(?:\((?P<args>[^)]*)\))?")
 
-    def parse(self, content: str) -> tuple[Command, str] | None:
+    def parse(
+        self, content: str, command_prefix: str | None = None
+    ) -> tuple[Command, str] | None:
         """
         Parses a command from the given content.
 
@@ -69,7 +71,11 @@ class CommandParser:
         Returns:
             A tuple containing the Command object and the matched string, or None.
         """
-        prefix = self.command_prefix
+        prefix_value: str | None = command_prefix if command_prefix else self.command_prefix
+        if not isinstance(prefix_value, str) or not prefix_value:
+            return None
+
+        prefix = prefix_value
         search_index = 0
         while True:
             start = content.find(prefix, search_index)

--- a/src/core/domain/commands/set_command.py
+++ b/src/core/domain/commands/set_command.py
@@ -272,8 +272,7 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 state,
             )
 
-        # Update state through secure DI interface
-        self.update_state_setting("command_prefix", value)
+        updated_state = state.with_command_prefix_override(value)
 
         return (
             CommandResult(
@@ -281,7 +280,7 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 message=f"Command prefix changed to {value}",
                 data={"command-prefix": value},
             ),
-            state,
+            updated_state,
         )
 
     async def _handle_interactive_mode(

--- a/src/core/domain/commands/unset_command.py
+++ b/src/core/domain/commands/unset_command.py
@@ -179,15 +179,14 @@ class UnsetCommand(StatefulCommandBase, BaseCommand):
     def _unset_command_prefix(
         self, state: ISessionState, context: Any
     ) -> tuple[CommandResult, ISessionState]:
-        # Update state through secure DI interface
-        self.update_state_setting("command_prefix", "!/")
+        updated_state = state.with_command_prefix_override(None)
 
         result = CommandResult(
             success=True,
             message="Command prefix reset to default (!/)",
             data={"command-prefix": "!/"},
         )
-        return result, state  # No state change in session
+        return result, updated_state
 
     def _unset_project(
         self, state: ISessionState, context: Any

--- a/src/core/domain/session.py
+++ b/src/core/domain/session.py
@@ -78,6 +78,7 @@ class SessionState(ValueObject):
     planning_phase_turn_count: int = 0
     planning_phase_file_write_count: int = 0
     api_key_redaction_enabled: bool | None = None
+    command_prefix_override: str | None = None
 
     def with_backend_config(self, backend_config: BackendConfiguration) -> SessionState:
         """Create a new session state with updated backend config."""
@@ -148,6 +149,13 @@ class SessionState(ValueObject):
     def with_api_key_redaction_enabled(self, enabled: bool | None) -> SessionState:
         """Create a new session state with updated API key redaction flag."""
         return self.model_copy(update={"api_key_redaction_enabled": enabled})
+
+    def with_command_prefix_override(
+        self, command_prefix: str | None
+    ) -> SessionState:
+        """Create a new session state with a session-scoped command prefix override."""
+
+        return self.model_copy(update={"command_prefix_override": command_prefix})
 
 
 class SessionStateAdapter(ISessionState, ISessionStateMutator):
@@ -261,6 +269,28 @@ class SessionStateAdapter(ISessionState, ISessionStateMutator):
             base_state = SessionState.from_dict(self._state.to_dict())
 
         new_state = base_state.with_api_key_redaction_enabled(enabled)
+        return SessionStateAdapter(new_state)
+
+    @property
+    def command_prefix_override(self) -> str | None:
+        """Get the session-specific command prefix override if configured."""
+        value = getattr(self._state, "command_prefix_override", None)
+        if isinstance(value, str):
+            return value
+        return None
+
+    def with_command_prefix_override(
+        self, command_prefix: str | None
+    ) -> ISessionState:
+        """Create a new session state adapter with updated command prefix override."""
+
+        base_state: SessionState
+        if isinstance(self._state, SessionState):
+            base_state = self._state
+        else:
+            base_state = SessionState.from_dict(self._state.to_dict())
+
+        new_state = base_state.with_command_prefix_override(command_prefix)
         return SessionStateAdapter(new_state)
 
     @property

--- a/src/core/interfaces/domain_entities_interface.py
+++ b/src/core/interfaces/domain_entities_interface.py
@@ -260,6 +260,17 @@ class ISessionState(IValueObject, ISessionStateMutator):
     def with_api_key_redaction_enabled(self, enabled: bool | None) -> ISessionState:
         """Create a new state with updated API key redaction flag."""
 
+    @property
+    @abstractmethod
+    def command_prefix_override(self) -> str | None:
+        """Get the session-scoped command prefix override if present."""
+
+    @abstractmethod
+    def with_command_prefix_override(
+        self, command_prefix: str | None
+    ) -> ISessionState:
+        """Create a new state with updated command prefix override."""
+
     @abstractmethod
     def with_planning_phase_config(self, config: IPlanningPhaseConfig) -> ISessionState:
         """Create a new state with updated planning phase configuration."""

--- a/src/core/services/request_processor_service.py
+++ b/src/core/services/request_processor_service.py
@@ -393,7 +393,19 @@ class RequestProcessor(IRequestProcessor):
                     api_keys = discover_api_keys_from_config_and_env(app_config)
                     # Command prefix can be None; RedactionMiddleware has a default
                     command_prefix = None
-                    if self._app_state is not None:
+                    try:
+                        if session is not None:
+                            override = getattr(
+                                getattr(session, "state", None),
+                                "command_prefix_override",
+                                None,
+                            )
+                            if isinstance(override, str) and override:
+                                command_prefix = override
+                    except Exception:
+                        command_prefix = None
+
+                    if not command_prefix and self._app_state is not None:
                         try:
                             command_prefix = self._app_state.get_command_prefix()
                         except AttributeError:

--- a/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
+++ b/tests/unit/proxy_logic_tests/test_process_commands_in_messages.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 import src.core.domain.chat as models
+from src.core.commands.command import Command
 from src.core.commands.parser import CommandParser
 from src.core.commands.service import NewCommandService
 from src.core.domain.session import Session
@@ -531,3 +532,53 @@ class TestProcessCommandsInMessages:
         else:
             # Message was cleared after command processing
             assert len(processed_messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_command_prefix_override_is_scoped_per_session(self) -> None:
+        class RecordingParser(CommandParser):
+            def __init__(self) -> None:
+                super().__init__()
+                self.prefix_history: list[str] = []
+
+            def parse(
+                self, content: str, command_prefix: str | None = None
+            ) -> tuple[Command, str] | None:
+                prefix = command_prefix if command_prefix else self.command_prefix
+                self.prefix_history.append(prefix)
+                return super().parse(content, command_prefix=command_prefix)
+
+        class RecordingSessionService:
+            def __init__(self) -> None:
+                self._sessions: dict[str, Session] = {}
+
+            async def get_session(self, session_id: str) -> Session:
+                session = self._sessions.get(session_id)
+                if session is None:
+                    session = Session(session_id=session_id)
+                    self._sessions[session_id] = session
+                return session
+
+        class StaticAppState:
+            def __init__(self, prefix: str) -> None:
+                self._prefix = prefix
+
+            def get_command_prefix(self) -> str:
+                return self._prefix
+
+        from src.core.services.command_processor import CommandProcessor
+
+        session_service = RecordingSessionService()
+        parser = RecordingParser()
+        app_state = StaticAppState("!/")
+        service = NewCommandService(session_service, parser, app_state=app_state)
+        processor = CommandProcessor(service)
+
+        session_a = await session_service.get_session("session-a")
+        session_a.state = session_a.state.with_command_prefix_override("#/")
+
+        msg = models.ChatMessage(role="user", content="no command here")
+        await processor.process_messages([msg], "session-a")
+        assert parser.prefix_history[-1] == "#/"
+
+        await processor.process_messages([msg], "session-b")
+        assert parser.prefix_history[-1] == "!/"

--- a/tests/unit/test_request_processor_service_command_prefix.py
+++ b/tests/unit/test_request_processor_service_command_prefix.py
@@ -110,3 +110,107 @@ async def test_request_processor_uses_app_state_command_prefix(monkeypatch) -> N
     await processor.process_request(context, request)
 
     assert captured_prefix.get("value") == "$/"
+
+
+@pytest.mark.asyncio
+async def test_request_processor_prefers_session_command_prefix(monkeypatch) -> None:
+    session_override = Session(session_id="session-override")
+    session_override.state = session_override.state.with_command_prefix_override("#/")
+
+    app_state = ApplicationStateService()
+    app_state.set_command_prefix("!/")
+    app_state.set_setting(
+        "app_config",
+        SimpleNamespace(
+            auth=SimpleNamespace(redact_api_keys_in_prompts=True),
+            command_prefix="!/",
+        ),
+    )
+
+    class DummyCommandProcessor:
+        async def process_messages(self, messages, session_id, context):
+            return ProcessedResult(
+                modified_messages=messages,
+                command_executed=False,
+                command_results=[],
+            )
+
+    class DummySessionManager:
+        async def resolve_session_id(self, context):
+            return session_override.session_id
+
+        async def get_session(self, session_id):
+            return session_override
+
+        async def update_session_agent(self, session, agent):
+            return session
+
+        async def record_command_in_session(self, request, session_id):
+            return None
+
+        async def update_session_history(
+            self, request_data, backend_request, backend_response, session_id
+        ):
+            return None
+
+    class DummyBackendRequestManager:
+        async def prepare_backend_request(self, request_data, command_result):
+            return request_data
+
+        async def process_backend_request(self, backend_request, session_id, context):
+            return ResponseEnvelope(content={"ok": True})
+
+    class DummyResponseManager:
+        async def process_command_result(self, command_result, session):
+            return ResponseEnvelope(content={"command": True})
+
+    captured_prefix: dict[str, str] = {}
+
+    async def _echo_process(request, _context):
+        return request
+
+    def fake_redaction(*, api_keys, command_prefix):
+        captured_prefix["value"] = command_prefix
+        middleware = MagicMock()
+        middleware.process = AsyncMock(side_effect=_echo_process)
+        return middleware
+
+    monkeypatch.setattr(
+        "src.core.services.redaction_middleware.RedactionMiddleware",
+        fake_redaction,
+    )
+    monkeypatch.setattr(
+        "src.core.common.logging_utils.discover_api_keys_from_config_and_env",
+        lambda cfg: [],
+    )
+    monkeypatch.setattr(
+        "src.core.config.edit_precision_temperatures.load_edit_precision_temperatures_config",
+        dict,
+    )
+
+    class DummyEditPrecision:
+        async def process(self, request, context):
+            return request
+
+    monkeypatch.setattr(
+        "src.core.services.edit_precision_middleware.EditPrecisionTuningMiddleware",
+        lambda *args, **kwargs: DummyEditPrecision(),
+    )
+
+    processor = RequestProcessor(
+        command_processor=DummyCommandProcessor(),
+        session_manager=DummySessionManager(),
+        backend_request_manager=DummyBackendRequestManager(),
+        response_manager=DummyResponseManager(),
+        app_state=app_state,
+    )
+
+    request = ChatRequest(
+        model="gpt-test",
+        messages=[ChatMessage(role="user", content="Hello")],
+    )
+    context = RequestContext(headers={}, cookies={}, state={}, app_state=None)
+
+    await processor.process_request(context, request)
+
+    assert captured_prefix.get("value") == "#/"


### PR DESCRIPTION
## Summary
- add session-scoped command prefix overrides to the session state interfaces and adapters
- ensure command parsing and request redaction prefer the session-specific prefix before falling back to global settings
- add regression tests covering per-session parsing behaviour and redaction overrides

## Testing
- `PYTEST_ADDOPTS="" python -m pytest tests/unit/test_request_processor_service_command_prefix.py tests/unit/proxy_logic_tests/test_process_commands_in_messages.py` *(fails: pytest configuration requires plugins providing --asyncio-mode/xdist which are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e91b6d0c348333a5ccd6a48ddfa95f