### PR TITLE
Ensure fallback request managers reuse DI wire capture

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -533,8 +533,39 @@ def get_anthropic_controller(service_provider: IServiceProvider) -> AnthropicCon
                     agent_response_formatter = AgentResponseFormatter()
 
                 session_manager = SessionManager(session, session_resolver)
+                wire_capture = None
+                try:
+                    from src.core.interfaces.wire_capture_interface import (
+                        IWireCapture as _IWireCapture,
+                    )
+
+                    wire_capture = service_provider.get_service(
+                        cast(type, _IWireCapture)
+                    )
+                except Exception:
+                    wire_capture = None
+
+                if wire_capture is None:
+                    try:
+                        from src.core.di.services import get_service_provider
+
+                        global_provider = get_service_provider()
+                    except Exception:
+                        global_provider = None
+                    else:
+                        if (
+                            global_provider is not None
+                            and global_provider is not service_provider
+                        ):
+                            try:
+                                wire_capture = global_provider.get_service(
+                                    cast(type, _IWireCapture)
+                                )
+                            except Exception:
+                                wire_capture = None
+
                 backend_request_manager = BackendRequestManager(
-                    backend_processor, response_proc
+                    backend_processor, response_proc, wire_capture
                 )
                 response_manager = ResponseManager(agent_response_formatter)
 

--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -795,8 +795,39 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
                         agent_response_formatter = AgentResponseFormatter()
 
                     session_manager = SessionManager(concrete_session, session_resolver)
+                    wire_capture = None
+                    try:
+                        from src.core.interfaces.wire_capture_interface import (
+                            IWireCapture as _IWireCapture,
+                        )
+
+                        wire_capture = service_provider.get_service(
+                            cast(type, _IWireCapture)
+                        )
+                    except Exception:
+                        wire_capture = None
+
+                    if wire_capture is None:
+                        try:
+                            from src.core.di.services import get_service_provider
+
+                            global_provider = get_service_provider()
+                        except Exception:
+                            global_provider = None
+                        else:
+                            if (
+                                global_provider is not None
+                                and global_provider is not service_provider
+                            ):
+                                try:
+                                    wire_capture = global_provider.get_service(
+                                        cast(type, _IWireCapture)
+                                    )
+                                except Exception:
+                                    wire_capture = None
+
                     backend_request_manager = BackendRequestManager(
-                        backend_processor, concrete_response_proc
+                        backend_processor, concrete_response_proc, wire_capture
                     )
                     response_manager = ResponseManager(agent_response_formatter)
 


### PR DESCRIPTION
## Summary
- ensure the Anthropic and chat controller fallbacks re-use the wire capture service from the DI container when constructing backend request managers manually
- preserve proxy-wide request capture when controllers self-heal missing backend request manager registrations

## Testing
- `python -m pytest -o addopts="" tests/integration/test_direct_controllers.py -k chat` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68ec24c75d088333bc0d3e5950ad0e4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional capture integration for backend requests in AI and chat flows; automatically used when available with no user action required.
- Refactor
  - Updated request handling to accept an optional capture service and gracefully proceed when it’s unavailable.
- Chores
  - Adjusted initialization paths to support the optional service across relevant controllers and request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->