### PR TITLE
Improve pytest full-suite detection heuristics

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -169,8 +169,8 @@ def _looks_like_full_suite(command: str) -> bool:
             continue
 
         if any(token.startswith(prefix) for prefix in allowed_flag_prefixes):
-            flag_name, _, _ = token.partition("=")
-            if flag_name in flags_requiring_value and not token.endswith("="):
+            flag_name, sep, inline_value = token.partition("=")
+            if flag_name in flags_requiring_value and (not sep or not inline_value):
                 skip_next_value = True
             continue
 

--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -122,12 +122,56 @@ def _looks_like_full_suite(command: str) -> bool:
     allowed_flag_prefixes = {"-", "--"}
     file_like_extensions = (".py", ".pyi")
 
+    skip_next_value = False
+    flags_requiring_value = {
+        "-k",
+        "-m",
+        "-c",
+        "-p",
+        "-o",
+        "-n",
+        "--maxfail",
+        "--deselect",
+        "--lfnf",
+        "--ffnf",
+        "--max-worker-restart",
+        "--max-workers",
+        "--dist",
+        "--tx",
+        "--cov",
+        "--cov-report",
+        "--rootdir",
+        "--basetemp",
+        "--junitxml",
+        "--resultlog",
+        "--log-cli-level",
+        "--log-cli-format",
+        "--log-cli-date-format",
+        "--log-file",
+        "--log-file-level",
+        "--log-file-format",
+        "--log-file-date-format",
+        "--durations",
+        "--max-slave-restart",
+        "--pdbcls",
+        "--pastebin",
+        "--reruns",
+        "--reruns-delay",
+        "--stepwise-skip",
+    }
+
     for token in tail:
+        if skip_next_value:
+            skip_next_value = False
+            continue
+
         if not token:
             continue
 
         if any(token.startswith(prefix) for prefix in allowed_flag_prefixes):
-            # Flags do not imply file selection; continue scanning
+            flag_name, _, _ = token.partition("=")
+            if flag_name in flags_requiring_value and not token.endswith("="):
+                skip_next_value = True
             continue
 
         # Strip trailing commas to handle cases like "pytest ,"
@@ -159,6 +203,9 @@ def _looks_like_full_suite(command: str) -> bool:
         # by considering any dotted path that is not a Python file extension as
         # a targeted run.
         if "." in candidate and not candidate.endswith(file_like_extensions):
+            return False
+
+        if re.fullmatch(r"[A-Za-z0-9_]+", candidate):
             return False
 
     return True

--- a/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
+++ b/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
@@ -22,6 +22,8 @@ from src.core.services.tool_call_handlers.pytest_full_suite_handler import (
         ("pytest some/test/path", False),
         ("pytest some/test/path::TestSuite::test_case", False),
         ("pytest tests.unit.test_example", False),
+        ("pytest test_module", False),
+        ("pytest -k slow", True),
         ("pytest .", True),
         ("pytest ./tests", False),
     ],


### PR DESCRIPTION
## Summary
- refine the pytest full-suite detector to ignore option values and treat bare module names as targeted runs
- extend the handler unit tests to cover module targets and ensure -k filtering still triggers the steering guard

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest -o addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68ec26beb3b0833397f9204b4e11ff80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of full pytest-suite runs: correctly handle flags that consume the following value and exclude plain alphanumeric identifiers from being treated as test targets.

* **Tests**
  * Expanded unit tests to cover additional CLI patterns (e.g., flag-with-value and plain-identifier cases) to validate detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->