### PR TITLE
Fix OpenAI connector payload normalization for list content

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -337,7 +337,7 @@ class OpenAIConnector(LLMBackend):
                     return getattr(message, key, None)
 
                 def _normalize_content(value: Any) -> Any:
-                    if isinstance(value, list | tuple):
+                    if isinstance(value, (list, tuple)):
                         normalized_parts: list[Any] = []
                         for part in value:
                             if hasattr(part, "model_dump") and callable(

--- a/tests/unit/openai_connector_tests/test_processed_messages_normalization.py
+++ b/tests/unit/openai_connector_tests/test_processed_messages_normalization.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.connectors.openai import OpenAIConnector
+from src.core.config.app_config import AppConfig
+from src.core.domain.chat import (
+    CanonicalChatRequest,
+    ChatMessage,
+    MessageContentPartText,
+)
+from src.core.domain.responses import ResponseEnvelope
+
+
+@pytest.mark.asyncio
+async def test_prepare_payload_handles_sequence_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure list-based message content does not raise during payload normalization."""
+
+    client = AsyncMock()
+    translation_service = MagicMock()
+    translation_service.from_domain_request.return_value = {
+        "model": "gpt-4",
+        "messages": [],
+    }
+
+    connector = OpenAIConnector(
+        client=client,
+        config=AppConfig(),
+        translation_service=translation_service,
+    )
+    connector.disable_health_check()
+    connector.api_key = "test-token"
+
+    observed_payloads: list[dict[str, Any]] = []
+
+    async def fake_handle(
+        self: OpenAIConnector,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None,
+        session_id: str,
+    ) -> ResponseEnvelope:
+        observed_payloads.append(payload)
+        return ResponseEnvelope(content={}, headers={}, status_code=200)
+
+    monkeypatch.setattr(
+        OpenAIConnector,
+        "_handle_non_streaming_response",
+        fake_handle,
+    )
+
+    request = CanonicalChatRequest(
+        model="gpt-4",
+        messages=[
+            ChatMessage(
+                role="user",
+                content=[
+                    MessageContentPartText(text="first"),
+                    MessageContentPartText(text="second"),
+                ],
+            )
+        ],
+        stream=False,
+    )
+
+    processed_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"},
+            ],
+        }
+    ]
+
+    await connector.chat_completions(
+        request,
+        processed_messages,
+        "gpt-4",
+        identity=None,
+    )
+
+    assert observed_payloads, "Expected payload normalization to occur"
+    payload = observed_payloads[0]
+    assert payload["messages"][0]["content"] == [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "second"},
+    ]


### PR DESCRIPTION
## Summary
- ensure `OpenAIConnector` normalizes message content sequences without raising type errors
- add a regression test verifying list-based processed messages are handled correctly

## Testing
- `python -m pytest -o addopts="" tests/unit/openai_connector_tests/test_processed_messages_normalization.py`
- `python -m pytest -o addopts=""` *(fails: missing optional test dependencies such as pytest-asyncio and pytest-httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68ec25fa5a0c8333923ed0f3169275bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type checking in content normalization to prevent a runtime error and ensure consistent handling of list/tuple message content without altering behavior.

* **Tests**
  * Added unit tests for sequence-based message content normalization, verifying preservation of multiple text parts and expected payload structure to improve reliability and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->