### PR TITLE
Ensure OpenAI streaming errors close responses

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import inspect
 import logging
 
 logger = logging.getLogger(__name__)
@@ -479,10 +481,17 @@ class OpenAIConnector(LLMBackend):
         if status_code >= 400:
             # For backwards compatibility with existing error handlers, still use HTTPException here.
             # This will be replaced in a future update with domain exceptions.
+            close_callable = getattr(response, "aclose", None)
             try:
                 body = (await response.aread()).decode("utf-8")
             except Exception:
                 body = getattr(response, "text", "")
+            finally:
+                if callable(close_callable):
+                    with contextlib.suppress(Exception):
+                        maybe_awaitable = close_callable()
+                        if inspect.isawaitable(maybe_awaitable):
+                            await maybe_awaitable
             raise HTTPException(
                 status_code=status_code,
                 detail={


### PR DESCRIPTION
## Summary
- ensure OpenAI streaming error handling always closes the underlying HTTP response before raising
- add a regression test verifying that streaming error responses trigger the response close path

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/openai_connector_tests/test_streaming_response.py::test_streaming_response_error_closes_response
- ./.venv/Scripts/python.exe -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e9371dba8083338209d112a9615fc2