### PR TITLE
Ensure CLI creates log directory when custom path provided

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -13,6 +13,8 @@ import sys
 from collections.abc import Callable, Sequence
 from typing import Any, cast
 
+from pathlib import Path
+
 import uvicorn
 from fastapi import FastAPI
 
@@ -574,17 +576,16 @@ def apply_cli_args(
     # Logging configuration
     logging_overrides: dict[str, Any] = {}
     if args.log_file is not None:
-        logging_overrides["log_file"] = args.log_file
-        record_cli("logging.log_file", args.log_file, "--log")
+        log_path = Path(args.log_file).expanduser()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        logging_overrides["log_file"] = str(log_path)
+        record_cli("logging.log_file", str(log_path), "--log")
     elif cfg.logging.log_file is None:
         # Set default log file only if none specified in config or CLI
-        from pathlib import Path
-
-        default_log_file = "logs/proxy.log"
+        default_log_file = Path("logs/proxy.log")
         # Ensure logs directory exists
-        log_dir = Path(default_log_file).parent
-        log_dir.mkdir(exist_ok=True)
-        logging_overrides["log_file"] = default_log_file
+        default_log_file.parent.mkdir(parents=True, exist_ok=True)
+        logging_overrides["log_file"] = str(default_log_file)
     if args.log_level is not None:
         logging_overrides["level"] = LogLevel[args.log_level]
         record_cli("logging.level", LogLevel[args.log_level].value, "--log-level")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import socket
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -355,6 +356,20 @@ def test_cli_capture_limits_arguments() -> None:
         assert config.logging.capture_max_bytes == 1024
         assert config.logging.capture_truncate_bytes == 256
         assert config.logging.capture_max_files == 3
+
+
+def test_cli_creates_log_directory_for_custom_path(tmp_path: Path) -> None:
+    """CLI should create parent directories for user-specified log files."""
+
+    from src.core.cli import apply_cli_args, parse_cli_args
+
+    custom_log = tmp_path / "nested" / "proxy.log"
+
+    with patch("src.core.cli.load_config", return_value=AppConfig()):
+        args = parse_cli_args(["--log", str(custom_log)])
+        apply_cli_args(args)
+
+    assert custom_log.parent.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- ensure the CLI creates parent directories before configuring a user-specified log file
- add a regression test that verifies custom log paths are prepared automatically

## Testing
- python -m pytest -o addopts= tests/unit/test_cli.py::test_cli_creates_log_directory_for_custom_path
- python -m pytest -o addopts= tests/unit/test_cli.py
- python -m pytest -o addopts= *(fails: missing pytest_asyncio, respx, pytest_httpx, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2547146883338083fba3562a6ad3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log file handling now expands user home paths and creates parent directories for custom log locations to prevent errors.
  * Default log location is created automatically on first run.
  * Logging configuration consistently stores the log path as a string for reliability.

* **Tests**
  * Added a unit test to verify directory creation for a user-specified log path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->