### PR TITLE
Support developer role in content rewriting

### DIFF
--- a/src/core/services/content_rewriter_service.py
+++ b/src/core/services/content_rewriter_service.py
@@ -144,9 +144,11 @@ class ContentRewriterService:
 
     def rewrite_prompt(self, prompt: str, prompt_type: str) -> str:
         """Rewrites a prompt based on its type."""
-        if prompt_type == "system":
+        normalized_type = prompt_type.lower() if isinstance(prompt_type, str) else ""
+
+        if normalized_type in {"system", "developer"}:
             rules = self.prompt_system_rules
-        elif prompt_type == "user":
+        elif normalized_type == "user":
             rules = self.prompt_user_rules
         else:
             return prompt

--- a/tests/integration/test_content_rewriting_middleware.py
+++ b/tests/integration/test_content_rewriting_middleware.py
@@ -311,6 +311,59 @@ class TestContentRewritingMiddleware(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_outbound_prompt_rewriting_handles_developer_role(self):
+        """Developer role prompts should reuse system rewrite rules."""
+
+        async def run_test():
+            rewriter = ContentRewriterService(config_path=self.test_config_dir)
+            middleware = ContentRewritingMiddleware(app=None, rewriter=rewriter)
+
+            payload = {
+                "messages": [
+                    {
+                        "role": "developer",
+                        "content": "This is an original system prompt.",
+                    }
+                ]
+            }
+
+            async def get_body():
+                return json.dumps(payload).encode("utf-8")
+
+            request = Request(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "headers": Headers({"content-type": "application/json"}).raw,
+                    "http_version": "1.1",
+                    "server": ("testserver", 80),
+                    "client": ("testclient", 123),
+                    "scheme": "http",
+                    "root_path": "",
+                    "path": "/test",
+                    "raw_path": b"/test",
+                    "query_string": b"",
+                }
+            )
+            request._body = await get_body()
+
+            call_next = AsyncMock()
+            call_next.return_value = Response("OK")
+
+            await middleware.dispatch(request, call_next)
+
+            new_request = call_next.call_args[0][0]
+            new_body = await new_request.json()
+
+            self.assertEqual(
+                new_body["messages"][0]["content"],
+                "This is an rewritten system prompt.",
+            )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
     def test_outbound_prompt_rewriting_updates_content_length_header(self):
         """Ensure rewritten requests expose the correct Content-Length."""
 

--- a/tests/unit/core/services/test_content_rewriter_service.py
+++ b/tests/unit/core/services/test_content_rewriter_service.py
@@ -192,10 +192,9 @@ class TestContentRewriterService(unittest.TestCase):
 
         # System prompt with REPLACE and PREPEND
         system_prompt = "This is an original system prompt."
-        rewritten = service.rewrite_prompt(system_prompt, "system")
-        # The order of execution is not guaranteed, so we check for both possibilities
+        rewritten_system = service.rewrite_prompt(system_prompt, "system")
         self.assertIn(
-            rewritten,
+            rewritten_system,
             [
                 "This is an prepended system: rewritten system prompt.",
                 "This is an rewritten system prompt.",
@@ -204,8 +203,24 @@ class TestContentRewriterService(unittest.TestCase):
 
         # User prompt with REPLACE and APPEND
         user_prompt = "This is an original user prompt."
-        rewritten = service.rewrite_prompt(user_prompt, "user")
-        self.assertEqual(rewritten, "This is an rewritten user prompt.")
+        rewritten_user = service.rewrite_prompt(user_prompt, "user")
+        self.assertEqual(rewritten_user, "This is an rewritten user prompt.")
+
+    def test_rewrite_prompt_for_developer_role(self):
+        """Developer role prompts should reuse system rewrite rules."""
+
+        service = ContentRewriterService(config_path=self.test_config_dir)
+
+        developer_prompt = "This is an original system prompt."
+        rewritten = service.rewrite_prompt(developer_prompt, "developer")
+
+        self.assertIn(
+            rewritten,
+            [
+                "This is an prepended system: rewritten system prompt.",
+                "This is an rewritten system prompt.",
+            ],
+        )
 
     def test_rewrite_reply(self):
         service = ContentRewriterService(config_path=self.test_config_dir)


### PR DESCRIPTION
## Summary
- treat developer-role prompts the same as system prompts so configured replacements still apply when upstream clients send the new developer role
- add unit and integration coverage to confirm developer prompts follow system rewrite rules and continue to exercise existing behaviour

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/test_content_rewriter_service.py
- python -m pytest -o addopts="" tests/integration/test_content_rewriting_middleware.py
- python -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68ec25991fdc8333a330a77b2af39221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures prompts labeled as “developer” are rewritten using the same rules as “system” prompts.
  - Improves reliability with case-insensitive handling of prompt roles.
  - Leaves prompts unchanged when the role is unrecognized, preserving expected behavior.

- Tests
  - Added integration and unit tests to validate developer-role rewriting behavior.
  - Refined existing test assertions for clearer coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->