### PR TITLE
Fix backend service DI scope

### DIFF
--- a/src/core/app/stages/backend.py
+++ b/src/core/app/stages/backend.py
@@ -248,9 +248,11 @@ class BackendStage(InitializationStage):
                 BackendService, implementation_factory=backend_service_factory
             )
 
-            services.add_singleton(
+            services.add_singleton_factory(
                 cast(type, IBackendService),
-                implementation_factory=backend_service_factory,
+                implementation_factory=lambda provider: provider.get_required_service(
+                    BackendService
+                ),
             )
 
             if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
## Summary
- ensure the backend service interface registration resolves to the concrete BackendService singleton via the DI container
- extend the backend startup validation test to fail if multiple BackendService instances are constructed

## Testing
- python -m pytest tests/unit/core/app/stages/test_backend_startup_validation.py::test_backend_service_interface_shares_concrete_singleton --override-ini addopts="" -q
- python -m pytest --override-ini addopts="" -q *(fails: missing pytest_asyncio, respx, pytest_httpx, hypothesis dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e936e628ac83338639a844f2e098d6