### PR TITLE
Fix response rewriting for multimodal assistant messages

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -129,13 +129,29 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                 continue
 
             original_content = message.get("content")
-            if not isinstance(original_content, str):
+
+            if isinstance(original_content, str):
+                rewritten_content = self.rewriter.rewrite_reply(original_content)
+                if original_content != rewritten_content:
+                    message["content"] = rewritten_content
+                    is_rewritten = True
                 continue
 
-            rewritten_content = self.rewriter.rewrite_reply(original_content)
-            if original_content != rewritten_content:
-                message["content"] = rewritten_content
-                is_rewritten = True
+            if not isinstance(original_content, list):
+                continue
+
+            for block in original_content:
+                if not isinstance(block, dict):
+                    continue
+
+                text_value = block.get("text")
+                if not isinstance(text_value, str):
+                    continue
+
+                rewritten_text = self.rewriter.rewrite_reply(text_value)
+                if rewritten_text != text_value:
+                    block["text"] = rewritten_text
+                    is_rewritten = True
 
         return is_rewritten
 


### PR DESCRIPTION
## Summary
- update the content rewriting middleware so assistant responses with list-style content blocks have their text segments rewritten
- adjust the middleware integration test to cover multimodal replies and ensure non-text blocks remain unchanged

## Testing
- python -m pytest -o addopts="" tests/integration/test_content_rewriting_middleware.py::TestContentRewritingMiddleware::test_inbound_reply_rewriting_handles_multimodal_content
- python -m pytest -o addopts="" *(fails: missing optional dev dependencies such as pytest_asyncio, pytest_httpx, respx, hypothesis, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68e91ae5f8008333829ddcaf61bc22f7