### PR TITLE
Fix OpenAI connector health check flag handling

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -71,8 +71,8 @@ class OpenAIConnector(LLMBackend):
             "DISABLE_HEALTH_CHECKS", "false"
         ).lower() in ("true", "1", "yes")
 
-        disable_health_checks_config = self.config.get(
-            "session.dangerous_command_prevention_enabled", False
+        disable_health_checks_config = bool(
+            getattr(self.config, "disable_health_checks", False)
         )
 
         # Enable health checks only when neither config nor env disable them

--- a/tests/unit/openai_connector_tests/test_health_check_configuration.py
+++ b/tests/unit/openai_connector_tests/test_health_check_configuration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from src.connectors.openai import OpenAIConnector
+from src.core.config.app_config import AppConfig
+from src.core.services.translation_service import TranslationService
+
+
+@pytest.fixture()
+def translation_service() -> TranslationService:
+    return TranslationService()
+
+
+def _build_connector(
+    config: AppConfig, translation_service: TranslationService
+) -> OpenAIConnector:
+    client = AsyncMock(spec=httpx.AsyncClient)
+    return OpenAIConnector(
+        client=client,
+        config=config,
+        translation_service=translation_service,
+    )
+
+
+def test_health_checks_disabled_by_config(
+    monkeypatch: pytest.MonkeyPatch, translation_service: TranslationService
+) -> None:
+    monkeypatch.delenv("DISABLE_HEALTH_CHECKS", raising=False)
+    connector = _build_connector(
+        AppConfig(disable_health_checks=True), translation_service
+    )
+    assert connector._health_check_enabled is False
+
+
+def test_health_checks_enabled_by_default(
+    monkeypatch: pytest.MonkeyPatch, translation_service: TranslationService
+) -> None:
+    monkeypatch.delenv("DISABLE_HEALTH_CHECKS", raising=False)
+    connector = _build_connector(AppConfig(), translation_service)
+    assert connector._health_check_enabled is True
+
+
+def test_env_override_disables_health_checks(
+    monkeypatch: pytest.MonkeyPatch, translation_service: TranslationService
+) -> None:
+    monkeypatch.setenv("DISABLE_HEALTH_CHECKS", "1")
+    connector = _build_connector(AppConfig(), translation_service)
+    assert connector._health_check_enabled is False


### PR DESCRIPTION
## Summary
- ensure the OpenAI connector honors the global disable_health_checks flag when deciding whether to run provider health checks
- add unit coverage for the configuration and environment flag interactions that control OpenAI connector health checks

## Testing
- python -m pytest -c /tmp/pytest-noaddopts.ini tests/unit/openai_connector_tests/test_health_check_configuration.py
- python -m pytest -c /tmp/pytest-noaddopts.ini

------
https://chatgpt.com/codex/tasks/task_e_68ec25fa5a0c8333923ed0f3169275bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configuration option to disable health checks directly in app settings.
  - Supported environment variable override (DISABLE_HEALTH_CHECKS) to force-disable health checks.
  - Default behavior remains: health checks are enabled unless explicitly disabled.

- Tests
  - Added unit tests covering default behavior, configuration-based disabling, and environment-based overrides to ensure consistent health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->