### PR TITLE
Prevent secure state access log from growing without bound

### DIFF
--- a/src/core/services/secure_state_service.py
+++ b/src/core/services/secure_state_service.py
@@ -8,6 +8,7 @@ only authorized operations are performed through proper interfaces.
 from __future__ import annotations
 
 import logging
+from collections import deque
 from typing import Any
 
 from src.core.interfaces.application_state_interface import IApplicationState
@@ -23,14 +24,21 @@ logger = logging.getLogger(__name__)
 class SecureStateService(ISecureStateAccess, ISecureStateModification):
     """Secure state service that enforces proper access patterns."""
 
-    def __init__(self, application_state: IApplicationState):
+    def __init__(
+        self,
+        application_state: IApplicationState,
+        *,
+        max_access_log_entries: int = 1024,
+    ) -> None:
         """Initialize with application state dependency.
 
         Args:
             application_state: The application state service to use
         """
         self._application_state = application_state
-        self._access_log: list[dict[str, Any]] = []
+        if max_access_log_entries <= 0:
+            raise ValueError("max_access_log_entries must be positive")
+        self._access_log: deque[dict[str, Any]] = deque(maxlen=max_access_log_entries)
 
     # Secure read access methods
     def get_command_prefix(self) -> str | None:
@@ -135,7 +143,7 @@ class SecureStateService(ISecureStateAccess, ISecureStateModification):
 
     def get_access_log(self) -> list[dict[str, Any]]:
         """Get the access log for auditing."""
-        return self._access_log.copy()
+        return list(self._access_log)
 
 
 class StateAccessProxy:

--- a/tests/unit/core/services/test_secure_state_service.py
+++ b/tests/unit/core/services/test_secure_state_service.py
@@ -1,6 +1,9 @@
 """Tests for secure state service utilities."""
 
-from src.core.services.secure_state_service import StateAccessProxy
+import pytest
+
+from src.core.services.application_state_service import ApplicationStateService
+from src.core.services.secure_state_service import SecureStateService, StateAccessProxy
 
 
 class _DummyState:
@@ -14,3 +17,29 @@ def test_state_access_proxy_allows_session_id_attribute() -> None:
     proxy.session_id = "abc123"
 
     assert proxy.session_id == "abc123"
+
+
+def test_secure_state_service_access_log_is_bounded() -> None:
+    """Access log should drop oldest entries to avoid unbounded growth."""
+    app_state = ApplicationStateService()
+    service = SecureStateService(app_state, max_access_log_entries=3)
+
+    for i in range(5):
+        service.update_command_prefix(f"/cmd{i}")
+
+    access_log = service.get_access_log()
+
+    assert len(access_log) == 3
+    assert [entry["data"]["prefix"] for entry in access_log] == [
+        "/cmd2",
+        "/cmd3",
+        "/cmd4",
+    ]
+
+
+def test_secure_state_service_rejects_invalid_log_size() -> None:
+    """Constructor should guard against non-positive access log sizes."""
+    app_state = ApplicationStateService()
+
+    with pytest.raises(ValueError):
+        SecureStateService(app_state, max_access_log_entries=0)


### PR DESCRIPTION
## Summary
- convert the SecureStateService access log into a bounded deque so repeated accesses do not accumulate unlimited entries in memory
- add unit tests covering the capped log behaviour and constructor validation for invalid limits

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_secure_state_service.py
- python -m pytest -o addopts='' *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68eb82fe3f9483339df6fe3846a2c270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access log is now bounded and configurable, defaulting to 1024 entries.
  * Access log returns a stable list snapshot for easier inspection.
* **Reliability**
  * Validation prevents invalid (non-positive) access log sizes, ensuring predictable behavior.
  * Replaces unbounded logging with a fixed-size buffer to reduce memory usage.
* **Tests**
  * Added unit tests to verify bounded log behavior and validation of configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->