### PR TITLE
Improve session service DI test coverage

### DIFF
--- a/tests/unit/test_session_manager_di.py
+++ b/tests/unit/test_session_manager_di.py
@@ -26,12 +26,14 @@ def session_service(app: FastAPI) -> ISessionService:
     return get_required_service_from_app(app, ISessionService)
 
 
-def test_session_service_can_create_sessions(app: FastAPI) -> None:
-    """Test that session service can create and manage sessions."""
+@pytest.mark.asyncio
+async def test_session_service_can_create_sessions(app: FastAPI) -> None:
+    """Test that session service retrieved via DI can create sessions."""
     service = get_required_service_from_app(app, ISessionService)
 
-    # This is a basic test to verify the service works
-    assert service is not None
+    session = await service.get_or_create_session("di-session")
+
+    assert session.session_id == "di-session"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update the session service DI smoke test to exercise real session creation instead of just checking for a non-null service

## Testing
- pytest tests/unit/test_session_manager_di.py::test_session_service_can_create_sessions -q (fails: pytest configuration references xdist options unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec249a02248333a1d8a31e6c868e41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Converted a related test to run asynchronously, aligning with the asynchronous behavior of the session flow.
  * Replaced a placeholder assertion with a real validation that exercises the async operation and verifies the resulting identifier.
  * Improves test reliability and coverage for session creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->