### PR TITLE
Fix OpenAI connector health check configuration

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -71,8 +71,8 @@ class OpenAIConnector(LLMBackend):
             "DISABLE_HEALTH_CHECKS", "false"
         ).lower() in ("true", "1", "yes")
 
-        disable_health_checks_config = self.config.get(
-            "session.dangerous_command_prevention_enabled", False
+        disable_health_checks_config = bool(
+            getattr(self.config, "disable_health_checks", False)
         )
 
         # Enable health checks only when neither config nor env disable them


### PR DESCRIPTION
## Summary
- ensure the OpenAI connector reads the dedicated disable_health_checks flag instead of the dangerous command prevention setting so health checks remain enabled by default

## Testing
- python -m pytest -o addopts="" tests/unit/openai_connector_tests/openai_logging_test.py
- python -m pytest -o addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68ec26beb3b0833397f9204b4e11ff80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated the health check toggle into a single configuration setting, replacing the previous nested key.
  - Default behavior remains unchanged; environments using the old key should switch to the new setting for consistent behavior.
  - No changes to public interfaces or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->