### PR TITLE
Fix FastAPI exception handler serialization failures

### DIFF
--- a/src/core/transport/fastapi/exception_adapters.py
+++ b/src/core/transport/fastapi/exception_adapters.py
@@ -29,6 +29,29 @@ from src.core.common.exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def _safe_json_default(value: Any) -> str:
+    """Convert non-serializable objects to a safe string representation."""
+
+    try:
+        return str(value)
+    except Exception:  # pragma: no cover - extremely defensive
+        return repr(value)
+
+
+def _serialize_exception_detail(detail: Any) -> str:
+    """Serialize exception detail payloads without raising errors."""
+
+    try:
+        return json.dumps(detail, default=_safe_json_default)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Failed to serialize exception detail payload; falling back to string.",
+            exc_info=True,
+        )
+        fallback_payload = {"message": _safe_json_default(detail)}
+        return json.dumps(fallback_payload)
+
+
 def _build_retry_after_header(reset_at: float | None) -> dict[str, str] | None:
     """Compute a standards-compliant Retry-After header value."""
 
@@ -119,8 +142,9 @@ def register_exception_handlers(app: FastAPI) -> None:
         request: Request, exc: LLMProxyError
     ) -> Response:
         http_exception = map_domain_exception_to_http_exception(exc)
+        serialized_detail = _serialize_exception_detail(http_exception.detail)
         return Response(
-            content=json.dumps(http_exception.detail),
+            content=serialized_detail,
             status_code=http_exception.status_code,
             media_type="application/json",
             headers=getattr(http_exception, "headers", None),

--- a/tests/unit/test_transport_adapters.py
+++ b/tests/unit/test_transport_adapters.py
@@ -3,9 +3,11 @@ Tests for the transport adapters.
 """
 
 import json
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from src.core.common.exceptions import (
     AuthenticationError,
@@ -18,6 +20,7 @@ from src.core.domain.request_context import RequestContext
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.transport.fastapi.exception_adapters import (
     map_domain_exception_to_http_exception,
+    register_exception_handlers,
 )
 from src.core.transport.fastapi.request_adapters import (
     fastapi_to_domain_request_context,
@@ -249,3 +252,23 @@ class TestExceptionAdapters:
         http_exc = map_domain_exception_to_http_exception(expired_rate_error)
         assert http_exc.status_code == 429
         assert http_exc.headers == {"Retry-After": "0"}
+
+    @pytest.mark.asyncio
+    async def test_domain_exception_handler_serializes_non_json_details(self):
+        """Ensure FastAPI handler can serialize complex detail payloads."""
+
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        handler = app.exception_handlers[BackendError]
+        error = BackendError(
+            "backend exploded",
+            details={"when": datetime(2025, 1, 1, 12, 30, 15)},
+        )
+
+        response = await handler(MagicMock(), error)  # type: ignore[arg-type]
+
+        assert response.status_code == 502
+        payload = json.loads(response.body.decode("utf-8"))
+        assert payload["message"] == "backend exploded"
+        assert payload["details"]["when"].startswith("2025-01-01 12:30:15")


### PR DESCRIPTION
## Summary
- ensure the FastAPI domain exception handler safely serializes complex exception details without crashing
- add a regression test that exercises serialization of datetime objects in handler responses

## Testing
- python -m pytest --override-ini=addopts= tests/unit/test_transport_adapters.py::TestExceptionAdapters::test_domain_exception_handler_serializes_non_json_details -q
- python -m pytest --override-ini=addopts=


------
https://chatgpt.com/codex/tasks/task_e_68ec25e4aee08333a1a09066d47a3acf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now serialize non-JSON data (e.g., datetime) into strings, ensuring responses are always valid JSON.
  * Improves consistency and readability of error details without failing on complex payloads.
  * Maintains expected HTTP status codes while providing clearer messages.

* **Tests**
  * Added unit test verifying error responses correctly handle and serialize non-JSON detail payloads in a FastAPI app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->