### PR TITLE
Add schema size guard to structured output validation

### DIFF
--- a/src/core/app/controllers/responses_controller.py
+++ b/src/core/app/controllers/responses_controller.py
@@ -16,6 +16,7 @@ from src.core.interfaces.response_processor_interface import ProcessedResponse
 from src.core.interfaces.translation_service_interface import (
     ITranslationService,
 )
+from src.core.services.json_repair_service import enforce_schema_size_limits
 from src.core.transport.fastapi.exception_adapters import (
     map_domain_exception_to_http_exception,
 )
@@ -624,6 +625,8 @@ class ResponsesController:
         """
         if not isinstance(schema, dict):
             raise ValueError("Schema must be a dictionary")
+
+        enforce_schema_size_limits(schema)
 
         # Check for required fields
         if "type" not in schema:


### PR DESCRIPTION
## Summary
- add defensive limits that reject oversized JSON schemas before they reach expensive validation paths
- reuse the new guard inside the Responses controller and JSON repair service to prevent attacker-supplied schemas from exhausting resources
- cover the new guard with unit tests that assert large property counts and collections are rejected

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/services/test_json_repair_service.py
- python -m pytest --override-ini addopts="" *(fails: missing pytest_asyncio/respx/pytest_httpx/hypothesis dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e93753fc1c833396340c710bf1f1aa