### PR TITLE
Fix Gemini backend OpenRouter header handling

### DIFF
--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -9,7 +9,11 @@ import httpx
 from fastapi import HTTPException
 
 from src.connectors.base import LLMBackend
-from src.core.common.exceptions import BackendError, ServiceUnavailableError
+from src.core.common.exceptions import (
+    AuthenticationError,
+    BackendError,
+    ServiceUnavailableError,
+)
 from src.core.config.app_config import AppConfig  # Added
 from src.core.domain.chat import (
     ChatRequest,
@@ -348,7 +352,12 @@ class GeminiBackend(LLMBackend):
     ) -> ResponseEnvelope | StreamingResponseEnvelope:
         # Resolve base configuration
         base_api_url, headers = await self._resolve_gemini_api_config(
-            gemini_api_base_url, openrouter_api_base_url, api_key, **kwargs
+            gemini_api_base_url,
+            openrouter_api_base_url,
+            api_key,
+            openrouter_headers_provider=openrouter_headers_provider,
+            key_name=key_name,
+            **kwargs,
         )
         if identity:
             headers.update(identity.get_resolved_headers(None))
@@ -449,11 +458,31 @@ class GeminiBackend(LLMBackend):
             model_url, payload, headers, effective_model
         )
 
+    def _build_openrouter_header_context(self) -> dict[str, str]:
+        referer = "http://localhost:8000"
+        title = "InterceptorProxy"
+
+        identity = getattr(self.config, "identity", None)
+        if identity is not None:
+            referer = (
+                getattr(getattr(identity, "url", None), "default_value", referer)
+                or referer
+            )
+            title = (
+                getattr(getattr(identity, "title", None), "default_value", title)
+                or title
+            )
+
+        return {"app_site_url": referer, "app_x_title": title}
+
     async def _resolve_gemini_api_config(
         self,
         gemini_api_base_url: str | None,
         openrouter_api_base_url: str | None,
         api_key: str | None,
+        *,
+        openrouter_headers_provider: Callable[[Any, str], dict[str, str]] | None = None,
+        key_name: str | None = None,
         **kwargs: Any,
     ) -> tuple[str, dict[str, str]]:
         # Prefer explicit params, then kwargs, then instance attributes set during initialize
@@ -469,7 +498,64 @@ class GeminiBackend(LLMBackend):
                 status_code=500,
                 detail="Gemini API base URL and API key must be provided.",
             )
