### PR TITLE
Handle quoted project directory paths

### DIFF
--- a/src/core/commands/handlers/project_dir_handler.py
+++ b/src/core/commands/handlers/project_dir_handler.py
@@ -90,6 +90,13 @@ class ProjectDirCommandHandler(BaseCommandHandler):
         else:
             normalized_input = str(param_value)
 
+        if (
+            len(normalized_input) >= 2
+            and normalized_input[0] == normalized_input[-1]
+            and normalized_input[0] in {'"', "'"}
+        ):
+            normalized_input = normalized_input[1:-1].strip()
+
         if normalized_input == "":
             new_state = current_state.with_project_dir(None)
             return CommandHandlerResult(


### PR DESCRIPTION
## Summary
- strip matching quotes from project directory command values before validating
- add coverage for quoted project paths and empty quoted values

## Testing
- python -m pytest tests/unit/core/commands/handlers/test_project_dir_handler.py
- python -m pytest *(fails: existing suite issues including redaction, failover route, lint, and mypy checks)*

------
https://chatgpt.com/codex/tasks/task_e_68e91ab0e9e88333a9564252a6cadefd