### PR TITLE
Handle tuple arguments in pytest full suite handler

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -81,7 +82,11 @@ def _extract_command(arguments: Any) -> str | None:
 
         return None
 
-    if isinstance(arguments, list):
+    if (
+        isinstance(arguments, Sequence)
+        and not isinstance(arguments, str | bytes)
+        and arguments
+    ):
         return " ".join(str(item) for item in arguments)
 
     return None

--- a/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
+++ b/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
@@ -144,6 +144,24 @@ async def test_handler_detects_list_based_command() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handler_detects_tuple_arguments_root_level() -> None:
+    handler = PytestFullSuiteHandler(enabled=True)
+    context = ToolCallContext(
+        session_id="session-tuple",
+        backend_name="backend",
+        model_name="model",
+        full_response={},
+        tool_name="bash",
+        tool_arguments=("pytest", "-q"),
+    )
+
+    assert await handler.can_handle(context) is True
+    result = await handler.handle(context)
+
+    assert result.should_swallow is True
+
+
+@pytest.mark.asyncio
 async def test_handler_enabled_flag_controls_behavior() -> None:
     handler = PytestFullSuiteHandler(enabled=False)
     context = _build_context("pytest")


### PR DESCRIPTION
## Summary
- handle tuple-style tool arguments when extracting commands in the pytest full suite steering handler
- add a regression test covering tuple arguments supplied at the top level of the tool call context

## Testing
- python -m pytest tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest *(fails: tests/unit/test_config_persistence.py::test_save_and_load_persistent_config and tests/integration/test_versioned_api.py::test_versioned_endpoint_requires_authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68ec25355ce08333b87d0889ca85b9a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Broadened support for command arguments by accepting tuples and other sequences, improving reliability when running the full test suite from varied input formats.
- Bug Fixes
  - Fixed edge cases where non-list argument inputs weren’t recognized, ensuring consistent detection and execution of the test suite.
- Tests
  - Added coverage for tuple-based root-level arguments to validate handler behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->