### PR TITLE
Fix content rewriting config path resolution

### DIFF
--- a/src/core/di/container.py
+++ b/src/core/di/container.py
@@ -400,7 +400,13 @@ class ServiceCollection(IServiceCollection):
         self.add_singleton(IUsageTrackingService, UsageTrackingService)
         self.add_singleton(ISessionService, SessionService)
         # ICommandService registered in register_core_services()
-        self.add_singleton(ContentRewriterService, ContentRewriterService)
+        def _content_rewriter_factory(provider: IServiceProvider) -> ContentRewriterService:
+            app_config = provider.get_required_service(AppConfig)
+            return ContentRewriterService(app_config=app_config)
+
+        self.add_singleton(
+            ContentRewriterService, implementation_factory=_content_rewriter_factory
+        )
 
         self.add_scoped(IBackendProcessor, BackendProcessor)
         self.add_scoped(IBackendRequestManager, BackendRequestManager)

--- a/src/core/services/content_rewriter_service.py
+++ b/src/core/services/content_rewriter_service.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from src.core.domain.replacement_rule import ReplacementMode, ReplacementRule
+
+if TYPE_CHECKING:
+    from src.core.config.app_config import AppConfig
 
 logger = logging.getLogger(__name__)
 
@@ -9,8 +15,25 @@ logger = logging.getLogger(__name__)
 class ContentRewriterService:
     """Loads and applies content replacement rules."""
 
-    def __init__(self, config_path: str = "config/replacements"):
-        self.config_path = config_path
+    def __init__(
+        self,
+        config_path: str | None = None,
+        app_config: AppConfig | None = None,
+    ) -> None:
+        """Create a content rewriter service.
+
+        Args:
+            config_path: Optional explicit path to the replacements directory.
+            app_config: Optional application configuration used to resolve the
+                replacements directory when ``config_path`` is not provided.
+        """
+
+        if config_path is not None:
+            self.config_path = config_path
+        elif app_config is not None:
+            self.config_path = app_config.rewriting.config_path
+        else:
+            self.config_path = "config/replacements"
         self.prompt_system_rules: list[ReplacementRule] = []
         self.prompt_user_rules: list[ReplacementRule] = []
         self.reply_rules: list[ReplacementRule] = []

--- a/tests/unit/core/services/test_content_rewriter_service.py
+++ b/tests/unit/core/services/test_content_rewriter_service.py
@@ -2,8 +2,10 @@ import os
 import shutil
 import tempfile
 import unittest
+from types import SimpleNamespace
 
 from src.core.domain.replacement_rule import ReplacementMode
+from src.core.config.app_config import RewritingConfig
 from src.core.services.content_rewriter_service import ContentRewriterService
 
 
@@ -212,6 +214,34 @@ class TestContentRewriterService(unittest.TestCase):
         reply = "This is an original reply."
         rewritten = service.rewrite_reply(reply)
         self.assertEqual(rewritten, "This is an rewritten reply.")
+
+    def test_app_config_overrides_default_config_path(self):
+        alternate_dir = os.path.join(self.test_config_dir, "app_config_rules")
+        os.makedirs(os.path.join(alternate_dir, "replies", "010_replace"), exist_ok=True)
+
+        with open(
+            os.path.join(alternate_dir, "replies", "010_replace", "SEARCH.txt"),
+            "w",
+        ) as handle:
+            handle.write("custom reply")
+
+        with open(
+            os.path.join(alternate_dir, "replies", "010_replace", "REPLACE.txt"),
+            "w",
+        ) as handle:
+            handle.write("rewritten custom reply")
+
+        app_config = SimpleNamespace(
+            rewriting=RewritingConfig(enabled=True, config_path=alternate_dir)
+        )
+
+        service = ContentRewriterService(app_config=app_config)
+
+        self.assertEqual(service.config_path, alternate_dir)
+        self.assertEqual(
+            service.rewrite_reply("custom reply"),
+            "rewritten custom reply",
+        )
 
     def test_rewrite_prompt_ignores_trailing_newline_in_search_rule(self):
         """Trailing newlines in SEARCH.txt should not prevent matches."""


### PR DESCRIPTION
## Summary
- allow `ContentRewriterService` to resolve its configuration path from `AppConfig` when no explicit override is supplied
- register the content rewriter through the DI container with an application-config aware factory so request/response rewriting respects user configuration
- add a regression test covering the AppConfig-driven configuration path

## Testing
- python -m pytest -o addopts= tests/unit/core/services/test_content_rewriter_service.py
- python -m pytest -o addopts= tests/integration/test_content_rewriting_middleware.py
- python -m pytest -o addopts= *(fails: environment is missing pytest_asyncio, respx, pytest_httpx, and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68ec25991fdc8333a330a77b2af39221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Content rewriting now supports customizing the rules path via app settings, enabling alternative locations for rewrite rules.
  - Rewrite rules are loaded on startup so changes take effect immediately.

- Tests
  - Added coverage to validate custom configuration paths for rewrite rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->