### PR TITLE
Fix tool call reactor handling of empty replacement responses

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -195,7 +195,7 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
                     )
 
                     # Create a new response with the replacement content
-                    if result.replacement_response:
+                    if result.replacement_response is not None:
                         replacement_response = self._create_replacement_response(
                             response,
                             result.replacement_response,

--- a/tests/unit/core/services/test_tool_call_reactor_middleware.py
+++ b/tests/unit/core/services/test_tool_call_reactor_middleware.py
@@ -404,6 +404,52 @@ class TestToolCallReactorMiddleware:
         assert result == response
 
     @pytest.mark.asyncio
+    async def test_process_with_tool_calls_swallowed_empty_string(
+        self, middleware, mock_reactor
+    ):
+        """Handlers should be able to swallow with an empty replacement payload."""
+
+        tool_call_response = {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "call_124",
+                                "type": "function",
+                                "function": {
+                                    "name": "test_tool",
+                                    "arguments": '{"arg": "value"}',
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        response = ProcessedResponse(content=json.dumps(tool_call_response))
+
+        swallow_result = ToolCallReactionResult(
+            should_swallow=True,
+            replacement_response="",
+            metadata={"handler": "test_handler"},
+        )
+
+        mock_reactor.process_tool_call.return_value = swallow_result
+
+        result = await middleware.process(
+            response=response,
+            session_id="test_session",
+            context={"backend_name": "test", "model_name": "test"},
+        )
+
+        assert isinstance(result, ProcessedResponse)
+        assert result.content == ""
+        assert result.metadata["tool_call_swallowed"] is True
+        assert result.metadata["tool_call_reactor"]["handler"] == "test_handler"
+
+    @pytest.mark.asyncio
     async def test_process_multiple_tool_calls(self, middleware, mock_reactor):
         """Test processing response with multiple tool calls."""
         tool_call_response = {


### PR DESCRIPTION
## Summary
- ensure the tool call reactor middleware accepts empty replacement payloads when swallowing
- add a regression test confirming an empty steering message still swallows the tool call

## Testing
- python -m pytest tests/unit/core/services/test_tool_call_reactor_middleware.py -q -o addopts=
- python -m pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68ec25355ce08333b87d0889ca85b9a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected response handling so tool-call outputs can be intentionally replaced with empty content while preserving associated metadata. This prevents unintended text from appearing when an empty result is desired and ensures consistent behavior across responses.

* **Tests**
  * Added unit coverage for empty replacement scenarios to validate that content is cleared correctly and metadata is retained, helping prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->