### PR TITLE
Fix handling of empty steering responses in tool call middleware

### DIFF
--- a/src/core/services/tool_call_reactor_middleware.py
+++ b/src/core/services/tool_call_reactor_middleware.py
@@ -195,7 +195,7 @@ class ToolCallReactorMiddleware(IResponseMiddleware):
                     )
 
                     # Create a new response with the replacement content
-                    if result.replacement_response:
+                    if result.replacement_response is not None:
                         replacement_response = self._create_replacement_response(
                             response,
                             result.replacement_response,

--- a/tests/unit/core/services/test_tool_call_reactor_middleware.py
+++ b/tests/unit/core/services/test_tool_call_reactor_middleware.py
@@ -307,6 +307,50 @@ class TestToolCallReactorMiddleware:
         assert result.metadata["tool_call_reactor"]["handler"] == "test_handler"
 
     @pytest.mark.asyncio
+    async def test_process_with_empty_replacement(self, middleware, mock_reactor):
+        """Handlers should be able to swallow calls with empty steering content."""
+
+        tool_call_response = {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "call_321",
+                                "type": "function",
+                                "function": {
+                                    "name": "test_tool",
+                                    "arguments": '{"arg": "value"}',
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        response = ProcessedResponse(content=json.dumps(tool_call_response))
+
+        swallow_result = ToolCallReactionResult(
+            should_swallow=True,
+            replacement_response="",
+            metadata={"handler": "test_handler"},
+        )
+
+        mock_reactor.process_tool_call.return_value = swallow_result
+
+        result = await middleware.process(
+            response=response,
+            session_id="test_session",
+            context={"backend_name": "test", "model_name": "test"},
+        )
+
+        assert isinstance(result, ProcessedResponse)
+        assert result is not response
+        assert result.content == ""
+        assert result.metadata["tool_call_swallowed"] is True
+
+    @pytest.mark.asyncio
     async def test_process_with_tool_calls_swallowed_merges_metadata(
         self, middleware, mock_reactor
     ):


### PR DESCRIPTION
## Summary
- ensure the tool call reactor middleware still swallows calls when handlers return an empty replacement response
- add a regression unit test covering the empty replacement scenario

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/test_tool_call_reactor_middleware.py
- python -m pytest -o addopts='' *(fails: missing pytest_asyncio, respx, pytest_httpx optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ec25355ce08333b87d0889ca85b9a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty replacement responses from tool-driven actions are now respected rather than ignored, preventing unintended fallback content and ensuring outputs can be intentionally blank when appropriate.
  * Preserves related metadata flags to accurately reflect when a tool call was swallowed.

* **Tests**
  * Added unit test to validate behavior when a swallowed tool call provides an empty replacement, ensuring the response content is empty and metadata is correctly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->