### PR TITLE
Normalize tool call metadata entries

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -113,8 +113,17 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
         try:
             if hasattr(response, "metadata") and isinstance(response.metadata, dict):
                 response.metadata.setdefault("tool_calls", [])
-                # Only extend if not already present to avoid duplication
-                if response.metadata["tool_calls"] == []:
+                existing_calls = response.metadata.get("tool_calls")
+
+                replace_metadata_calls = False
+                if not isinstance(existing_calls, list):
+                    replace_metadata_calls = True
+                elif not existing_calls:
+                    replace_metadata_calls = True
+                elif not all(isinstance(item, dict) for item in existing_calls):
+                    replace_metadata_calls = True
+
+                if replace_metadata_calls:
                     response.metadata["tool_calls"] = list(tool_calls)
             # Also pass via context so processors can use them even if metadata is overwritten later
             if isinstance(context, dict):


### PR DESCRIPTION
## Summary
- normalize response metadata so tool call annotations replace missing, non-list, or non-dict entries before propagating detected tool calls
- add a regression test covering None-valued metadata to ensure normalized tool call lists are exposed

## Testing
- python -m pytest tests/unit/core/services/test_tool_call_reactor_middleware.py::TestToolCallReactorMiddleware::test_process_metadata_tool_calls_none_value
- python -m pytest *(fails in existing baseline suites such as reasoning handler, redaction, quality checks, and mypy validation)*

------
https://chatgpt.com/codex/tasks/task_e_68e91b218d9083338b1ece39d1549d0e