### PR TITLE
Guard structured wire capture redaction against deep nesting attacks

### DIFF
--- a/src/core/services/structured_wire_capture_service.py
+++ b/src/core/services/structured_wire_capture_service.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from src.core.common.logging_utils import discover_api_keys_from_config_and_env
 from src.core.common.structlog_config import get_logger
@@ -19,6 +19,9 @@ from src.core.interfaces.wire_capture_interface import IWireCapture
 from src.core.services.redaction_middleware import APIKeyRedactor
 
 logger = get_logger(__name__)
+
+MAX_REDACTION_DEPTH = 100
+REDACTION_DEPTH_PLACEHOLDER = "(redaction-depth-exceeded)"
 
 
 class StructuredWireCapture(IWireCapture):
@@ -261,15 +264,11 @@ class StructuredWireCapture(IWireCapture):
         return entry.model_dump()
 
     def _redact_payload(self, payload: Any) -> Any:
-        """Recursively redact sensitive information from payload."""
-        if isinstance(payload, dict):
-            return {k: self._redact_payload(v) for k, v in payload.items()}
-        elif isinstance(payload, list):
-            return [self._redact_payload(item) for item in payload]
-        elif isinstance(payload, str):
-            return self._redactor.redact(payload)
-        else:
-            return payload
+        """Redact sensitive information while guarding against malicious nesting."""
+
+        return _redact_payload_with_depth_limit(
+            payload, redact_str=self._redactor.redact
+        )
 
     def _extract_system_prompt(self, payload: Any) -> str | None:
         """Extract system prompt from payload if present."""
@@ -448,3 +447,48 @@ def _safe_json_dump(obj: Any) -> str:
                 exc_info=True,
             )
             return str(obj)
+
+
+def _redact_payload_with_depth_limit(
+    value: Any,
+    *,
+    redact_str: Callable[[str], str],
+    depth: int = 0,
+) -> Any:
+    """Redact nested payloads without exceeding Python's recursion limit."""
+
+    if depth >= MAX_REDACTION_DEPTH:
+        logger.warning(
+            "Maximum payload redaction depth (%d) exceeded; truncating nested structure",
+            MAX_REDACTION_DEPTH,
+        )
+        return REDACTION_DEPTH_PLACEHOLDER
+
+    if isinstance(value, dict):
+        return {
+            key: _redact_payload_with_depth_limit(
+                item, redact_str=redact_str, depth=depth + 1
+            )
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            _redact_payload_with_depth_limit(
+                item, redact_str=redact_str, depth=depth + 1
+            )
+            for item in value
+        ]
+
+    if isinstance(value, tuple):
+        return tuple(
+            _redact_payload_with_depth_limit(
+                item, redact_str=redact_str, depth=depth + 1
+            )
+            for item in value
+        )
+
+    if isinstance(value, str):
+        return redact_str(value)
+
+    return value

--- a/tests/unit/core/services/test_structured_wire_capture.py
+++ b/tests/unit/core/services/test_structured_wire_capture.py
@@ -1,12 +1,17 @@
 import json
 import os
 import tempfile
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from src.core.config.app_config import AppConfig
 from src.core.domain.request_context import RequestContext
-from src.core.services.structured_wire_capture_service import StructuredWireCapture
+from src.core.services.structured_wire_capture_service import (
+    MAX_REDACTION_DEPTH,
+    REDACTION_DEPTH_PLACEHOLDER,
+    StructuredWireCapture,
+)
 
 
 @pytest.fixture
@@ -350,3 +355,26 @@ def test_extract_system_prompt(structured_wire_capture):
     # No system prompt
     no_system_payload = {"messages": [{"role": "user", "content": "Hello"}]}
     assert structured_wire_capture._extract_system_prompt(no_system_payload) is None
+
+
+def test_redact_payload_handles_deeply_nested_payload(structured_wire_capture):
+    """Ensure deep nesting cannot trigger a RecursionError during redaction."""
+
+    payload: dict[str, Any] = {}
+    current: dict[str, Any] = payload
+    for _ in range(MAX_REDACTION_DEPTH + 1024):
+        next_level: dict[str, Any] = {}
+        current["nest"] = next_level
+        current = next_level
+
+    redacted = structured_wire_capture._redact_payload(payload)
+
+    depth = 0
+    current_level = redacted
+    while isinstance(current_level, dict):
+        assert "nest" in current_level
+        current_level = current_level["nest"]
+        depth += 1
+        assert depth <= MAX_REDACTION_DEPTH
+
+    assert current_level == REDACTION_DEPTH_PLACEHOLDER


### PR DESCRIPTION
## Summary
- add a maximum recursion depth guard for structured wire capture payload redaction to prevent maliciously deep payloads from crashing the proxy
- return a clear placeholder when the limit is exceeded and log the truncation for observability
- add a regression test that builds an extremely deep payload and asserts the redaction guard engages

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/core/services/test_structured_wire_capture.py::test_redact_payload_handles_deeply_nested_payload
- python -m pytest --override-ini=addopts="" *(fails: missing pytest_asyncio/respx/pytest_httpx dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb82da181c8333a853d0793aaebcdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redaction now safely handles deeply nested data by limiting depth, preventing failures or timeouts and substituting a placeholder beyond the limit.
* **Refactor**
  * Simplified redaction flow for more predictable and consistent handling of complex payloads.
* **Tests**
  * Added unit tests covering redaction of deeply nested payloads to ensure depth limits and placeholder behavior work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->