### PR TITLE
Fix CLI default command prefix handling

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -1025,7 +1025,7 @@ def apply_cli_args(
         cfg = AppConfig.model_validate(config_dict)
 
     # Validate and apply configurations
-    _validate_and_apply_prefix(cfg)
+    cfg = _validate_and_apply_prefix(cfg)
     _apply_feature_flags(cfg)
     cfg = _apply_security_flags(cfg)
     if return_resolution:
@@ -1033,16 +1033,16 @@ def apply_cli_args(
     return cfg
 
 
-def _validate_and_apply_prefix(cfg: AppConfig) -> None:
-    """Validate and apply command prefix configuration."""
+def _validate_and_apply_prefix(cfg: AppConfig) -> AppConfig:
+    """Validate command prefix configuration and apply defaults safely."""
     if cfg.command_prefix is None:
-        cfg.command_prefix = DEFAULT_COMMAND_PREFIX
-        return
+        return cfg.model_copy(update={"command_prefix": DEFAULT_COMMAND_PREFIX})
 
     prefix = str(cfg.command_prefix)
     err = validate_command_prefix(prefix)
     if err:
         raise ValueError(f"Invalid command prefix: {err}")
+    return cfg
 
 
 def _apply_feature_flags(cfg: AppConfig) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,7 @@ import socket
 from unittest.mock import patch
 
 import pytest
+from src.constants import DEFAULT_COMMAND_PREFIX
 from src.core.cli import _maybe_run_as_daemon, apply_cli_args, parse_cli_args
 from src.core.config.app_config import AppConfig, ParameterResolution
 
@@ -38,6 +39,18 @@ def _unwrap_config(
     result: AppConfig | tuple[AppConfig, ParameterResolution],
 ) -> AppConfig:
     return result[0] if isinstance(result, tuple) else result
+
+
+def test_cli_restores_default_prefix_when_missing() -> None:
+    """CLI should restore the default prefix when configuration omits it."""
+
+    broken_config = AppConfig().model_copy(update={"command_prefix": None})
+
+    with patch("src.core.cli.load_config", return_value=broken_config):
+        args = parse_cli_args([])
+        config = _unwrap_config(apply_cli_args(args))
+
+    assert config.command_prefix == DEFAULT_COMMAND_PREFIX
 
 
 def test_cli_allows_all_registered_backends() -> None:


### PR DESCRIPTION
## Summary
- return a new AppConfig when CLI needs to restore the default command prefix
- update apply_cli_args to use the safe helper and add a regression test for missing prefixes

## Testing
- python -m pytest tests/unit/test_cli.py::test_cli_restores_default_prefix_when_missing *(fails: requires pytest-xdist to handle default -n option in pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2547146883338083fba3562a6ad3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now automatically restores the default command prefix when it’s missing from the configuration, ensuring commands work reliably even with incomplete settings.
* **Tests**
  * Added a unit test to verify the default command prefix is correctly restored when absent in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->