### PR TITLE
Honor STRICT_COMMAND_DETECTION environment flag

### DIFF
--- a/src/core/commands/service.py
+++ b/src/core/commands/service.py
@@ -8,6 +8,7 @@ from src.core.commands.handlers.failover_command_handler import (
 )
 from src.core.commands.parser import CommandParser
 from src.core.commands.registry import get_all_commands, get_command_handler
+from src.core.common.env_utils import get_env_flag
 from src.core.domain import chat as models
 from src.core.domain.chat import ChatMessage
 from src.core.domain.processed_result import ProcessedResult
@@ -43,6 +44,10 @@ class NewCommandService(ICommandService):
         """
         self.session_service = session_service
         self.command_parser = command_parser
+        if not strict_command_detection:
+            strict_command_detection = get_env_flag(
+                "STRICT_COMMAND_DETECTION", False
+            )
         self.strict_command_detection = strict_command_detection
         self._app_state = app_state
 

--- a/src/core/common/env_utils.py
+++ b/src/core/common/env_utils.py
@@ -1,0 +1,16 @@
+"""Utility helpers for environment-driven feature flags."""
+
+from __future__ import annotations
+
+import os
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def get_env_flag(name: str, default: bool) -> bool:
+    """Return a boolean flag sourced from the environment."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in _TRUE_VALUES

--- a/src/core/services/redaction_middleware.py
+++ b/src/core/services/redaction_middleware.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from src.core.domain.chat import ChatRequest, MessageContentPartText
 from src.core.interfaces.request_processor_interface import IRequestMiddleware
+from src.core.common.env_utils import get_env_flag
 from src.security import APIKeyRedactor, ProxyCommandFilter
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,10 @@ class RedactionMiddleware(IRequestMiddleware):
         """
         self._api_key_redactor = APIKeyRedactor(api_keys)
         self._command_filter = ProxyCommandFilter(command_prefix)
+        if not strict_command_detection:
+            strict_command_detection = get_env_flag(
+                "STRICT_COMMAND_DETECTION", False
+            )
         self._strict_command_detection = strict_command_detection
 
     async def process(

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,8 +1,7 @@
-"""
-Tests for the configuration module.
-"""
+"""Tests for the configuration module."""
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from src.core.config.app_config import (
@@ -50,6 +49,26 @@ def test_app_config_from_env(mock_env_vars: dict[str, str]) -> None:
     assert config.backends.openai.api_key
     assert len(config.backends.openrouter.api_key) > 0
     assert config.auth.disable_auth is True
+
+
+def test_command_service_respects_strict_command_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command service should enable strict mode via environment flag."""
+    from src.core.commands.parser import CommandParser
+    from src.core.commands.service import NewCommandService
+
+    monkeypatch.setenv("STRICT_COMMAND_DETECTION", "true")
+
+    service = NewCommandService(
+        session_service=Mock(),
+        command_parser=CommandParser(),
+        strict_command_detection=False,
+    )
+
+    assert service.strict_command_detection is True
+
+    monkeypatch.delenv("STRICT_COMMAND_DETECTION")
 
 
 # def test_legacy_config_loader():


### PR DESCRIPTION
## Summary
- add a shared environment flag helper for boolean feature toggles
- use the helper so command processing and redaction respect STRICT_COMMAND_DETECTION when config values are unset
- cover the new behaviour with a unit test exercising the environment flag

## Testing
- python -m pytest --override-ini addopts= tests/unit/core/test_config.py::test_command_service_respects_strict_command_env
- python -m pytest --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68ec2580a92883338037a8e0a42c4943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring strict command detection via the STRICT_COMMAND_DETECTION environment variable, enabling runtime control of stricter command parsing and redaction behavior without code changes.

* **Tests**
  * Added unit tests to verify that the STRICT_COMMAND_DETECTION environment variable correctly enables strict command detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->