### PR TITLE
Fix reasoning alias command config resolution

### DIFF
--- a/src/core/commands/handlers/reasoning_aliases.py
+++ b/src/core/commands/handlers/reasoning_aliases.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from src.core.commands.command import Command
 from src.core.commands.handler import ICommandHandler
@@ -9,12 +9,73 @@ from src.core.common.utils import wildcard_match
 from src.core.domain.command_results import CommandResult
 from src.core.domain.configuration.reasoning_aliases_config import (
     ModelReasoningAliases,
+    ReasoningAliasesConfig,
     ReasoningMode,
 )
 from src.core.domain.session import Session
 
 if TYPE_CHECKING:
     from src.core.interfaces.command_service_interface import ICommandService
+
+
+def _get_app_config(
+    secure_state_access: Any,
+    command_service: "ICommandService | None",
+) -> Any | None:
+    """Resolve the application configuration from available dependencies."""
+
+    if secure_state_access is not None:
+        config_getter = getattr(secure_state_access, "get_config", None)
+        if callable(config_getter):
+            config = config_getter()
+            if config is not None:
+                return config
+
+    if command_service is not None:
+        command_service_getter = getattr(command_service, "get_app_config", None)
+        if callable(command_service_getter):
+            config = command_service_getter()
+            if config is not None:
+                return config
+
+        app_state = getattr(command_service, "app_state", None)
+        if app_state is not None:
+            setting_getter = getattr(app_state, "get_setting", None)
+            if callable(setting_getter):
+                config = setting_getter("app_config")
+                if config is not None:
+                    return config
+
+            direct_config = getattr(app_state, "app_config", None)
+            if direct_config is not None:
+                return direct_config
+
+    return None
+
+
+def _get_reasoning_aliases_config(
+    secure_state_access: Any,
+    command_service: "ICommandService | None",
+) -> tuple[bool, list[ModelReasoningAliases]]:
+    """Retrieve the reasoning aliases configuration if available."""
+
+    app_config = _get_app_config(secure_state_access, command_service)
+    if app_config is None:
+        return False, []
+
+    reasoning_aliases = getattr(app_config, "reasoning_aliases", None)
+    if reasoning_aliases is None:
+        return False, []
+
+    if isinstance(reasoning_aliases, ReasoningAliasesConfig):
+        return True, reasoning_aliases.reasoning_alias_settings
+
+    if hasattr(reasoning_aliases, "reasoning_alias_settings"):
+        settings = getattr(reasoning_aliases, "reasoning_alias_settings")
+        if isinstance(settings, list):
+            return True, cast(list[ModelReasoningAliases], settings)
+
+    return True, []
 
 
 class ReasoningAliasCommandHandler(ICommandHandler):
@@ -46,14 +107,16 @@ class ReasoningAliasCommandHandler(ICommandHandler):
         return [f"!/{self.command_name}"]
 
     async def handle(self, command: Command, session: Session) -> CommandResult:
-        config = self._secure_state_access.get_config()
+        has_aliases_config, alias_settings = _get_reasoning_aliases_config(
+            self._secure_state_access, self._command_service
+        )
         model_id = session.get_model()
 
-        if not config or not config.reasoning_aliases:
+        if not has_aliases_config:
             return CommandResult(False, "Reasoning aliases are not configured.")
 
         if model_id:
-            for model_aliases in config.reasoning_aliases.reasoning_alias_settings:
+            for model_aliases in alias_settings:
                 if wildcard_match(model_aliases.model, model_id):
                     mode = self.get_reasoning_mode(model_aliases)
                     if mode:
@@ -201,14 +264,16 @@ class SetModeCommandHandler(ICommandHandler):
             return CommandResult(False, "Mode name is required.")
 
         mode_name = str(command.args["mode_name"])
-        config = self._secure_state_access.get_config()
+        has_aliases_config, alias_settings = _get_reasoning_aliases_config(
+            self._secure_state_access, self._command_service
+        )
         model_id = session.get_model()
 
-        if not config or not config.reasoning_aliases:
+        if not has_aliases_config:
             return CommandResult(False, "Reasoning aliases are not configured.")
 
         if model_id:
-            for model_aliases in config.reasoning_aliases.reasoning_alias_settings:
+            for model_aliases in alias_settings:
                 if wildcard_match(model_aliases.model, model_id):
                     mode = model_aliases.modes.get(mode_name)
                     if mode:

--- a/src/core/commands/service.py
+++ b/src/core/commands/service.py
@@ -43,6 +43,23 @@ class NewCommandService(ICommandService):
         self.strict_command_detection = strict_command_detection
         self._app_state = app_state
 
