### PR TITLE
Fix backend request manager DI resolution

### DIFF
--- a/src/core/app/controllers/anthropic_controller.py
+++ b/src/core/app/controllers/anthropic_controller.py
@@ -7,7 +7,7 @@ Handles Anthropic API endpoints.
 import json
 import logging
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, cast
 
 from fastapi import HTTPException, Request, Response
 
@@ -533,9 +533,32 @@ def get_anthropic_controller(service_provider: IServiceProvider) -> AnthropicCon
                     agent_response_formatter = AgentResponseFormatter()
 
                 session_manager = SessionManager(session, session_resolver)
-                backend_request_manager = BackendRequestManager(
-                    backend_processor, response_proc
+                backend_request_manager_service = service_provider.get_service(
+                    cast(type, IBackendRequestManager)
                 )
+                if backend_request_manager_service is None:
+                    backend_request_manager_service = service_provider.get_service(
+                        BackendRequestManager
+                    )
+                if backend_request_manager_service is None:
+                    from src.core.interfaces.wire_capture_interface import IWireCapture
+
+                    wire_capture = service_provider.get_service(
+                        cast(type, IWireCapture)
+                    )
+                    backend_request_manager_service = BackendRequestManager(
+                        backend_processor,
+                        response_proc,
+                        wire_capture,
+                    )
+
+                backend_request_manager = cast(
+                    IBackendRequestManager, backend_request_manager_service
+                )
+                if backend_request_manager is None:
+                    raise InitializationError(
+                        "Could not resolve BackendRequestManager"
+                    )
                 response_manager = ResponseManager(agent_response_formatter)
 
                 request_processor = RequestProcessor(

--- a/src/core/app/controllers/chat_controller.py
+++ b/src/core/app/controllers/chat_controller.py
@@ -795,9 +795,34 @@ def get_chat_controller(service_provider: IServiceProvider) -> ChatController:
                         agent_response_formatter = AgentResponseFormatter()
 
                     session_manager = SessionManager(concrete_session, session_resolver)
-                    backend_request_manager = BackendRequestManager(
-                        backend_processor, concrete_response_proc
+                    backend_request_manager_service = service_provider.get_service(
+                        cast(type, IBackendRequestManager)
                     )
+                    if backend_request_manager_service is None:
+                        backend_request_manager_service = service_provider.get_service(
+                            BackendRequestManager
+                        )
+                    if backend_request_manager_service is None:
+                        from src.core.interfaces.wire_capture_interface import (
+                            IWireCapture,
+                        )
+
+                        wire_capture = service_provider.get_service(
+                            cast(type, IWireCapture)
+                        )
+                        backend_request_manager_service = BackendRequestManager(
+                            backend_processor,
+                            concrete_response_proc,
+                            wire_capture,
+                        )
+
+                    backend_request_manager = cast(
+                        IBackendRequestManager, backend_request_manager_service
+                    )
+                    if backend_request_manager is None:
+                        raise InitializationError(
+                            "Could not resolve BackendRequestManager"
+                        )
                     response_manager = ResponseManager(agent_response_formatter)
 
                     request_processor = RequestProcessor(

--- a/tests/unit/core/app/controllers/test_chat_controller_backend_request_manager.py
+++ b/tests/unit/core/app/controllers/test_chat_controller_backend_request_manager.py
@@ -1,0 +1,171 @@
+"""Tests for ChatController DI integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.core.app.controllers.chat_controller import ChatController, get_chat_controller
+from src.core.common.exceptions import ServiceResolutionError
+from src.core.interfaces.agent_response_formatter_interface import (
+    IAgentResponseFormatter,
+)
+from src.core.interfaces.application_state_interface import IApplicationState
+from src.core.interfaces.backend_processor_interface import IBackendProcessor
+from src.core.interfaces.backend_service_interface import IBackendService
+from src.core.interfaces.command_processor_interface import ICommandProcessor
+from src.core.interfaces.command_service_interface import ICommandService
+from src.core.interfaces.di_interface import IServiceProvider, IServiceScope
+from src.core.interfaces.response_processor_interface import IResponseProcessor
+from src.core.interfaces.session_resolver_interface import ISessionResolver
+from src.core.interfaces.session_service_interface import ISessionService
+from src.core.interfaces.translation_service_interface import ITranslationService
+from src.core.interfaces.wire_capture_interface import IWireCapture
+
+
+class _FakeScope(IServiceScope):
+    """Simple test scope implementation."""
+
+    def __init__(self, provider: IServiceProvider) -> None:
+        self._provider = provider
+
+    @property
+    def service_provider(self) -> IServiceProvider:
+        return self._provider
+
+    async def dispose(self) -> None:  # pragma: no cover - unused in test
+        return None
+
+
+class _FakeProvider(IServiceProvider):
+    """Minimal service provider for exercising controller wiring."""
+
+    def __init__(self, services: dict[type[Any], Any]) -> None:
+        self._services = services
+
+    def get_service(self, service_type: type[Any]) -> Any | None:
+        return self._services.get(service_type)
+
+    def get_required_service(self, service_type: type[Any]) -> Any:
+        service = self.get_service(service_type)
+        if service is None:
+            type_name = getattr(service_type, "__name__", repr(service_type))
+            raise ServiceResolutionError(
+                f"Missing required service: {type_name}", service_name=type_name
+            )
+        return service
+
+    def create_scope(self) -> IServiceScope:  # pragma: no cover - unused in test
+        return _FakeScope(self)
+
+
+class _DummySessionManager:
+    def __init__(self, session_service: Any, session_resolver: Any) -> None:
+        self.session_service = session_service
+        self.session_resolver = session_resolver
+
+
+class _DummyBackendRequestManager:
+    def __init__(
+        self,
+        backend_processor: Any,
+        response_processor: Any,
+        wire_capture: Any | None = None,
+    ) -> None:
+        self.backend_processor = backend_processor
+        self.response_processor = response_processor
+        self.wire_capture = wire_capture
+
+
+class _DummyResponseManager:
+    def __init__(self, agent_response_formatter: Any) -> None:
+        self.agent_response_formatter = agent_response_formatter
+
+
+class _DummyRequestProcessor:
+    def __init__(
+        self,
+        command_processor: Any,
+        session_manager: Any,
+        backend_request_manager: Any,
+        response_manager: Any,
+        app_state: Any | None = None,
+    ) -> None:
+        self.command_processor = command_processor
+        self.session_manager = session_manager
+        self.backend_request_manager = backend_request_manager
+        self.response_manager = response_manager
+        self.app_state = app_state
+
+    async def process_request(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - unused
+        raise AssertionError("process_request should not be called in this test")
+
+
+def test_get_chat_controller_uses_wire_capture_when_constructing_backend_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure fallback construction uses DI-provided wire capture instances."""
+
+    from src.core.services import backend_request_manager_service
+    from src.core.services import request_processor_service
+    from src.core.services import response_manager_service
+    from src.core.services import session_manager_service
+
+    monkeypatch.setattr(
+        session_manager_service,
+        "SessionManager",
+        _DummySessionManager,
+    )
+    monkeypatch.setattr(
+        backend_request_manager_service,
+        "BackendRequestManager",
+        _DummyBackendRequestManager,
+    )
+    monkeypatch.setattr(
+        response_manager_service,
+        "ResponseManager",
+        _DummyResponseManager,
+    )
+    monkeypatch.setattr(
+        request_processor_service,
+        "RequestProcessor",
+        _DummyRequestProcessor,
+    )
+
+    sentinel_wire_capture = object()
+    sentinel_command_service = object()
+    sentinel_backend_service = object()
+    sentinel_session_service = object()
+    sentinel_response_processor = object()
+    sentinel_command_processor = object()
+    sentinel_backend_processor = object()
+    sentinel_application_state = object()
+    sentinel_session_resolver = object()
+    sentinel_formatter = object()
+    sentinel_translation_service = object()
+
+    provider = _FakeProvider(
+        {
+            ICommandService: sentinel_command_service,
+            IBackendService: sentinel_backend_service,
+            ISessionService: sentinel_session_service,
+            IResponseProcessor: sentinel_response_processor,
+            ICommandProcessor: sentinel_command_processor,
+            IBackendProcessor: sentinel_backend_processor,
+            IApplicationState: sentinel_application_state,
+            ISessionResolver: sentinel_session_resolver,
+            IAgentResponseFormatter: sentinel_formatter,
+            ITranslationService: sentinel_translation_service,
+            IWireCapture: sentinel_wire_capture,
+        }
+    )
+
+    controller = get_chat_controller(provider)
+
+    assert isinstance(controller, ChatController)
+    processor = controller._processor
+    assert isinstance(processor, _DummyRequestProcessor)
+    backend_manager = processor.backend_request_manager
+    assert isinstance(backend_manager, _DummyBackendRequestManager)
+    assert backend_manager.wire_capture is sentinel_wire_capture


### PR DESCRIPTION
## Summary
- update the chat and Anthropic controllers to resolve `BackendRequestManager` through the DI container, falling back to manual construction that includes the wire capture dependency when needed
- add a focused unit test to ensure the Chat controller fallback path still wires the DI-provided wire capture into the backend request manager

## Testing
- python -m pytest -o addopts="" tests/unit/core/app/controllers/test_chat_controller_backend_request_manager.py
- python -m pytest -o addopts="" *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68ec24c75d088333bc0d3e5950ad0e4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional diagnostics capture integrated into backend request handling.
- Bug Fixes
  - More robust startup with clear initialization errors when required services are unavailable.
- Refactor
  - Migrated controllers to dependency-injected resolution for backend request management with runtime fallbacks.
- Tests
  - Added unit tests to validate controller wiring and dependency injection paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->