### PR TITLE
Fix session-scoped command prefix handling

### DIFF
--- a/src/core/domain/commands/set_command.py
+++ b/src/core/domain/commands/set_command.py
@@ -272,16 +272,16 @@ class SetCommand(StatefulCommandBase, BaseCommand):
                 state,
             )
 
-        # Update state through secure DI interface
-        self.update_state_setting("command_prefix", value)
+        updated_state = state.with_command_prefix(value)
 
         return (
             CommandResult(
                 success=True,
                 message=f"Command prefix changed to {value}",
                 data={"command-prefix": value},
+                new_state=updated_state,
             ),
-            state,
+            updated_state,
         )
 
     async def _handle_interactive_mode(

--- a/src/core/domain/commands/unset_command.py
+++ b/src/core/domain/commands/unset_command.py
@@ -179,15 +179,15 @@ class UnsetCommand(StatefulCommandBase, BaseCommand):
     def _unset_command_prefix(
         self, state: ISessionState, context: Any
     ) -> tuple[CommandResult, ISessionState]:
-        # Update state through secure DI interface
-        self.update_state_setting("command_prefix", "!/")
+        updated_state = state.with_command_prefix(None)
 
         result = CommandResult(
             success=True,
             message="Command prefix reset to default (!/)",
             data={"command-prefix": "!/"},
+            new_state=updated_state,
         )
-        return result, state  # No state change in session
+        return result, updated_state
 
     def _unset_project(
         self, state: ISessionState, context: Any

--- a/src/core/domain/session.py
+++ b/src/core/domain/session.py
@@ -78,6 +78,7 @@ class SessionState(ValueObject):
     planning_phase_turn_count: int = 0
     planning_phase_file_write_count: int = 0
     api_key_redaction_enabled: bool | None = None
+    command_prefix: str | None = None
 
     def with_backend_config(self, backend_config: BackendConfiguration) -> SessionState:
         """Create a new session state with updated backend config."""
@@ -148,6 +149,10 @@ class SessionState(ValueObject):
     def with_api_key_redaction_enabled(self, enabled: bool | None) -> SessionState:
         """Create a new session state with updated API key redaction flag."""
         return self.model_copy(update={"api_key_redaction_enabled": enabled})
+
+    def with_command_prefix(self, command_prefix: str | None) -> SessionState:
+        """Create a new session state with updated command prefix."""
+        return self.model_copy(update={"command_prefix": command_prefix})
 
 
 class SessionStateAdapter(ISessionState, ISessionStateMutator):
@@ -252,6 +257,17 @@ class SessionStateAdapter(ISessionState, ISessionStateMutator):
         with contextlib.suppress(Exception):
             self._state = self._state.with_api_key_redaction_enabled(value)
 
+    @property
+    def command_prefix(self) -> str | None:
+        """Get the command prefix override for this session."""
+        return getattr(self._state, "command_prefix", None)
+
+    @command_prefix.setter
+    def command_prefix(self, value: str | None) -> None:
+        """Set the command prefix override on the underlying state."""
+        with contextlib.suppress(Exception):
+            self._state = self._state.with_command_prefix(value)
+
     def with_api_key_redaction_enabled(self, enabled: bool | None) -> ISessionState:
         """Create a new session state with updated API key redaction flag."""
         base_state: SessionState
@@ -261,6 +277,19 @@ class SessionStateAdapter(ISessionState, ISessionStateMutator):
             base_state = SessionState.from_dict(self._state.to_dict())
 
         new_state = base_state.with_api_key_redaction_enabled(enabled)
+        return SessionStateAdapter(new_state)
+
+    def with_command_prefix(
+        self, command_prefix: str | None
+    ) -> ISessionState:
+        """Create a new session state with updated command prefix."""
+        base_state: SessionState
+        if isinstance(self._state, SessionState):
+            base_state = self._state
+        else:
+            base_state = SessionState.from_dict(self._state.to_dict())
+
+        new_state = base_state.with_command_prefix(command_prefix)
         return SessionStateAdapter(new_state)
 
     @property

--- a/src/core/interfaces/domain_entities_interface.py
+++ b/src/core/interfaces/domain_entities_interface.py
@@ -120,6 +120,12 @@ class ISessionStateMutator(ABC):
     def with_is_cline_agent(self, is_cline: bool) -> ISessionState:
         """Create a new state with updated is_cline_agent flag."""
 
+    @abstractmethod
+    def with_command_prefix(
+        self, command_prefix: str | None
+    ) -> ISessionState:
+        """Create a new state with updated command prefix."""
+
 
 class ISessionState(IValueObject, ISessionStateMutator):
     """Interface for session state value objects."""
@@ -197,6 +203,11 @@ class ISessionState(IValueObject, ISessionStateMutator):
     @abstractmethod
     def hello_requested(self) -> bool:
         """Get whether hello was requested in this session."""
+
+    @property
+    @abstractmethod
+    def command_prefix(self) -> str | None:
+        """Get the session-specific command prefix override."""
 
     @hello_requested.setter
     @abstractmethod

--- a/src/core/services/request_processor_service.py
+++ b/src/core/services/request_processor_service.py
@@ -393,7 +393,15 @@ class RequestProcessor(IRequestProcessor):
                     api_keys = discover_api_keys_from_config_and_env(app_config)
                     # Command prefix can be None; RedactionMiddleware has a default
                     command_prefix = None
-                    if self._app_state is not None:
+                    session_prefix: str | None = None
+                    if session is not None:
+                        try:
+                            session_prefix = getattr(session.state, "command_prefix", None)
+                            if isinstance(session_prefix, str) and session_prefix:
+                                command_prefix = session_prefix
+                        except Exception:
+                            session_prefix = None
+                    if command_prefix is None and self._app_state is not None:
                         try:
                             command_prefix = self._app_state.get_command_prefix()
                         except AttributeError:

--- a/tests/unit/commands/test_set_command.py
+++ b/tests/unit/commands/test_set_command.py
@@ -184,3 +184,20 @@ async def test_handle_redact_api_keys_enables_state(
 
     assert result.success is True
     assert new_state.api_key_redaction_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_handle_command_prefix_updates_session_state_only() -> None:
+    from src.core.services.application_state_service import ApplicationStateService
+    from src.core.services.secure_state_service import SecureStateService
+
+    app_state = ApplicationStateService()
+    secure_state = SecureStateService(app_state)
+    command = SetCommand(state_reader=secure_state, state_modifier=secure_state)
+
+    state = SessionState()
+    result, new_state = await command._handle_command_prefix("$/", state, {})
+
+    assert result.success is True
+    assert new_state.command_prefix == "$/"
+    assert app_state.get_command_prefix() is None

--- a/tests/unit/commands/test_set_command_handler.py
+++ b/tests/unit/commands/test_set_command_handler.py
@@ -6,6 +6,10 @@ from pathlib import Path
 import pytest
 from src.core.commands.command import Command
 from src.core.commands.handlers.set_command_handler import SetCommandHandler
+from src.core.commands.parser import CommandParser
+from src.core.commands.service import NewCommandService
+from src.core.domain import chat as models
+from src.core.domain.command_results import CommandResult
 from src.core.domain.configuration.reasoning_config import ReasoningConfiguration
 from src.core.domain.session import Session, SessionState
 
@@ -59,3 +63,43 @@ def test_set_command_handler_validates_temperature_range() -> None:
 
     assert result.success is False
     assert result.message == "Temperature must be between 0.0 and 1.0"
+
+
+@pytest.mark.asyncio
+async def test_command_service_uses_session_specific_prefix_and_restores(monkeypatch):
+    parser = CommandParser()
+    original_prefix = parser.command_prefix
+
+    session = Session(session_id="session", state=SessionState(command_prefix="$/"))
+
+    class DummySessionService:
+        async def get_session(self, session_id: str) -> Session:
+            return session
+
+    command_service = NewCommandService(
+        session_service=DummySessionService(),
+        command_parser=parser,
+        strict_command_detection=False,
+        app_state=None,
+    )
+
+    class DummyHandler:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def handle(self, command: Command, session: Session) -> CommandResult:
+            return CommandResult(success=True, message="ok", name=command.name)
+
+    def fake_get_command_handler(name: str):
+        return DummyHandler if name == "set" else None
+
+    monkeypatch.setattr(
+        "src.core.commands.service.get_command_handler",
+        fake_get_command_handler,
+    )
+
+    messages = [models.ChatMessage(role="user", content="$/set(temperature=0.5)")]
+    result = await command_service.process_commands(messages, session.session_id)
+
+    assert result.command_executed is True
+    assert parser.command_prefix == original_prefix

--- a/tests/unit/commands/test_unit_unset_command.py
+++ b/tests/unit/commands/test_unit_unset_command.py
@@ -93,3 +93,12 @@ def test_unset_redact_api_keys(command: UnsetCommand, initial_state: SessionStat
 
     assert result.success is True
     assert new_state.api_key_redaction_enabled is None
+
+
+def test_unset_command_prefix(command: UnsetCommand, initial_state: SessionState):
+    state_with_prefix = initial_state.with_command_prefix("$/")
+
+    result, new_state = command._unset_command_prefix(state_with_prefix, {})
+
+    assert result.success is True
+    assert new_state.command_prefix is None


### PR DESCRIPTION
## Summary
- track session-specific command prefix overrides in `SessionState` and surface them through the DI interfaces
- update command processing to mutate session state when changing prefixes and to apply per-session prefixes without leaking them globally
- extend request redaction and command tests to respect the new session prefix behaviour and cover regression cases

## Testing
- ❌ `./.venv/Scripts/python.exe -m pytest tests/unit/commands/test_set_command.py tests/unit/commands/test_unit_unset_command.py tests/unit/commands/test_set_command_handler.py` *(fails: python.exe launcher unavailable in container)*
- ❌ `/usr/bin/python3 -m pip install -e .[dev]` *(fails: pip network access unavailable)*
- ❌ `/usr/bin/python3 -m pytest` *(not run due to missing dependencies after failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68e91b6d0c348333a5ccd6a48ddfa95f