### PR TITLE
Limit SecureStateService access log growth

### DIFF
--- a/src/core/services/secure_state_service.py
+++ b/src/core/services/secure_state_service.py
@@ -7,6 +7,7 @@ only authorized operations are performed through proper interfaces.
 
 from __future__ import annotations
 
+from collections import deque
 import logging
 from typing import Any
 
@@ -23,14 +24,29 @@ logger = logging.getLogger(__name__)
 class SecureStateService(ISecureStateAccess, ISecureStateModification):
     """Secure state service that enforces proper access patterns."""
 
-    def __init__(self, application_state: IApplicationState):
+    DEFAULT_MAX_ACCESS_LOG_ENTRIES = 1024
+
+    def __init__(
+        self,
+        application_state: IApplicationState,
+        max_access_log_entries: int | None = None,
+    ) -> None:
         """Initialize with application state dependency.
 
         Args:
             application_state: The application state service to use
+            max_access_log_entries: Maximum number of access log entries to retain
         """
+        if max_access_log_entries is None:
+            max_entries = self.DEFAULT_MAX_ACCESS_LOG_ENTRIES
+        elif max_access_log_entries <= 0:
+            raise ValueError("max_access_log_entries must be a positive integer")
+        else:
+            max_entries = max_access_log_entries
+
         self._application_state = application_state
-        self._access_log: list[dict[str, Any]] = []
+        self._access_log_max_entries = max_entries
+        self._access_log: deque[dict[str, Any]] = deque(maxlen=max_entries)
 
     # Secure read access methods
     def get_command_prefix(self) -> str | None:
@@ -135,7 +151,7 @@ class SecureStateService(ISecureStateAccess, ISecureStateModification):
 
     def get_access_log(self) -> list[dict[str, Any]]:
         """Get the access log for auditing."""
-        return self._access_log.copy()
+        return list(self._access_log)
 
 
 class StateAccessProxy:

--- a/tests/unit/core/services/test_secure_state_service.py
+++ b/tests/unit/core/services/test_secure_state_service.py
@@ -1,6 +1,11 @@
 """Tests for secure state service utilities."""
 
-from src.core.services.secure_state_service import StateAccessProxy
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.interfaces.application_state_interface import IApplicationState
+from src.core.services.secure_state_service import SecureStateService, StateAccessProxy
 
 
 class _DummyState:
@@ -14,3 +19,39 @@ def test_state_access_proxy_allows_session_id_attribute() -> None:
     proxy.session_id = "abc123"
 
     assert proxy.session_id == "abc123"
+
+
+def test_secure_state_service_limits_access_log_growth() -> None:
+    """SecureStateService should cap its access log to prevent memory leaks."""
+
+    app_state = MagicMock(spec=IApplicationState)
+    app_state.get_command_prefix.return_value = "!/"
+    app_state.get_api_key_redaction_enabled.return_value = True
+    app_state.get_disable_interactive_commands.return_value = False
+    app_state.get_failover_routes.return_value = []
+
+    service = SecureStateService(app_state, max_access_log_entries=3)
+
+    service.get_command_prefix()
+    service.get_api_key_redaction_enabled()
+    service.get_disable_interactive_commands()
+    service.get_failover_routes()
+    service.get_command_prefix()
+
+    operations = [entry["operation"] for entry in service.get_access_log()]
+
+    assert len(operations) == 3
+    assert operations == [
+        "get_disable_interactive_commands",
+        "get_failover_routes",
+        "get_command_prefix",
+    ]
+
+
+def test_secure_state_service_rejects_non_positive_access_log_limit() -> None:
+    """Constructor should reject zero or negative log limits to avoid silent issues."""
+
+    app_state = MagicMock(spec=IApplicationState)
+
+    with pytest.raises(ValueError):
+        SecureStateService(app_state, max_access_log_entries=0)


### PR DESCRIPTION
## Summary
- cap the SecureStateService audit log with a bounded deque to prevent unbounded memory growth
- allow configuring the maximum log size and validate against invalid values
- add unit tests covering the capped log behaviour and validation errors

## Testing
- python -m pytest -c /tmp/pytest_custom.ini tests/unit/core/services/test_secure_state_service.py
- python -m pytest -c /tmp/pytest_custom.ini *(fails: missing optional dev dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68eb82fe3f9483339df6fe3846a2c270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access log size is now configurable with a maximum entries setting; defaults to 1024.
  * Access log automatically trims the oldest entries when the limit is reached, keeping only the most recent activity.
  * Invalid non-positive limits are rejected with a clear error.
* **Tests**
  * Added tests to verify log size capping behavior and validation of the maximum entries setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->