### PR TITLE
Fix chat controller DI factories to resolve dependencies

### DIFF
--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -587,7 +587,12 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
                                     def command_processor_factory(
                                         provider: IServiceProvider,
                                     ) -> CommandProcessor:
-                                        return CommandProcessor(concrete_cmd)
+                                        resolved_command_service: ICommandService = (
+                                            provider.get_required_service(
+                                                cast(type, ICommandService)
+                                            )
+                                        )
+                                        return CommandProcessor(resolved_command_service)
 
                                     services.add_singleton(
                                         ICommandProcessor,  # type: ignore[type-abstract]
@@ -603,10 +608,29 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
                                     def backend_processor_factory(
                                         provider: IServiceProvider,
                                     ) -> BackendProcessor:
+                                        from src.core.interfaces.application_state_interface import (
+                                            IApplicationState,
+                                        )
+
+                                        resolved_backend_service: IBackendService = (
+                                            provider.get_required_service(
+                                                cast(type, IBackendService)
+                                            )
+                                        )
+                                        resolved_session_service: ISessionService = (
+                                            provider.get_required_service(
+                                                cast(type, ISessionService)
+                                            )
+                                        )
+                                        resolved_app_state: IApplicationState = (
+                                            provider.get_required_service(
+                                                cast(type, IApplicationState)
+                                            )
+                                        )
                                         return BackendProcessor(
-                                            concrete_backend,
-                                            concrete_session,
-                                            app_state,
+                                            resolved_backend_service,
+                                            resolved_session_service,
+                                            resolved_app_state,
                                         )
 
                                     services.add_singleton(


### PR DESCRIPTION
## Summary
- update the fallback factories in `ChatController` to resolve their dependencies from the supplied service provider
- ensure backend and command processor factories no longer close over outer-scope objects so DI continues to work as expected

## Testing
- pytest --override-ini addopts="" tests/integration/test_direct_controllers.py *(fails: missing pytest_asyncio dependency)*
- pytest --override-ini addopts="" *(fails: missing pytest_asyncio and respx dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e936e628ac83338639a844f2e098d6