### PR TITLE
Fix general exception handler to preserve traceback logging

### DIFF
--- a/src/core/app/error_handlers.py
+++ b/src/core/app/error_handlers.py
@@ -242,7 +242,19 @@ async def general_exception_handler(request: Request, exc: Exception) -> Respons
     Returns:
         JSON response with error details
     """
-    logger.exception("Unhandled exception", exc_info=exc)
+    # Starlette calls exception handlers after it has already unwound the stack,
+    # so `sys.exc_info()` no longer contains the traceback for `exc`. Passing the
+    # exception object to `exc_info` does not help either because the logging
+    # module treats any non-tuple value as truthy and simply falls back to
+    # `sys.exc_info()`, which results in a `(None, None, None)` triple. This
+    # silently drops the traceback and makes debugging significantly harder.
+    #
+    # Instead, explicitly provide the exception info tuple so that the original
+    # traceback attached to the exception is preserved in the logs.
+    logger.exception(
+        "Unhandled exception",
+        exc_info=(type(exc), exc, getattr(exc, "__traceback__", None)),
+    )
 
     # Check if this is a chat completions endpoint request
     is_chat_completions = False

--- a/tests/unit/core/app/test_error_handlers.py
+++ b/tests/unit/core/app/test_error_handlers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Any
 
 import pytest
@@ -356,6 +357,47 @@ def test_general_exception_handler_standard_request(
         }
     }
     assert any(record.exc_info for record in caplog.records)
+
+
+def test_general_exception_handler_preserves_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request = make_request("/v1/embeddings")
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as err:
+        captured_exc = err
+
+    with caplog.at_level(logging.ERROR, logger="src.core.app.error_handlers"):
+        response = call_handler(
+            general_exception_handler,
+            request,
+            captured_exc,
+        )
+
+    assert response.status_code == 500
+    payload = parse_json_response(response)
+    assert payload == {
+        "detail": {
+            "error": {
+                "message": "Internal Server Error",
+                "type": "InternalError",
+                "status_code": 500,
+            }
+        }
+    }
+
+    error_records = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR and record.exc_info is not None
+    ]
+    assert error_records, "Expected at least one error log with exception info"
+    exc_type, exc_value, exc_tb = error_records[0].exc_info
+    assert exc_type is RuntimeError
+    assert exc_value is captured_exc
+    assert exc_tb is captured_exc.__traceback__
 
 
 def test_configure_exception_handlers_registers_handlers() -> None:


### PR DESCRIPTION
## Summary
- ensure the general exception handler passes an explicit exc_info tuple so traceback information is logged
- extend the error handler unit tests to assert that raised exceptions retain their traceback in log records

## Testing
- `python -m pytest -o addopts='' tests/unit/core/app/test_error_handlers.py`
- `python -m pytest -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68ec25e4aee08333a1a09066d47a3acf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved server error handling to reliably preserve the original exception traceback in logs, enabling more accurate diagnostics without changing the user-facing error response.

- Tests
  - Added unit tests to verify that general exception handling maintains the original traceback and returns the expected 500 Internal Server Error payload.

- Chores
  - Minor logging adjustments to enhance observability during unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->