### PR TITLE
Respect content rewriting config path from AppConfig

### DIFF
--- a/src/core/di/container.py
+++ b/src/core/di/container.py
@@ -399,8 +399,17 @@ class ServiceCollection(IServiceCollection):
         self.add_singleton(BackendRegistry, BackendRegistry)
         self.add_singleton(IUsageTrackingService, UsageTrackingService)
         self.add_singleton(ISessionService, SessionService)
+
         # ICommandService registered in register_core_services()
-        self.add_singleton(ContentRewriterService, ContentRewriterService)
+        def _content_rewriter_factory(
+            provider: IServiceProvider,
+        ) -> ContentRewriterService:
+            app_config = provider.get_required_service(AppConfig)
+            return ContentRewriterService(app_config=app_config)
+
+        self.add_singleton(
+            ContentRewriterService, implementation_factory=_content_rewriter_factory
+        )
 
         self.add_scoped(IBackendProcessor, BackendProcessor)
         self.add_scoped(IBackendRequestManager, BackendRequestManager)

--- a/src/core/services/content_rewriter_service.py
+++ b/src/core/services/content_rewriter_service.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from src.core.domain.replacement_rule import ReplacementMode, ReplacementRule
+
+if TYPE_CHECKING:
+    from src.core.config.app_config import AppConfig
 
 logger = logging.getLogger(__name__)
 
@@ -9,8 +15,19 @@ logger = logging.getLogger(__name__)
 class ContentRewriterService:
     """Loads and applies content replacement rules."""
 
-    def __init__(self, config_path: str = "config/replacements"):
-        self.config_path = config_path
+    def __init__(
+        self,
+        config_path: str | None = None,
+        app_config: AppConfig | None = None,
+    ):
+        if config_path is not None:
+            resolved_path = config_path
+        elif app_config is not None:
+            resolved_path = app_config.rewriting.config_path
+        else:
+            resolved_path = "config/replacements"
+
+        self.config_path = resolved_path
         self.prompt_system_rules: list[ReplacementRule] = []
         self.prompt_user_rules: list[ReplacementRule] = []
         self.reply_rules: list[ReplacementRule] = []

--- a/tests/unit/core/services/test_content_rewriter_service.py
+++ b/tests/unit/core/services/test_content_rewriter_service.py
@@ -299,6 +299,24 @@ class TestContentRewriterService(unittest.TestCase):
         service = ContentRewriterService(config_path=self.test_config_dir)
         self.assertEqual(len(service.prompt_system_rules), 2)
 
+    def test_uses_app_config_path_when_provided(self):
+        """Service resolves configuration path from the app config when present."""
+
+        class DummyRewritingConfig:
+            def __init__(self, config_path: str) -> None:
+                self.config_path = config_path
+
+        class DummyAppConfig:
+            def __init__(self, config_path: str) -> None:
+                self.rewriting = DummyRewritingConfig(config_path)
+
+        service = ContentRewriterService(
+            app_config=DummyAppConfig(self.test_config_dir)
+        )
+
+        self.assertEqual(service.config_path, self.test_config_dir)
+        self.assertEqual(len(service.prompt_system_rules), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- resolve the content rewriting configuration path from AppConfig when the service is built through DI
- extend the content rewriter unit tests to cover AppConfig-provided configuration paths

## Testing
- ./.venv/Scripts/python.exe -m pytest tests/unit/core/services/test_content_rewriter_service.py
- ./.venv/Scripts/python.exe -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68ec25991fdc8333a330a77b2af39221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Content rewriting now automatically uses the app’s configured rules directory when available, with a sensible default fallback.
- Bug Fixes
  - Ensures content rewriting consistently resolves the correct configuration path, improving reliability.
- Tests
  - Added unit tests to validate loading rules from the app-configured path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->