### PR TITLE
Handle Qwen CLI refresh process cleanup

### DIFF
--- a/src/connectors/qwen_oauth.py
+++ b/src/connectors/qwen_oauth.py
@@ -905,5 +905,21 @@ class QwenOAuthConnector(OpenAIConnector):
         with contextlib.suppress(Exception):
             self._stop_file_watching()
 
+        process = self._cli_refresh_process
+        if process is not None:
+            try:
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)
+            except Exception:
+                # Suppress all errors during cleanup to avoid issues at interpreter shutdown
+                pass
+            finally:
+                self._cli_refresh_process = None
+
 
 backend_registry.register_backend("qwen-oauth", QwenOAuthConnector)

--- a/tests/unit/connectors/test_qwen_oauth_cleanup.py
+++ b/tests/unit/connectors/test_qwen_oauth_cleanup.py
@@ -1,0 +1,76 @@
+"""Unit tests for Qwen OAuth connector cleanup behavior."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from src.connectors.qwen_oauth import QwenOAuthConnector
+from src.core.config.app_config import AppConfig
+
+
+@pytest.fixture
+def connector() -> QwenOAuthConnector:
+    """Create a QwenOAuthConnector instance for testing cleanup logic."""
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    return QwenOAuthConnector(mock_client, config=AppConfig())
+
+
+def test_cleanup_stops_file_watching_and_terminates_process(
+    connector: QwenOAuthConnector,
+) -> None:
+    """Connector cleanup should stop file watching and terminate CLI refresh process."""
+
+    mock_process = Mock()
+    mock_process.poll.return_value = None
+    connector._cli_refresh_process = mock_process
+
+    with patch.object(connector, "_stop_file_watching") as mock_stop:
+        connector.__del__()
+        mock_stop.assert_called_once()
+
+    mock_process.terminate.assert_called_once()
+    assert mock_process.wait.call_count >= 1
+    assert connector._cli_refresh_process is None
+
+
+def test_cleanup_kills_hung_cli_refresh_process(
+    connector: QwenOAuthConnector,
+) -> None:
+    """Connector cleanup should kill CLI process if terminate does not finish it."""
+
+    mock_process = Mock()
+    mock_process.poll.return_value = None
+    mock_process.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd="qwen", timeout=5),
+        None,
+    ]
+    connector._cli_refresh_process = mock_process
+
+    connector.__del__()
+
+    mock_process.terminate.assert_called_once()
+    mock_process.kill.assert_called_once()
+    assert mock_process.wait.call_count == 2
+    assert connector._cli_refresh_process is None
+
+
+def test_cleanup_ignores_errors_during_shutdown(
+    connector: QwenOAuthConnector,
+) -> None:
+    """Exceptions while stopping watchers or processes should be suppressed."""
+
+    connector._cli_refresh_process = Mock()
+    connector._cli_refresh_process.poll.side_effect = RuntimeError("boom")
+
+    with patch.object(
+        connector, "_stop_file_watching", side_effect=Exception("watch error")
+    ):
+        connector.__del__()
+
+    # Process attribute should be cleared even when errors occur
+    assert connector._cli_refresh_process is None


### PR DESCRIPTION
## Summary
- ensure the Qwen OAuth connector terminates the background CLI refresh process during cleanup
- add focused unit tests that exercise the new cleanup logic for normal, hung, and error cases

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts='' tests/unit/connectors/test_qwen_oauth_cleanup.py -vv`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts=''` *(fails: missing optional dev dependencies such as pytest-asyncio, respx, pytest_httpx, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2685724083339dafb8594c547032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability for the OAuth connector. The background refresh process now terminates gracefully with a timeout and is force-killed if unresponsive, preventing hangs during exit.
  * Cleanup is resilient to errors and ensures background tasks stop and resources are released, avoiding orphaned processes and reducing crash risk during logout or app close. Users should notice smoother shutdowns and fewer lingering processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->