+    @property
+    def app_state(self) -> IApplicationState | None:
+        """Expose the application state dependency for command handlers."""
+
+        return self._app_state
+
+    def get_app_config(self) -> Any | None:
+        """Return the current application configuration if available."""
+
+        if self._app_state is None:
+            return None
+
+        try:
+            return self._app_state.get_setting("app_config")
+        except Exception:  # pragma: no cover - defensive fallback
+            return getattr(self._app_state, "app_config", None)
+
     def _refresh_command_prefix(self) -> None:
         """Synchronize the parser's prefix with the current application state."""
         if self._app_state is None:

--- a/tests/unit/core/commands/handlers/test_reasoning_aliases.py
+++ b/tests/unit/core/commands/handlers/test_reasoning_aliases.py
@@ -1,13 +1,33 @@
 from unittest.mock import Mock
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 from src.core.commands.command import Command
 from src.core.commands.handlers.reasoning_aliases import (
+    MaxReasoningHandler,
     SetModeCommandHandler,
     SetProviderCommandHandler,
 )
-from src.core.domain.configuration.reasoning_aliases_config import ReasoningMode
+from src.core.domain.configuration.reasoning_aliases_config import (
+    ModelReasoningAliases,
+    ReasoningAliasesConfig,
+    ReasoningMode,
+)
 from src.core.domain.session import Session
+
+
+class _CommandServiceStub:
+    def __init__(self, config):
+        self._config = config
+
+    def get_app_config(self):
+        return self._config
+
+    @property
+    def app_state(self):  # pragma: no cover - compatibility shim
+        return None
 
 
 class TestSetProviderCommandHandler:
@@ -116,3 +136,77 @@ class TestSetModeCommandHandler:
 
         assert result.success is False
         assert result.message == "No reasoning settings found for model None."
+
+
+class TestReasoningAliasHandlersWithoutSecureState:
+    @pytest.fixture
+    def config(self):
+        return SimpleNamespace(
+            reasoning_aliases=ReasoningAliasesConfig(
+                reasoning_alias_settings=[
+                    ModelReasoningAliases(
+                        model="claude-*",
+                        modes={
+                            "high": ReasoningMode(max_reasoning_tokens=1000),
+                            "custom": ReasoningMode(reasoning_effort="medium"),
+                        },
+                    )
+                ]
+            )
+        )
+
+    @pytest.fixture
+    def command_service(self, config):
+        return _CommandServiceStub(config)
+
+    @pytest.fixture
+    def session(self):
+        session = Mock(spec=Session)
+        session.get_model = Mock(return_value="claude-3-opus")
+        session.set_reasoning_mode = Mock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_reasoning_alias_handler_uses_command_service_config(
+        self, command_service, session, config
+    ):
+        handler = MaxReasoningHandler(command_service=command_service)
+        command = Command(name="max", args={})
+
+        result = await handler.handle(command, session)
+
+        assert result.success is True
+        assert result.message == "Reasoning mode set to max."
+        session.set_reasoning_mode.assert_called_once_with(
+            config.reasoning_aliases.reasoning_alias_settings[0].modes["high"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_mode_handler_uses_command_service_config(
+        self, command_service, session, config
+    ):
+        handler = SetModeCommandHandler(command_service=command_service)
+        command = Command(name="mode", args={"mode_name": "custom"})
+
+        result = await handler.handle(command, session)
+
+        assert result.success is True
+        assert result.message == "Reasoning mode set to custom."
+        session.set_reasoning_mode.assert_called_once_with(
+            config.reasoning_aliases.reasoning_alias_settings[0].modes["custom"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_mode_handler_without_config_returns_error(self, session):
+        empty_config = SimpleNamespace(reasoning_aliases=None)
+        handler = SetModeCommandHandler(
+            command_service=_CommandServiceStub(empty_config)
+        )
+        command = Command(name="mode", args={"mode_name": "custom"})
+        session.get_model.return_value = "claude-3"
+
+        result = await handler.handle(command, session)
+
+        assert result.success is False
+        assert result.message == "Reasoning aliases are not configured."
+        session.set_reasoning_mode.assert_not_called()


### PR DESCRIPTION
## Summary
- resolve reasoning alias and mode commands against the shared app config when secure state access does not expose configuration
- expose the application state and app-config helper on the new command service so handlers can retrieve configuration data
- add regression coverage proving reasoning alias commands work without secure state access

## Testing
- python -m pytest -o addopts='' tests/unit/core/commands/handlers/test_reasoning_aliases.py
- python -m pytest -o addopts=''  # fails: missing dev test dependencies in this environment


------
https://chatgpt.com/codex/tasks/task_e_68e91ab0e9e88333a9564252a6cadefd