### PR TITLE
Fix command result wrapper scope

### DIFF
--- a/src/core/commands/service.py
+++ b/src/core/commands/service.py
@@ -21,6 +21,32 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class CommandResultWrapper:
+    """Lightweight wrapper around command handler results.
+
+    Historically the wrapper was defined inside ``process_commands`` which meant
+    every invocation created a brand new class object.  Instances produced in
+    separate calls therefore had different types which broke identity-based
+    checks and made it impossible to import the wrapper for typing or
+    isinstance() checks.  By hoisting the class to module scope we ensure the
+    wrapper has a single, stable definition while keeping the behaviour
+    identical to the previous implementation.
+    """
+
+    def __init__(self, command_name: str, result: Any) -> None:
+        self.name = command_name
+        self.message = result.message
+        self.success = result.success
+        self.new_state = getattr(result, "new_state", None)
+        self._original_result = result
+
+    @property
+    def result(self) -> Any:
+        """Expose the original command result for callers that need it."""
+
+        return self._original_result
+
+
 class NewCommandService(ICommandService):
     """
     A service for processing and executing commands using the new architecture.
@@ -249,14 +275,6 @@ class NewCommandService(ICommandService):
             result = await handler.handle(command, session)
 
             # Wrap the result with command name for proper response formatting
-            class CommandResultWrapper:
-                def __init__(self, command_name: str, result):
-                    self.name = command_name
-                    self.message = result.message
-                    self.success = result.success
-                    self.new_state = getattr(result, "new_state", None)
-                    self._original_result = result
-
             executed_command_name = command.name
             wrapped_result = CommandResultWrapper(executed_command_name, result)
             command_executed = True

--- a/tests/unit/core/commands/test_command_result_wrapper.py
+++ b/tests/unit/core/commands/test_command_result_wrapper.py
@@ -1,0 +1,73 @@
+"""Unit tests for the command result wrapper scoping bug."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.core.commands.command import Command
+from src.core.commands.handler import ICommandHandler
+from src.core.commands.parser import CommandParser
+from src.core.commands.service import CommandResultWrapper, NewCommandService
+from src.core.domain.chat import ChatMessage
+from src.core.domain.command_results import CommandResult
+from src.core.domain.session import Session
+
+
+class _StubSessionService:
+    async def get_session(self, session_id: str) -> Session:
+        return Session(session_id=session_id)
+
+    async def update_session(self, session: Session) -> None:  # pragma: no cover - interface stub
+        return None
+
+
+class _DummyHandler(ICommandHandler):
+    @property
+    def command_name(self) -> str:
+        return "mock"
+
+    @property
+    def description(self) -> str:
+        return "mock handler"
+
+    @property
+    def format(self) -> str:
+        return "mock()"
+
+    @property
+    def examples(self) -> list[str]:
+        return ["!/mock()"]
+
+    async def handle(self, command: Command, session: Session) -> CommandResult:
+        return CommandResult(success=True, message="done", name=command.name)
+
+
+@pytest.mark.asyncio
+async def test_command_result_wrapper_type_is_stable(monkeypatch: Any) -> None:
+    """Ensure the wrapper class is shared across invocations for type checks."""
+
+    service = NewCommandService(_StubSessionService(), CommandParser())
+
+    def _get_command_handler(name: str) -> type[ICommandHandler] | None:
+        return _DummyHandler if name == "mock" else None
+
+    monkeypatch.setattr(
+        "src.core.commands.service.get_command_handler", _get_command_handler
+    )
+
+    messages_one = [ChatMessage(role="user", content="!/mock()")]
+    messages_two = [ChatMessage(role="user", content="!/mock()")]
+
+    result_one = await service.process_commands(messages_one, session_id="s1")
+    result_two = await service.process_commands(messages_two, session_id="s1")
+
+    wrapper_one = result_one.command_results[0]
+    wrapper_two = result_two.command_results[0]
+
+    assert isinstance(wrapper_one, CommandResultWrapper)
+    assert type(wrapper_one) is CommandResultWrapper
+    assert type(wrapper_one) is type(wrapper_two)
+    assert wrapper_one.message == "done"
+    assert wrapper_one.name == "mock"


### PR DESCRIPTION
## Summary
- move `CommandResultWrapper` to module scope so command results keep a stable type identity
- expose the wrapped result via a property while preserving previous behaviour
- add a regression test covering repeated command execution to ensure the wrapper class is shared

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/commands/test_command_result_wrapper.py
- python -m pytest --override-ini addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68eb82ad745883339623866868b35281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Refactor
  - Standardized the command result wrapper to a single, stable type across the app, improving consistency, diagnostics, and future compatibility without altering behavior.
- Tests
  - Added unit tests to verify the stability and correctness of command result handling across multiple runs, increasing confidence in command processing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->