### PR TITLE
Ensure Anthropic fallback request processor keeps app state

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -543,6 +543,7 @@ def get_anthropic_controller(service_provider: IServiceProvider) -> AnthropicCon
                     session_manager,
                     backend_request_manager,
                     response_manager,
+                    app_state=app_state,
                 )
 
                 # Register it for future use

--- a/tests/unit/anthropic_frontend_tests/test_anthropic_controller_di_fallback.py
+++ b/tests/unit/anthropic_frontend_tests/test_anthropic_controller_di_fallback.py
@@ -1,0 +1,191 @@
+"""Tests covering DI fallback behavior for the Anthropic controller."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from src.core.app.controllers.anthropic_controller import (
+    AnthropicController,
+    get_anthropic_controller,
+)
+from src.core.config.app_config import AppConfig
+from src.core.di.container import ServiceCollection
+from src.core.interfaces.application_state_interface import IApplicationState
+from src.core.interfaces.backend_service_interface import IBackendService
+from src.core.interfaces.command_service_interface import ICommandService
+from src.core.interfaces.request_processor_interface import IRequestProcessor
+from src.core.interfaces.response_processor_interface import (
+    IResponseProcessor,
+    ProcessedResponse,
+)
+from src.core.interfaces.session_resolver_interface import ISessionResolver
+from src.core.interfaces.session_service_interface import ISessionService
+from src.core.interfaces.wire_capture_interface import IWireCapture
+from src.core.services.application_state_service import ApplicationStateService
+from src.core.services.response_manager_service import AgentResponseFormatter
+from src.core.services.session_resolver_service import DefaultSessionResolver
+from src.core.services.session_service_impl import SessionService
+from src.core.domain.processed_result import ProcessedResult
+from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
+from src.core.domain.chat import ChatRequest
+from src.core.domain.request_context import RequestContext
+from src.core.repositories.in_memory_session_repository import InMemorySessionRepository
+
+
+class _StubCommandService(ICommandService):
+    async def process_commands(
+        self, messages: list[Any], session_id: str
+    ) -> ProcessedResult:
+        return ProcessedResult(
+            modified_messages=messages,
+            command_executed=False,
+            command_results=[],
+        )
+
+
+class _StubBackendService(IBackendService):
+    async def call_completion(
+        self,
+        request: ChatRequest,
+        stream: bool = False,
+        allow_failover: bool = True,
+        context: RequestContext | None = None,
+    ) -> ResponseEnvelope | StreamingResponseEnvelope:
+        if stream:
+            async def _stream() -> AsyncIterator[StreamingResponseEnvelope]:
+                yield StreamingResponseEnvelope(content={}, headers={}, status_code=200)
+
+            return _stream()
+
+        return ResponseEnvelope(content={}, headers={}, status_code=200)
+
+    async def validate_backend_and_model(
+        self, backend: str, model: str
+    ) -> tuple[bool, str | None]:
+        return True, None
+
+
+class _StubResponseProcessor(IResponseProcessor):
+    async def process_response(
+        self,
+        response: Any,
+        session_id: str,
+        context: dict[str, Any] | None = None,
+    ) -> ProcessedResponse:
+        return ProcessedResponse(content=response)
+
+    def process_streaming_response(
+        self, response_iterator: AsyncIterator[Any], session_id: str
+    ) -> AsyncIterator[ProcessedResponse]:
+        async def _generator() -> AsyncIterator[ProcessedResponse]:
+            async for chunk in response_iterator:
+                yield ProcessedResponse(content=chunk)
+
+        return _generator()
+
+    async def register_middleware(
+        self, middleware: Any, priority: int = 0
+    ) -> None:
+        return None
+
+
+class _StubWireCapture(IWireCapture):
+    def enabled(self) -> bool:
+        return False
+
+    async def capture_outbound_request(
+        self,
+        *,
+        context: RequestContext | None,
+        session_id: str | None,
+        backend: str,
+        model: str,
+        key_name: str | None,
+        request_payload: Any,
+    ) -> None:
+        return None
+
+    async def capture_inbound_response(
+        self,
+        *,
+        context: RequestContext | None,
+        session_id: str | None,
+        backend: str,
+        model: str,
+        key_name: str | None,
+        response_content: Any,
+    ) -> None:
+        return None
+
+    def wrap_inbound_stream(
+        self,
+        *,
+        context: RequestContext | None,
+        session_id: str | None,
+        backend: str,
+        model: str,
+        key_name: str | None,
+        stream: AsyncIterator[bytes],
+    ) -> AsyncIterator[bytes]:
+        return stream
+
+    async def shutdown(self) -> None:
+        return None
+
+
+def _build_service_provider_without_request_processor():
+    """Create a service provider missing IRequestProcessor to trigger fallback."""
+    services = ServiceCollection()
+
+    app_config = AppConfig()
+    services.add_instance(AppConfig, app_config)
+
+    command_service = _StubCommandService()
+    services.add_instance(_StubCommandService, command_service)
+    services.add_instance(ICommandService, command_service)
+
+    backend_service = _StubBackendService()
+    services.add_instance(_StubBackendService, backend_service)
+    services.add_instance(IBackendService, backend_service)
+
+    session_service = SessionService(InMemorySessionRepository())
+    services.add_instance(SessionService, session_service)
+    services.add_instance(ISessionService, session_service)
+
+    response_processor = _StubResponseProcessor()
+    services.add_instance(_StubResponseProcessor, response_processor)
+    services.add_instance(IResponseProcessor, response_processor)
+
+    app_state = ApplicationStateService()
+    services.add_instance(ApplicationStateService, app_state)
+    services.add_instance(IApplicationState, app_state)
+
+    session_resolver = DefaultSessionResolver(app_config)
+    services.add_instance(DefaultSessionResolver, session_resolver)
+    services.add_instance(ISessionResolver, session_resolver)
+
+    agent_formatter = AgentResponseFormatter(session_service=session_service)
+    services.add_instance(AgentResponseFormatter, agent_formatter)
+
+    # Provide a wire capture implementation to satisfy downstream dependencies.
+    wire_capture = _StubWireCapture()
+    services.add_instance(_StubWireCapture, wire_capture)
+    services.add_instance(IWireCapture, wire_capture)
+
+    return services.build_service_provider()
+
+
+def test_fallback_request_processor_receives_app_state():
+    """Ensure fallback construction does not drop required DI-managed state."""
+    provider = _build_service_provider_without_request_processor()
+
+    # Sanity check: DI resolution path is indeed missing the request processor.
+    assert provider.get_service(IRequestProcessor) is None
+
+    controller = get_anthropic_controller(provider)
+    assert isinstance(controller, AnthropicController)
+
+    app_state = provider.get_required_service(ApplicationStateService)
+    # The fallback-constructed request processor must receive application state.
+    assert controller._processor._app_state is app_state


### PR DESCRIPTION
## Summary
- ensure the Anthropic controller's manual RequestProcessor fallback wires through the application state dependency
- add a regression test covering the fallback path to verify the request processor retains the DI-provided application state

## Testing
- python -m pytest -o addopts='' tests/unit/anthropic_frontend_tests/test_anthropic_controller_di_fallback.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68ec24c75d088333bc0d3e5950ad0e4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved request processing by integrating application state, enhancing consistency and reliability across controller operations. No user-facing changes.
- Tests
  - Added unit tests to verify fallback behavior and correct state propagation in the controller when certain services are not explicitly registered, strengthening overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->