### PR TITLE
Fix tool call middleware handling of empty replacements

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -186,7 +186,7 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
                     )
 
                     # Create a new response with the replacement content
-                    if result.replacement_response:
+                    if result.replacement_response is not None:
                         replacement_response = self._create_replacement_response(
                             response,
                             result.replacement_response,


### PR DESCRIPTION
## Summary
- ensure the tool call reactor middleware treats empty replacement payloads as valid
- add a regression test covering swallowed tool calls that return an empty string response

## Testing
- python -m pytest -o addopts= tests/unit/core/services/test_tool_call_reactor_middleware.py
- python -m pytest -o addopts=
  - fails: missing optional dependencies (e.g., pytest_asyncio, respx, pytest_httpx) required by the full suite

------
https://chatgpt.com/codex/tasks/task_e_68e91b218d9083338b1ece39d1549d0e