### PR TITLE
Improve top_p regression test coverage

### DIFF
--- a/tests/test_top_p_fix.py
+++ b/tests/test_top_p_fix.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from src.core.domain.chat import ChatMessage, ChatRequest
 from src.core.domain.responses import ResponseEnvelope
+from src.core.services.backend_request_manager_service import BackendRequestManager
 from src.core.services.request_processor_service import RequestProcessor
 
 
@@ -16,7 +17,14 @@ async def test_top_p_fix_with_actual_request() -> None:
 
     mock_command_processor = MagicMock(spec=ICommandProcessor)
     mock_session_manager = AsyncMock()
-    mock_backend_request_manager = AsyncMock()
+    mock_backend_processor = MagicMock()
+    mock_backend_processor.process_backend_request = AsyncMock()
+    mock_response_processor = AsyncMock()
+    mock_response_processor.process_response = AsyncMock()
+    backend_request_manager = BackendRequestManager(
+        backend_processor=mock_backend_processor,
+        response_processor=mock_response_processor,
+    )
     mock_response_manager = AsyncMock()
 
     # Configure session manager to return a real session object
@@ -37,17 +45,18 @@ async def test_top_p_fix_with_actual_request() -> None:
     )
 
     # Configure mock_backend_request_manager to capture the request it receives
-    captured_request = None
+    captured_request: ChatRequest | None = None
 
     async def capture_request(*args: Any, **kwargs: Any) -> ResponseEnvelope:
         nonlocal captured_request
-        captured_request = args[0] if args else kwargs.get("request")
-        # Return a dummy response envelope
+        captured_request = kwargs.get("request")
+        if captured_request is None and args:
+            captured_request = args[0]
         return ResponseEnvelope(
-            content={}, headers={}, status_code=200, media_type="application/json"
+            content=None, headers={}, status_code=200, media_type="application/json"
         )
 
-    mock_backend_request_manager.process_backend_request.side_effect = capture_request
+    mock_backend_processor.process_backend_request.side_effect = capture_request
 
     # This is a request that would have triggered the original error
     # It includes top_p which would have been added to extra_body before our fix
@@ -58,14 +67,10 @@ async def test_top_p_fix_with_actual_request() -> None:
         messages=[ChatMessage(role="user", content="Hello")],
     )
 
-    mock_backend_request_manager.prepare_backend_request.return_value = (
-        request_data  # Return the original request
-    )
-
     processor = RequestProcessor(
         mock_command_processor,
         mock_session_manager,
-        mock_backend_request_manager,
+        backend_request_manager,
         mock_response_manager,
     )
 


### PR DESCRIPTION
## Summary
- update the `top_p` regression test to exercise the real backend request manager instead of a stub
- capture the backend request via the mocked processor to verify that `top_p` never leaks into the extra body

## Testing
- python -m pytest tests/test_top_p_fix.py --override-ini addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68ec249a02248333a1d8a31e6c868e41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined test setup to use dedicated processors for backend and response handling.
  * Improved request capture logic and typing to validate fields accurately.
  * Updated assertions to confirm top_p is included in the main request and excluded from extra payload.
  * Simplified mocks by removing unnecessary configurations.
  * Ensured existing validations for model and max_tokens remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->