### PR TITLE
Fix CLI planning phase overrides merging

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -933,7 +933,8 @@ def apply_cli_args(
     if getattr(args, "planning_phase_thinking_budget", None) is not None:
         overrides_updates["thinking_budget"] = args.planning_phase_thinking_budget
     if overrides_updates:
-        planning_phase_overrides["overrides"] = overrides_updates
+        existing_overrides = planning_phase_overrides.setdefault("overrides", {})
+        existing_overrides.update(overrides_updates)
         flag_mapping = {
             "temperature": "--planning-phase-temperature",
             "top_p": "--planning-phase-top-p",

--- a/tests/unit/test_cli_di.py
+++ b/tests/unit/test_cli_di.py
@@ -155,6 +155,28 @@ def test_cli_normalizes_backend_api_keys(monkeypatch: pytest.MonkeyPatch) -> Non
     assert cfg.backends.zai.api_key == ["zai-key"]
 
 
+def test_cli_planning_phase_overrides_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("THINKING_BUDGET", raising=False)
+    args = parse_cli_args(
+        [
+            "--thinking-budget",
+            "321",
+            "--planning-phase-temperature",
+            "0.42",
+        ]
+    )
+
+    cfg = apply_cli_args(args)
+    if isinstance(cfg, tuple):
+        cfg = cfg[0]
+
+    overrides = cfg.session.planning_phase.overrides
+    assert overrides.get("thinking_budget") == 321
+    assert overrides.get("temperature") == 0.42
+
+
 def test_cli_disable_interactive_commands(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DISABLE_INTERACTIVE_COMMANDS", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- keep CLI planning-phase overrides from overwriting existing values when multiple flags are used
- add a regression test covering simultaneous thinking-budget and planning-phase overrides

## Testing
- pytest -o addopts="" tests/unit/test_cli_di.py::test_cli_planning_phase_overrides_merge
- pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68ec2547146883338083fba3562a6ad3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI planning-phase override flags now merge across multiple inputs, allowing combined settings without overwriting earlier ones (e.g., thinking budget and temperature can be specified together).

* **Tests**
  * Added unit tests to verify that multiple planning-phase overrides from the CLI are merged correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->