### PR TITLE
Fix DI backend registry scoping

### DIFF
--- a/src/core/di/container.py
+++ b/src/core/di/container.py
@@ -353,6 +353,7 @@ class ServiceCollection(IServiceCollection):
         )
         from src.core.services.backend_registry import (
             BackendRegistry,  # type: ignore[import-untyped]
+            backend_registry,
         )
         from src.core.services.backend_request_manager_service import (
             BackendRequestManager,  # type: ignore[import-untyped]
@@ -396,7 +397,11 @@ class ServiceCollection(IServiceCollection):
         self.add_singleton(
             BackendFactory, implementation_factory=_backend_factory_factory
         )
-        self.add_singleton(BackendRegistry, BackendRegistry)
+        # Use the global backend registry instance so that connector auto-
+        # registration (performed at import time) is visible to the DI
+        # container. Creating a new BackendRegistry here would yield an empty
+        # registry in scoped providers and break backend resolution.
+        self.add_instance(BackendRegistry, backend_registry)
         self.add_singleton(IUsageTrackingService, UsageTrackingService)
         self.add_singleton(ISessionService, SessionService)
         # ICommandService registered in register_core_services()


### PR DESCRIPTION
## Summary
- ensure the service collection reuses the global backend_registry instance
- avoid constructing an empty BackendRegistry so connector registrations stay visible to DI consumers

## Testing
- python -m pytest -c /tmp/pytest.ini tests/unit/core/test_di_container.py
- python -m pytest -c /tmp/pytest.ini *(fails: missing pytest_asyncio, pytest_httpx, respx)*

------
https://chatgpt.com/codex/tasks/task_e_68eb82ad745883339623866868b35281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures all available backends are consistently recognized by the app.
  * Resolves intermittent cases where backend lists appeared empty in certain scopes.
  * Improves service resolution reliability during startup and runtime.

* **Refactor**
  * Streamlined dependency wiring to use a single shared registry instance across the application.
  * Added clarifying comments to document the behavior and rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->