### PR TITLE
Preserve backend retry kwargs on rate limit

### DIFF
--- a/src/core/services/backend_service.py
+++ b/src/core/services/backend_service.py
@@ -653,6 +653,7 @@ class BackendService(IBackendService):
                             processed_messages=request.messages,
                             effective_model=effective_model,
                             identity=identity,
+                            **backend_call_kwargs,
                         )
                     else:
                         raise

--- a/tests/unit/core/test_backend_service_enhanced.py
+++ b/tests/unit/core/test_backend_service_enhanced.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+from types import SimpleNamespace
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
@@ -19,6 +20,7 @@ from src.core.domain.chat import (
     ChatMessage,
     ChatRequest,
 )
+from src.core.domain.request_context import RequestContext
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.interfaces.application_state_interface import IApplicationState
 from src.core.interfaces.model_bases import DomainModel, InternalDTO
@@ -504,6 +506,87 @@ class TestBackendServiceCompletions:
             assert "Backend call failed" in str(exc_info.value)
             assert "API error" in str(exc_info.value)
             # Note: The backend type may not be included in the error message in all implementations
+
+    @pytest.mark.asyncio
+    async def test_retry_429_preserves_backend_kwargs(
+        self, service, chat_request
+    ) -> None:
+        """Ensure retrying a 429 keeps backend kwargs like session and project."""
+
+        class TrackingBackend(LLMBackend):
+            def __init__(self) -> None:
+                self.calls: list[dict[str, Any]] = []
+                self._responses: list[object] = [
+                    BackendError(
+                        "Rate limited",
+                        backend_name=BackendType.OPENAI,
+                        status_code=429,
+                        details={"error": {"message": "Too Many Requests"}},
+                    ),
+                    ResponseEnvelope(content={"ok": True}, headers={}),
+                ]
+
+            async def initialize(self, **kwargs: Any) -> None:  # pragma: no cover - unused in test
+                return None
+
+            def get_available_models(self) -> list[str]:
+                return ["model1"]
+
+            async def chat_completions(
+                self,
+                request_data: DomainModel | InternalDTO | dict[str, Any],
+                processed_messages: list,
+                effective_model: str,
+                identity: Any = None,
+                **kwargs: Any,
+            ) -> ResponseEnvelope | StreamingResponseEnvelope:
+                self.calls.append(dict(kwargs))
+                next_response = self._responses.pop(0)
+                if isinstance(next_response, Exception):
+                    raise next_response
+                return next_response  # type: ignore[return-value]
+
+        backend = TrackingBackend()
+        service._get_or_create_backend = AsyncMock(return_value=backend)
+
+        session = SimpleNamespace(
+            state=SimpleNamespace(
+                project="proj-alpha",
+                project_dir="/tmp/proj",
+                backend_config=None,
+            )
+        )
+        service._session_service.get_session = AsyncMock(return_value=session)
+
+        context = RequestContext(
+            headers={},
+            cookies={},
+            state=SimpleNamespace(),
+            app_state=SimpleNamespace(),
+            client_host="127.0.0.1",
+            session_id="sess-123",
+        )
+
+        request_with_session = chat_request.model_copy(
+            update={
+                "extra_body": {
+                    "backend_type": BackendType.OPENAI,
+                    "session_id": "sess-123",
+                }
+            }
+        )
+
+        response = await service.call_completion(
+            request_with_session, context=context, allow_failover=False
+        )
+
+        assert isinstance(response, ResponseEnvelope)
+        assert backend.calls and len(backend.calls) == 2
+        first_call, second_call = backend.calls
+        assert first_call == second_call
+        assert first_call.get("session_id") == "sess-123"
+        assert first_call.get("project") == "proj-alpha"
+        assert first_call.get("project_dir") == "/tmp/proj"
 
     @pytest.mark.asyncio
     async def test_call_completion_invalid_response(self, service, chat_request):


### PR DESCRIPTION
## Summary
- ensure backend retry after a 429 forwards the original backend_call_kwargs so session, project, and other context stay intact
- add a regression test covering the 429 retry path and import the request context helpers needed for the assertion

## Testing
- python -m pytest -o addopts='' tests/unit/core/test_backend_service_enhanced.py::TestBackendServiceCompletions::test_retry_429_preserves_backend_kwargs
- python -m pytest -o addopts='' *(fails: missing pytest_asyncio, respx, pytest_httpx dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68eb824f88148333b19d224eee834b5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures session and project context is preserved when retrying requests after a rate-limit (429) response, improving reliability and consistency of completions. Prevents occasional loss of context on retried requests.

- Tests
  - Added a unit test to verify that context is retained across retries after rate-limit responses, strengthening coverage of retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->