### PR TITLE
Fix streaming transport error handling in OpenAI connector

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -519,10 +519,15 @@ class OpenAIConnector(LLMBackend):
         async def gen() -> AsyncGenerator[ProcessedResponse, None]:
             # Forward raw text stream; central pipeline will handle normalization/repairs
             async def text_generator() -> AsyncGenerator[str, None]:
-                async for chunk in response.aiter_text():
-                    yield self.translation_service.to_domain_stream_chunk(
-                        chunk, stream_format
-                    )
+                try:
+                    async for chunk in response.aiter_text():
+                        yield self.translation_service.to_domain_stream_chunk(
+                            chunk, stream_format
+                        )
+                except httpx.HTTPError as exc:
+                    raise ServiceUnavailableError(
+                        message=f"Error receiving streaming response from backend ({exc})"
+                    ) from exc
 
             try:
                 async for chunk in text_generator():

--- a/tests/unit/openai_connector_tests/test_streaming_response.py
+++ b/tests/unit/openai_connector_tests/test_streaming_response.py
@@ -537,6 +537,56 @@ async def test_streaming_response_request_error(
 
 
 @pytest.mark.asyncio
+async def test_streaming_response_stream_failure() -> None:
+    """Test that streaming transport errors are surfaced as ServiceUnavailableError."""
+
+    mock_response = MockResponse(status_code=200)
+
+    async def failing_stream() -> Any:
+        raise httpx.ReadError(
+            "stream boom", request=httpx.Request("POST", "https://example.com")
+        )
+        yield  # pragma: no cover
+
+    mock_response.aiter_text = MagicMock(return_value=failing_stream())
+
+    fake_request = object()
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.build_request.return_value = fake_request
+    client.send = AsyncMock(return_value=mock_response)
+
+    from src.core.config.app_config import AppConfig, SessionConfig
+    from src.core.domain.chat import ChatMessage, ChatRequest
+    from src.core.services.translation_service import TranslationService
+
+    connector = OpenAIConnector(
+        client,
+        config=AppConfig(session=SessionConfig(json_repair_enabled=False)),
+        translation_service=TranslationService(),
+    )
+    connector.api_key = "test-api-key"
+
+    request_data = ChatRequest(
+        model="test-model",
+        messages=[ChatMessage(role="user", content="test")],
+        stream=True,
+    )
+
+    result = await connector.chat_completions(
+        request_data,
+        [{"role": "user", "content": "test"}],
+        "test-model",
+    )
+
+    with pytest.raises(ServiceUnavailableError) as excinfo:
+        async for _ in result.content:
+            pass
+
+    assert "stream boom" in str(excinfo.value)
+    assert mock_response.closed
+
+
+@pytest.mark.asyncio
 async def test_streaming_response_no_auth(connector: OpenAIConnector) -> None:
     """Test handling a streaming response with no auth."""
     # Create a mock ChatRequest with streaming enabled


### PR DESCRIPTION
## Summary
- wrap OpenAI streaming iteration in a try/except to convert httpx transport errors into ServiceUnavailableError
- add regression test covering stream iteration failures so the connector closes the response and raises the domain error

## Testing
- python -m pytest tests/unit/openai_connector_tests/test_streaming_response.py::test_streaming_response_stream_failure
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb82284d1483339d3f9d0a91799e5f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of streaming chat responses by converting transport errors during streaming into a clear service-unavailable error with a descriptive message. Ensures consistent error surfacing and prevents partial or hanging streams. No changes to the public API.

* **Tests**
  * Added an asynchronous test that simulates a streaming failure to verify correct error propagation and proper resource cleanup during streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->