### PR TITLE
Fix help command argument parsing fallback

### DIFF
--- a/src/core/commands/handlers/help_command_handler.py
+++ b/src/core/commands/handlers/help_command_handler.py
@@ -54,10 +54,20 @@ class HelpCommandHandler(ICommandHandler):
 
         # Detailed mode using service methods
         if command.args:
-            cmd_name = command.args.get("command_name") or ""
-            if not cmd_name and command.args:
-                cmd_name = next(iter(command.args.keys()), "")
-            cmd_name = cmd_name.strip()
+            raw_cmd_name = command.args.get("command_name")
+            if not raw_cmd_name:
+                raw_cmd_name = command.args.get("command")
+
+            if not raw_cmd_name and command.args:
+                first_key, first_value = next(iter(command.args.items()))
+                if isinstance(first_value, str) and first_value.strip():
+                    raw_cmd_name = first_value
+                elif first_value:
+                    raw_cmd_name = str(first_value)
+                else:
+                    raw_cmd_name = first_key
+
+            cmd_name = str(raw_cmd_name).strip() if raw_cmd_name is not None else ""
             if cmd_name:
                 handler_class = await self._command_service.get_command_handler(cmd_name)  # type: ignore[attr-defined]
                 if handler_class is None:

--- a/tests/unit/core/commands/handlers/test_help_command_handler.py
+++ b/tests/unit/core/commands/handlers/test_help_command_handler.py
@@ -71,3 +71,21 @@ async def test_help_command_handler_with_arg(mock_command_service: MagicMock):
     assert "Examples:" in result.message
     assert "hello" in result.message
     mock_command_service.get_command_handler.assert_called_once_with("hello")
+
+
+@pytest.mark.asyncio
+async def test_help_command_handler_with_generic_arg_key(
+    mock_command_service: MagicMock,
+):
+    """Help handler should accept arbitrary argument names containing the command."""
+
+    handler = HelpCommandHandler(mock_command_service)
+    command = Command(name="help", args={"command": "hello"})
+    session_state = SessionState()
+    session = Session(session_id="test_session", state=session_state)
+
+    result = await handler.handle(command, session)
+
+    assert result.success
+    assert "hello - Greets the user." in result.message
+    mock_command_service.get_command_handler.assert_called_once_with("hello")


### PR DESCRIPTION
## Summary
- ensure the `!/help` handler extracts the command name from provided argument values before falling back to keys
- add a regression test covering the generic `command=<name>` argument pattern

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/commands/handlers/test_help_command_handler.py
- python -m pytest --override-ini addopts="" *(fails: missing optional test dependencies such as pytest-asyncio and respx)*

------
https://chatgpt.com/codex/tasks/task_e_68e91ab0e9e88333a9564252a6cadefd