### PR TITLE
Fix planning phase override restoration

### DIFF
--- a/src/core/domain/session.py
+++ b/src/core/domain/session.py
@@ -77,6 +77,8 @@ class SessionState(ValueObject):
     pytest_compression_min_lines: int = 0
     planning_phase_turn_count: int = 0
     planning_phase_file_write_count: int = 0
+    planning_phase_original_backend: str | None = None
+    planning_phase_original_model: str | None = None
     api_key_redaction_enabled: bool | None = None
 
     def with_backend_config(self, backend_config: BackendConfiguration) -> SessionState:
@@ -144,6 +146,19 @@ class SessionState(ValueObject):
     def with_planning_phase_file_write_count(self, count: int) -> SessionState:
         """Create a new session state with updated planning phase file write count."""
         return self.model_copy(update={"planning_phase_file_write_count": count})
+
+    def with_planning_phase_original_route(
+        self,
+        backend: str | None,
+        model: str | None,
+    ) -> SessionState:
+        """Create a new session state with updated stored planning-phase route."""
+        return self.model_copy(
+            update={
+                "planning_phase_original_backend": backend,
+                "planning_phase_original_model": model,
+            }
+        )
 
     def with_api_key_redaction_enabled(self, enabled: bool | None) -> SessionState:
         """Create a new session state with updated API key redaction flag."""
@@ -411,6 +426,22 @@ class SessionStateAdapter(ISessionState, ISessionStateMutator):
         new_state = cast(
             SessionState, self._state
         ).with_planning_phase_file_write_count(count)
+        return SessionStateAdapter(new_state)
+
+    @property
+    def planning_phase_original_backend(self) -> str | None:
+        return cast(SessionState, self._state).planning_phase_original_backend
+
+    @property
+    def planning_phase_original_model(self) -> str | None:
+        return cast(SessionState, self._state).planning_phase_original_model
+
+    def with_planning_phase_original_route(
+        self, backend: str | None, model: str | None
+    ) -> ISessionState:
+        new_state = cast(SessionState, self._state).with_planning_phase_original_route(
+            backend, model
+        )
         return SessionStateAdapter(new_state)
 
     # Mutable convenience methods expected by legacy tests

--- a/src/core/interfaces/domain_entities_interface.py
+++ b/src/core/interfaces/domain_entities_interface.py
@@ -271,3 +271,19 @@ class ISessionState(IValueObject, ISessionStateMutator):
     @abstractmethod
     def with_planning_phase_file_write_count(self, count: int) -> ISessionState:
         """Create a new state with updated planning phase file write count."""
+
+    @property
+    @abstractmethod
+    def planning_phase_original_backend(self) -> str | None:
+        """Get the stored original backend for planning phase restoration."""
+
+    @property
+    @abstractmethod
+    def planning_phase_original_model(self) -> str | None:
+        """Get the stored original model for planning phase restoration."""
+
+    @abstractmethod
+    def with_planning_phase_original_route(
+        self, backend: str | None, model: str | None
+    ) -> ISessionState:
+        """Create a new state with updated stored planning-phase backend/model."""


### PR DESCRIPTION
## Summary
- track the original backend/model for planning phase overrides in session state
- restore the stored backend/model when the planning phase limits are reached
- add regression tests covering planning-phase storage and restoration paths

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_planning_phase.py

------
https://chatgpt.com/codex/tasks/task_e_68e91b6d0c348333a5ccd6a48ddfa95f