### PR TITLE
Fix structured capture redaction for deeply nested payloads

### DIFF
--- a/src/core/services/structured_wire_capture_service.py
+++ b/src/core/services/structured_wire_capture_service.py
@@ -261,15 +261,71 @@ class StructuredWireCapture(IWireCapture):
         return entry.model_dump()
 
     def _redact_payload(self, payload: Any) -> Any:
-        """Recursively redact sensitive information from payload."""
-        if isinstance(payload, dict):
-            return {k: self._redact_payload(v) for k, v in payload.items()}
-        elif isinstance(payload, list):
-            return [self._redact_payload(item) for item in payload]
-        elif isinstance(payload, str):
+        """Redact sensitive information from payload data structures."""
+
+        if isinstance(payload, str):
             return self._redactor.redact(payload)
+
+        if isinstance(payload, dict):
+            redacted_root: dict[Any, Any] = {}
+            stack: list[tuple[Any, Any]] = [(payload, redacted_root)]
+        elif isinstance(payload, list):
+            redacted_root = []
+            stack = [(payload, redacted_root)]
         else:
             return payload
+
+        # Iterative traversal avoids hitting Python's recursion depth when
+        # attackers supply deeply nested structures. Using a stack also keeps
+        # memory usage bounded to the size of the payload we need to redact.
+        #
+        # Each stack entry is a pair of (source_container, target_container).
+        # Containers are either dicts or lists depending on the originating
+        # value. Strings are redacted immediately while other scalar values are
+        # copied as-is.
+        processed_ids: set[int] = set()
+
+        while stack:
+            source, target = stack.pop()
+
+            # Skip already processed containers to avoid infinite loops if we
+            # ever encounter cyclic references (these are not expected for JSON
+            # payloads but this guard keeps the middleware resilient).
+            source_id = id(source)
+            if source_id in processed_ids:
+                continue
+            processed_ids.add(source_id)
+
+            if isinstance(source, dict) and isinstance(target, dict):
+                for key, value in source.items():
+                    if isinstance(value, str):
+                        target[key] = self._redactor.redact(value)
+                    elif isinstance(value, dict):
+                        child: dict[Any, Any] = {}
+                        target[key] = child
+                        stack.append((value, child))
+                    elif isinstance(value, list):
+                        child_list: list[Any] = []
+                        target[key] = child_list
+                        stack.append((value, child_list))
+                    else:
+                        target[key] = value
+            elif isinstance(source, list) and isinstance(target, list):
+                for item in source:
+                    if isinstance(item, str):
+                        target.append(self._redactor.redact(item))
+                    elif isinstance(item, dict):
+                        child = {}
+                        target.append(child)
+                        stack.append((item, child))
+                    elif isinstance(item, list):
+                        child_list = []
+                        target.append(child_list)
+                        stack.append((item, child_list))
+                    else:
+                        target.append(item)
+
+        return redacted_root
 
     def _extract_system_prompt(self, payload: Any) -> str | None:
         """Extract system prompt from payload if present."""

--- a/tests/unit/core/services/test_structured_wire_capture.py
+++ b/tests/unit/core/services/test_structured_wire_capture.py
@@ -1,12 +1,14 @@
 import json
 import os
 import tempfile
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from src.core.config.app_config import AppConfig
 from src.core.domain.request_context import RequestContext
 from src.core.services.structured_wire_capture_service import StructuredWireCapture
+from src.security import APIKeyRedactor
 
 
 @pytest.fixture
@@ -351,3 +353,40 @@ def test_extract_system_prompt(structured_wire_capture):
     # No system prompt
     no_system_payload = {"messages": [{"role": "user", "content": "Hello"}]}
     assert structured_wire_capture._extract_system_prompt(no_system_payload) is None
+
+
+def _build_deeply_nested_payload(depth: int, secret: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {"layers": []}
+    current: list[Any] = payload["layers"]
+    for _ in range(depth):
+        next_level: dict[str, Any] = {"nest": []}
+        current.append(next_level)
+        current = next_level["nest"]
+    current.append(secret)
+    return payload
+
+
+def test_redact_payload_handles_deeply_nested_structures(structured_wire_capture):
+    """Structured capture redaction must survive deeply nested payloads."""
+
+    secret = "sk-deep-secret"
+    structured_wire_capture._redactor = APIKeyRedactor([secret])
+
+    payload = _build_deeply_nested_payload(1500, secret)
+
+    redacted = structured_wire_capture._redact_payload(payload)
+
+    stack: list[Any] = [redacted]
+    found_redaction = False
+    while stack:
+        current = stack.pop()
+        if isinstance(current, str):
+            assert secret not in current
+            if "(API_KEY_HAS_BEEN_REDACTED)" in current:
+                found_redaction = True
+        elif isinstance(current, dict):
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+
+    assert found_redaction, "Redacted placeholder was not found in payload"


### PR DESCRIPTION
## Summary
- replace the recursive redaction helper in the structured wire capture service with an iterative stack-based traversal so extremely deep payloads can no longer trigger RecursionError crashes
- add a regression test that builds a >1000-level nested payload and verifies the redaction keeps the proxy safe from API key leaks

## Testing
- python -m pytest -o addopts="" tests/unit/core/services/test_structured_wire_capture.py
- python -m pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68ec26d70c8083338f26e9e0caaa409e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensitive data redaction to safely handle deeply nested or cyclic data without errors, preventing crashes and ensuring consistent placeholder output while preserving non-sensitive fields.

* **Refactor**
  * Reworked redaction logic to an iterative approach with cycle detection, enhancing robustness and stability for complex payloads.

* **Tests**
  * Added comprehensive tests for deeply nested structures to verify reliable API key redaction and correct placeholder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->