### PR TITLE
Fix OpenAI translation of multimodal chat requests

### DIFF
--- a/src/core/domain/translation.py
+++ b/src/core/domain/translation.py
@@ -1712,12 +1712,31 @@ class Translation(BaseTranslator):
         """
         Translate a CanonicalChatRequest to an OpenAI request.
         """
+        messages_payload: list[dict[str, Any]] = []
+        for message in request.messages:
+            if hasattr(message, "to_dict"):
+                message_dict = message.to_dict()
+                # Preserve explicit `content: None` semantics expected by the
+                # OpenAI API when tool_calls are present.
+                if "content" not in message_dict:
+                    message_dict["content"] = None
+            else:
+                message_dict = {
+                    "role": getattr(message, "role", "assistant"),
+                    "content": getattr(message, "content", None),
+                }
+                tool_calls = getattr(message, "tool_calls", None)
+                if tool_calls is not None:
+                    message_dict["tool_calls"] = tool_calls
+                tool_call_id = getattr(message, "tool_call_id", None)
+                if tool_call_id is not None:
+                    message_dict["tool_call_id"] = tool_call_id
+
+            messages_payload.append(message_dict)
+
         payload: dict[str, Any] = {
             "model": request.model,
-            "messages": [
-                {"role": message.role, "content": message.content}
-                for message in request.messages
-            ],
+            "messages": messages_payload,
         }
 
         # Add all supported parameters

--- a/tests/unit/core/domain/test_translation_edge_cases.py
+++ b/tests/unit/core/domain/test_translation_edge_cases.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import json
 
 import pytest
-from src.core.domain.chat import ImageURL, MessageContentPartImage
+from src.core.domain.chat import (
+    CanonicalChatRequest,
+    ChatMessage,
+    ImageURL,
+    MessageContentPartImage,
+    MessageContentPartText,
+)
 from src.core.domain.translation import Translation
 
 
@@ -47,6 +53,39 @@ class TestTranslationEdgeCases:
         result = Translation.gemini_to_domain_stream_chunk("not a dict")
 
         assert result == {"error": "Invalid chunk format: expected a dictionary"}
+
+    def test_from_domain_to_openai_request_serializes_multimodal_content(self):
+        """Ensure OpenAI payloads include plain multimodal structures."""
+
+        request = CanonicalChatRequest(
+            model="gpt-4o-mini",
+            messages=[
+                ChatMessage(
+                    role="user",
+                    content=[
+                        MessageContentPartText(text="Describe this image"),
+                        MessageContentPartImage(
+                            image_url=ImageURL(url="https://example.com/cat.png")
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        payload = Translation.from_domain_to_openai_request(request)
+
+        assert payload["model"] == "gpt-4o-mini"
+        assert len(payload["messages"]) == 1
+        message_payload = payload["messages"][0]
+
+        assert isinstance(message_payload["content"], list)
+        assert message_payload["content"][0] == {
+            "type": "text",
+            "text": "Describe this image",
+        }
+        image_part = message_payload["content"][1]
+        assert image_part["type"] == "image_url"
+        assert image_part["image_url"]["url"] == "https://example.com/cat.png"
 
     @pytest.mark.parametrize(
         "args_input, expected_output_str",


### PR DESCRIPTION
## Summary
- ensure OpenAI chat request translation serializes ChatMessage instances so multimodal payloads are plain dicts
- add regression coverage verifying multimodal OpenAI requests contain normalized text and image content

## Testing
- ./.venv/Scripts/python.exe -m pytest --override-ini="addopts=" tests/unit/core/domain/test_translation_edge_cases.py
- ./.venv/Scripts/python.exe -m pytest --override-ini="addopts=" (fails: missing optional dev dependencies such as pytest_asyncio/respx)


------
https://chatgpt.com/codex/tasks/task_e_68ec25afad688333be45713d2a26ad3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multimodal chat messages (text plus images) in translation/chat requests.
* **Improvements**
  * Improved compatibility and reliability when constructing chat payloads, including better handling of complex messages and tool-call scenarios.
* **Tests**
  * Added unit tests validating serialization of multimodal messages (text followed by image URL) to ensure correct payload structure and model preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->