### PR TITLE
Fix tool call reactor argument type checks

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -155,11 +155,11 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
                     # Preserve the original value so downstream handlers still
                     # receive the raw arguments string.
                     tool_arguments = tool_arguments_raw
-                elif isinstance(parsed_args, dict | list):
+                elif isinstance(parsed_args, (dict, list)):
                     tool_arguments = parsed_args
                 else:
                     tool_arguments = parsed_args
-            elif isinstance(tool_arguments_raw, dict | list):
+            elif isinstance(tool_arguments_raw, (dict, list)):
                 tool_arguments = tool_arguments_raw
             else:
                 tool_arguments = tool_arguments_raw
@@ -223,7 +223,7 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
             return []
 
         # Normalize the content into a Python structure that can be inspected
-        if isinstance(content, dict | list):
+        if isinstance(content, (dict, list)):
             data = content
         elif isinstance(content, str):
             try:


### PR DESCRIPTION
## Summary
- ensure the tool call reactor middleware correctly recognizes parsed argument objects without raising type errors
- keep tool call extraction working when responses are already parsed into Python dictionaries or lists

## Testing
- python -m pytest -o addopts= tests/integration/test_tool_call_reactor_integration.py
- python -m pytest -o addopts= (fails: missing dev-only test dependencies such as pytest-asyncio/respx)


------
https://chatgpt.com/codex/tasks/task_e_68e91b218d9083338b1ece39d1549d0e