### PR TITLE
Fix pytest command list parsing

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -61,7 +61,7 @@ def _extract_command(arguments: Any) -> str | None:
         command = arguments.get("command") or arguments.get("cmd")
         if isinstance(command, str) and command.strip():
             return command
-        if isinstance(command, list | tuple) and command:
+        if isinstance(command, (list, tuple)) and command:
             return " ".join(str(item) for item in command)
 
         for key in ("input", "body", "data"):
@@ -72,7 +72,7 @@ def _extract_command(arguments: Any) -> str | None:
                 sub = inner.get("command") or inner.get("cmd")
                 if isinstance(sub, str) and sub.strip():
                     return sub
-                if isinstance(sub, list | tuple) and sub:
+                if isinstance(sub, (list, tuple)) and sub:
                     return " ".join(str(item) for item in sub)
 
         args_list = arguments.get("args")


### PR DESCRIPTION
## Summary
- avoid union-type isinstance checks in the pytest full-suite handler so list-based commands no longer raise TypeError

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68ec26beb3b0833397f9204b4e11ff80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a type-check issue in command parsing that could cause errors when handling list or tuple inputs, ensuring the pytest full suite runs reliably.
  - Improved robustness of command and subcommand normalization by correctly detecting list and tuple inputs, preventing crashes and producing consistent command strings.
  - Enhances overall stability during test execution with no changes required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->