### PR TITLE
Allow Responses API requests without schemas

### DIFF
--- a/src/core/domain/responses_api.py
+++ b/src/core/domain/responses_api.py
@@ -98,8 +98,8 @@ class ResponsesRequest(ValueObject):
 
     model: str = Field(..., description="The model to use for generation")
     messages: list[ChatMessage] = Field(..., description="The conversation messages")
-    response_format: ResponseFormat = Field(
-        ..., description="The structured response format"
+    response_format: ResponseFormat | None = Field(
+        None, description="Optional structured response format"
     )
     max_tokens: int | None = Field(
         None, description="Maximum number of tokens to generate"

--- a/src/core/domain/translation.py
+++ b/src/core/domain/translation.py
@@ -2377,8 +2377,16 @@ class Translation(BaseTranslator):
             responses_request = ResponsesRequest(**request_payload)
 
         # Prepare extra_body with response format
-        extra_body = responses_request.extra_body or {}
-        extra_body["response_format"] = responses_request.response_format.model_dump()
+        extra_body = (
+            dict(responses_request.extra_body)
+            if responses_request.extra_body is not None
+            else {}
+        )
+
+        if responses_request.response_format is not None:
+            extra_body["response_format"] = (
+                responses_request.response_format.model_dump()
+            )
 
         # Convert to CanonicalChatRequest
         canonical_request = CanonicalChatRequest(

--- a/tests/unit/core/domain/test_responses_api_models.py
+++ b/tests/unit/core/domain/test_responses_api_models.py
@@ -197,6 +197,15 @@ class TestResponsesRequest:
         assert request.max_tokens is None
         assert request.temperature is None
 
+    def test_responses_request_without_response_format(self) -> None:
+        """Requests without response_format should be accepted."""
+        messages = [ChatMessage(role="user", content="Plain text response please")]
+
+        request = ResponsesRequest(model="gpt-4o", messages=messages)
+
+        assert request.model == "gpt-4o"
+        assert request.response_format is None
+
     def test_responses_request_empty_messages_validation(self) -> None:
         """Test that empty messages list raises ValidationError."""
         json_schema = JsonSchema(name="test", schema={"type": "string"})

--- a/tests/unit/core/services/test_translation_service_responses_api.py
+++ b/tests/unit/core/services/test_translation_service_responses_api.py
@@ -759,16 +759,19 @@ class TestResponsesApiErrorHandling:
             self.service.to_domain_request(invalid_request, "responses")
 
     def test_responses_to_domain_request_missing_response_format(self):
-        """Test error handling for missing response_format in request."""
-        invalid_request = {
+        """Requests without response_format should still translate successfully."""
+        request_without_schema = {
             "model": "gpt-4",
             "messages": [{"role": "user", "content": "Test"}],
         }
 
-        with pytest.raises(
-            ValidationError
-        ):  # Should raise validation error for missing response_format
-            self.service.to_domain_request(invalid_request, "responses")
+        domain_request = self.service.to_domain_request(
+            request_without_schema, "responses"
+        )
+
+        assert domain_request.model == "gpt-4"
+        assert domain_request.messages[0].content == "Test"
+        assert not (domain_request.extra_body or {}).get("response_format")
 
     def test_validate_json_against_schema_exception_handling(self):
         """Test error handling in schema validation when exceptions occur."""


### PR DESCRIPTION
## Summary
- allow ResponsesRequest to omit `response_format` so schema-less requests are valid
- update the Responses translator to only copy schemas when present and cover the behavior with tests

## Testing
- `pytest -o addopts="" tests/unit/core/services/test_translation_service_responses_api.py tests/unit/core/domain/test_responses_api_models.py`
- `pytest -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68ec25afad688333be45713d2a26ad3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now send responses without specifying a structured response format; requests will proceed normally when it’s omitted.
  * Request payloads include the response format only when provided, reducing unnecessary data.
* **Bug Fixes**
  * Prevents unintended mutation of additional request data when no extra fields are supplied.
* **Tests**
  * Added and updated unit tests to validate behavior when the response format is not provided and ensure payload correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->