-        return base.rstrip("/"), ensure_loop_guard_header({"x-goog-api-key": key})
+        normalized_base = base.rstrip("/")
+
+        using_openrouter = openrouter_api_base_url is not None
+
+        headers: dict[str, str]
+        if using_openrouter:
+            headers = {}
+            provided_headers: dict[str, str] | None = None
+
+            if openrouter_headers_provider is not None:
+                errors: list[Exception] = []
+
+                if key_name is not None:
+                    try:
+                        candidate = openrouter_headers_provider(key_name, key)
+                    except (AttributeError, TypeError) as exc:
+                        errors.append(exc)
+                    else:
+                        if candidate:
+                            provided_headers = dict(candidate)
+
+                if provided_headers is None:
+                    context = self._build_openrouter_header_context()
+                    try:
+                        candidate = openrouter_headers_provider(context, key)
+                    except Exception as exc:  # pragma: no cover - defensive guard
+                        if errors and logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "OpenRouter headers provider rejected key_name input: %s",
+                                errors[-1],
+                                exc_info=True,
+                            )
+                        raise AuthenticationError(
+                            message="OpenRouter headers provider failed to produce headers.",
+                            code="missing_credentials",
+                        ) from exc
+                    else:
+                        provided_headers = dict(candidate)
+
+            if provided_headers is None:
+                context = self._build_openrouter_header_context()
+                provided_headers = {
+                    "Authorization": f"Bearer {key}",
+                    "Content-Type": "application/json",
+                    "HTTP-Referer": context["app_site_url"],
+                    "X-Title": context["app_x_title"],
+                }
+
+            headers.update(provided_headers)
+            context = self._build_openrouter_header_context()
+            headers.setdefault("Authorization", f"Bearer {key}")
+            headers.setdefault("Content-Type", "application/json")
+            headers.setdefault("HTTP-Referer", context["app_site_url"])
+            headers.setdefault("X-Title", context["app_x_title"])
+        else:
+            headers = {"x-goog-api-key": key}
+
+        return normalized_base, ensure_loop_guard_header(headers)
 
     def _apply_generation_config(
         self, payload: dict[str, Any], request_data: ChatRequest

--- a/tests/unit/gemini_connector_tests/test_openrouter_headers.py
+++ b/tests/unit/gemini_connector_tests/test_openrouter_headers.py
@@ -1,0 +1,86 @@
+import asyncio
+
+import httpx
+
+from src.connectors.gemini import GeminiBackend
+from src.core.domain.chat import ChatMessage, ChatRequest
+
+OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_headers_provider_used() -> None:
+    async def run_test() -> None:
+        seen_headers: dict[str, str] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            seen_headers.update({k.lower(): v for k, v in request.headers.items()})
+            assert str(request.url) == (
+                f"{OPENROUTER_API_BASE_URL}/v1beta/models/gemini-1:generateContent"
+            )
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "candidates": [
+                        {"content": {"parts": [{"text": "Hi"}]}},
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+
+        async with httpx.AsyncClient(transport=transport) as client:
+            from src.core.config.app_config import AppConfig
+            from src.core.services.translation_service import TranslationService
+
+            backend = GeminiBackend(
+                client=client,
+                config=AppConfig(),
+                translation_service=TranslationService(),
+            )
+
+            chat_request = ChatRequest(
+                model="test-model",
+                messages=[ChatMessage(role="user", content="Hello")],
+                stream=False,
+            )
+            processed_messages = [ChatMessage(role="user", content="Hello")]
+
+            provider_calls: list[tuple[object, str]] = []
+
+            def provider(arg: object, api_key: str) -> dict[str, str]:
+                provider_calls.append((arg, api_key))
+                if isinstance(arg, str):
+                    raise TypeError("legacy signature not supported")
+                assert isinstance(arg, dict)
+                assert "app_site_url" in arg
+                assert "app_x_title" in arg
+                return {
+                    "Authorization": f"Bearer provided-{api_key}",
+                    "HTTP-Referer": "provided-ref",
+                }
+
+            await backend.chat_completions(
+                request_data=chat_request,
+                processed_messages=processed_messages,
+                effective_model="models/gemini-1",
+                openrouter_api_base_url=OPENROUTER_API_BASE_URL,
+                openrouter_headers_provider=provider,
+                key_name="gemini",
+                api_key="OPENROUTER_KEY",
+            )
+
+            assert len(provider_calls) == 2
+            assert isinstance(provider_calls[0][0], str)
+            assert isinstance(provider_calls[1][0], dict)
+
+        assert seen_headers["authorization"] == "Bearer provided-OPENROUTER_KEY"
+        assert seen_headers["http-referer"] == "provided-ref"
+        assert seen_headers["content-type"].startswith("application/json")
+        assert seen_headers["x-llmproxy-loop-guard"] == "1"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- ensure the Gemini connector resolves OpenRouter-specific headers and fallbacks when routed through OpenRouter
- add a targeted unit test that verifies OpenRouter header injection using httpx's mock transport

## Testing
- python -m pytest tests/unit/gemini_connector_tests/test_openrouter_headers.py -q -o addopts=
- python -m pytest -q -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68ec25fa5a0c8333923ed0f3169275bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for OpenRouter-compatible endpoints with automatic header construction and sensible defaults.
  - Optional custom headers provider to supply Authorization, Referer, and related headers, improving authentication flexibility.
  - Enhanced configuration resolution for more reliable routing and base URL handling during chat completions.

- Tests
  - Added unit tests validating header negotiation with a custom provider, correct propagation of Authorization and Referer, JSON content type, and loop-guard behavior when targeting OpenRouter endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->