### PR TITLE
Handle Responses requests without response_format

### DIFF
--- a/src/core/domain/responses_api.py
+++ b/src/core/domain/responses_api.py
@@ -98,8 +98,8 @@ class ResponsesRequest(ValueObject):
 
     model: str = Field(..., description="The model to use for generation")
     messages: list[ChatMessage] = Field(..., description="The conversation messages")
-    response_format: ResponseFormat = Field(
-        ..., description="The structured response format"
+    response_format: ResponseFormat | None = Field(
+        None, description="The structured response format"
     )
     max_tokens: int | None = Field(
         None, description="Maximum number of tokens to generate"

--- a/src/core/domain/translation.py
+++ b/src/core/domain/translation.py
@@ -2377,8 +2377,11 @@ class Translation(BaseTranslator):
             responses_request = ResponsesRequest(**request_payload)
 
         # Prepare extra_body with response format
-        extra_body = responses_request.extra_body or {}
-        extra_body["response_format"] = responses_request.response_format.model_dump()
+        extra_body = dict(responses_request.extra_body or {})
+        if responses_request.response_format is not None:
+            extra_body["response_format"] = (
+                responses_request.response_format.model_dump()
+            )
 
         # Convert to CanonicalChatRequest
         canonical_request = CanonicalChatRequest(

--- a/tests/unit/core/domain/test_openai_responses_translation.py
+++ b/tests/unit/core/domain/test_openai_responses_translation.py
@@ -78,6 +78,20 @@ class TestOpenAIResponsesTranslation:
         assert result.extra_body is not None
         assert "response_format" in result.extra_body
 
+    def test_responses_to_domain_request_without_response_format(self):
+        """Requests without response_format should still translate successfully."""
+
+        request_dict = {
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        result = Translation.responses_to_domain_request(request_dict)
+
+        assert isinstance(result, CanonicalChatRequest)
+        assert result.model == "gpt-4o-mini"
+        assert result.extra_body == {}
+
     def test_from_domain_to_responses_request(self):
         """Test converting a domain request to Responses API request format."""
         extra_body = {


### PR DESCRIPTION
## Summary
- allow `ResponsesRequest` to represent OpenAI Responses payloads that omit `response_format`
- avoid injecting a response format into canonical requests when none was supplied
- cover the regression with a unit test for Responses translation

## Testing
- python -m pytest -o addopts='' tests/unit/core/domain/test_openai_responses_translation.py
- python -m pytest -o addopts='' *(fails: missing pytest_asyncio/pytest_httpx/respx dependencies from dev extras)*

------
https://chatgpt.com/codex/tasks/task_e_68ec25afad688333be45713d2a26ad3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now send Responses API requests without specifying a response format; requests will proceed with sensible defaults.
  - Payload handling is more robust when the response format is omitted, preventing unnecessary fields from being sent.

- Tests
  - Added unit tests to validate behavior when the response format is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->