### PR TITLE
Fix output_text rewrite for responses API

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -283,6 +283,18 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
                         payload["output_text"][index] = rewritten_text
                         is_rewritten = True
 
+        elif isinstance(output_text, str):
+            if aggregated_texts and any(text is not None for text in aggregated_texts):
+                aggregated_combined = "".join(text or "" for text in aggregated_texts)
+                if aggregated_combined != output_text:
+                    payload["output_text"] = aggregated_combined
+                    is_rewritten = True
+            else:
+                rewritten_text = self.rewriter.rewrite_reply(output_text)
+                if rewritten_text != output_text:
+                    payload["output_text"] = rewritten_text
+                    is_rewritten = True
+
         return is_rewritten
 
     async def dispatch(

--- a/tests/integration/test_content_rewriting_middleware.py
+++ b/tests/integration/test_content_rewriting_middleware.py
@@ -867,6 +867,84 @@ class TestContentRewritingMiddleware(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_inbound_responses_output_rewriting_updates_output_text_string(self):
+        """Ensure scalar output_text stays in sync with rewritten outputs."""
+
+        async def run_test():
+            os.makedirs(
+                os.path.join(self.test_config_dir, "replies", "004b"),
+                exist_ok=True,
+            )
+            with open(
+                os.path.join(self.test_config_dir, "replies", "004b", "SEARCH.txt"),
+                "w",
+            ) as f:
+                f.write("original reply")
+            with open(
+                os.path.join(self.test_config_dir, "replies", "004b", "REPLACE.txt"),
+                "w",
+            ) as f:
+                f.write("rewritten reply")
+
+            rewriter = ContentRewriterService(config_path=self.test_config_dir)
+            middleware = ContentRewritingMiddleware(app=None, rewriter=rewriter)
+
+            response_payload = {
+                "output": [
+                    {
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "This is an original reply.",
+                            }
+                        ]
+                    }
+                ],
+                "output_text": "This is an original reply.",
+            }
+
+            async def call_next(request):
+                return Response(
+                    content=json.dumps(response_payload),
+                    media_type="application/json",
+                )
+
+            async def receive():
+                return {"type": "http.request", "body": b""}
+
+            request = Request(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "headers": Headers({"content-type": "application/json"}).raw,
+                    "http_version": "1.1",
+                    "server": ("testserver", 80),
+                    "client": ("testclient", 123),
+                    "scheme": "http",
+                    "root_path": "",
+                    "path": "/test",
+                    "raw_path": b"/test",
+                    "query_string": b"",
+                },
+                receive=receive,
+            )
+
+            response = await middleware.dispatch(request, call_next)
+            body = json.loads(response.body)
+
+            self.assertEqual(
+                body["output"][0]["content"][0]["text"],
+                "This is an rewritten reply.",
+            )
+            self.assertEqual(
+                body["output_text"],
+                "This is an rewritten reply.",
+            )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
     def test_inbound_responses_output_prepend_rules_apply_once(self):
         """Ensure PREPEND rules are not applied twice to output text."""
 


### PR DESCRIPTION
## Summary
- ensure the content rewriting middleware updates scalar `output_text` fields when replies are rewritten
- add an integration test that covers Responses API payloads with `output_text` provided as a string

## Testing
- python -m pytest -o addopts='' tests/integration/test_content_rewriting_middleware.py::TestContentRewritingMiddleware::test_inbound_responses_output_rewriting_updates_output_text_string
- python -m pytest -o addopts=''
  - fails: missing optional test dependencies (pytest-asyncio, respx, hypothesis, pytest-httpx)

------
https://chatgpt.com/codex/tasks/task_e_68ec25991fdc8333a330a77b2af39221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures rewritten content is applied when the response summary is a single string, keeping the top-level summary consistent with the detailed content.
  * Aggregates available snippets into the summary when appropriate and marks responses as rewritten when changes occur.

* **Tests**
  * Added integration test to verify that rewriting updates both the detailed content and the top-level summary for single-string responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->