### PR TITLE
Respect STRICT_PERSISTENCE_ERRORS for persistence DI errors

### DIFF
--- a/src/core/persistence.py
+++ b/src/core/persistence.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,9 @@ class ConfigManager:
 
     def _should_raise_strict_errors(self) -> bool:
         """Check if strict error handling is enabled via config."""
+        env_value = os.getenv("STRICT_PERSISTENCE_ERRORS", "false").lower()
+        if env_value in {"true", "1", "yes"}:
+            return True
         if self.config:
             value = self.config.get("session.dangerous_command_prevention_enabled")
             return bool(value) if value is not None else False

--- a/tests/unit/test_config_persistence.py
+++ b/tests/unit/test_config_persistence.py
@@ -12,7 +12,11 @@ def functional_backend() -> str:
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from src.core.app.test_builder import build_test_app as build_app
-from src.core.common.exceptions import ConfigurationError, JSONParsingError
+from src.core.common.exceptions import (
+    ConfigurationError,
+    JSONParsingError,
+    ServiceResolutionError,
+)
 from src.core.config.app_config import load_config
 from src.core.persistence import ConfigManager
 
@@ -225,6 +229,34 @@ def test_apply_default_backend_invalid_backend_still_raises_with_cli_override(
         "backend": "nonexistent",
         "functional_backends": ["openai"],
     }
+
+
+def test_apply_default_backend_strict_errors_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """STRICT_PERSISTENCE_ERRORS should force DI resolution failures to raise."""
+
+    class _StrictAppState(_DummyAppState):
+        def set_backend_type(self, backend_type: str | None) -> None:  # type: ignore[override]
+            self.backend_type = backend_type
+
+    class _FailingProvider:
+        def get_required_service(self, _service_type):  # type: ignore[no-untyped-def]
+            raise ServiceResolutionError("boom")
+
+    monkeypatch.setenv("STRICT_PERSISTENCE_ERRORS", "true")
+
+    manager = ConfigManager(
+        FastAPI(),
+        path=str(tmp_path / "config.json"),
+        service_provider=_FailingProvider(),
+        app_state=_StrictAppState(),
+    )
+
+    with pytest.raises(ServiceResolutionError):
+        manager._apply_default_backend("openai")
+
+    monkeypatch.delenv("STRICT_PERSISTENCE_ERRORS", raising=False)
 
 
 def test_load_raises_json_parsing_error_for_invalid_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure `ConfigManager` respects the `STRICT_PERSISTENCE_ERRORS` environment flag when deciding whether to raise DI failures
- add a regression test covering the strict persistence error path for default backend resolution

## Testing
- python -m pytest -o addopts='' tests/unit/test_config_persistence.py::test_apply_default_backend_strict_errors_env
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68ec25e4aee08333a1a09066d47a3acf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an environment variable to control strict persistence error handling. Setting STRICT_PERSISTENCE_ERRORS to a truthy value (e.g., true, 1, yes) enables strict mode, overriding configuration. Default remains disabled.
* **Tests**
  * Added unit tests to verify strict mode behavior and error surfacing when persistence backends are misconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->