### PR TITLE
Handle recursion errors when canonicalizing tool call arguments

### DIFF
--- a/src/tool_call_loop/tracker.py
+++ b/src/tool_call_loop/tracker.py
@@ -88,17 +88,20 @@ class ToolCallSignature(InternalDTO):
         if isinstance(arguments, str):
             try:
                 repaired_arguments = repair_json(arguments)
-            except TypeError:
+            except (RecursionError, TypeError):
                 return arguments
 
             try:
                 parsed_arguments = json.loads(repaired_arguments)
-            except (json.JSONDecodeError, TypeError):
+            except (json.JSONDecodeError, RecursionError, TypeError):
                 return arguments
 
-            return json.dumps(
-                parsed_arguments, sort_keys=True, ensure_ascii=False, default=str
-            )
+            try:
+                return json.dumps(
+                    parsed_arguments, sort_keys=True, ensure_ascii=False, default=str
+                )
+            except (RecursionError, TypeError):
+                return arguments
 
         if isinstance(arguments, Mapping) or (
             isinstance(arguments, Sequence)
@@ -111,7 +114,7 @@ class ToolCallSignature(InternalDTO):
                     ensure_ascii=False,
                     default=str,
                 )
-            except TypeError:
+            except (RecursionError, TypeError):
                 return str(arguments)
 
         return str(arguments)

--- a/tests/unit/loop_detection/test_tool_call_tracker.py
+++ b/tests/unit/loop_detection/test_tool_call_tracker.py
@@ -36,6 +36,19 @@ class TestToolCallSignature:
         # Invalid JSON should be used as-is
         assert signature.arguments_signature == arguments
 
+    def test_from_tool_call_with_deeply_nested_json(self) -> None:
+        """Deeply nested JSON should not raise recursion errors during canonicalization."""
+
+        tool_name = "test_tool"
+        depth = 1100
+        arguments = "[" * depth + "0" + "]" * depth
+
+        signature = ToolCallSignature.from_tool_call(tool_name, arguments)
+
+        assert signature.tool_name == tool_name
+        # Canonicalization should fall back to the original string when recursion limits are hit
+        assert signature.arguments_signature == arguments
+
     def test_from_tool_call_with_mapping_arguments(self):
         """Tool calls with dict arguments should be canonicalized."""
 


### PR DESCRIPTION
## Summary
- prevent recursion errors during tool call argument canonicalization so deeply nested payloads cannot crash the proxy
- add a regression test covering deeply nested JSON arguments to ensure graceful handling

## Testing
- python -m pytest -o addopts='' tests/unit/loop_detection/test_tool_call_tracker.py::TestToolCallSignature::test_from_tool_call_with_deeply_nested_json
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e93687b4608333b4487ec075dd0f5c