### PR TITLE
Fix dangerous command detection for mixed-case tool names

### DIFF
--- a/src/core/services/dangerous_command_service.py
+++ b/src/core/services/dangerous_command_service.py
@@ -11,6 +11,11 @@ from src.core.domain.configuration.dangerous_command_config import (
 class DangerousCommandService:
     def __init__(self, config: DangerousCommandConfig):
         self.config = config
+        # Normalize tool names once so lookups remain case-insensitive while
+        # preserving the original configuration for external access.
+        self._normalized_tool_names: set[str] = {
+            tool_name.lower() for tool_name in self.config.tool_names
+        }
 
     def scan_tool_call(
         self, tool_call: ToolCall
@@ -84,7 +89,8 @@ class DangerousCommandService:
 
         Returns matched rule and reconstructed command string, or None.
         """
-        if tool_name not in self.config.tool_names:
+        normalized_tool_name = tool_name.lower() if isinstance(tool_name, str) else ""
+        if normalized_tool_name not in self._normalized_tool_names:
             return None
 
         command_to_check = self._extract_command_string(arguments)

--- a/tests/unit/core/services/test_dangerous_command_service.py
+++ b/tests/unit/core/services/test_dangerous_command_service.py
@@ -103,6 +103,25 @@ def test_scan_tool_call_ignores_commands_with_safe_tool_names(
     assert result is None
 
 
+def test_scan_tool_call_handles_mixed_case_tool_names(
+    dangerous_command_service: DangerousCommandService,
+) -> None:
+    """Ensure detection works when tool names differ only by case."""
+    tool_call = ToolCall(
+        id="call_123",
+        function=FunctionCall(
+            name="Execute_Command", arguments="git reset --hard"
+        ),
+        type="function",
+    )
+
+    result = dangerous_command_service.scan_tool_call(tool_call)
+
+    assert result is not None
+    matched_rule, _ = result
+    assert matched_rule.name == "git-reset-hard"
+
+
 def test_scan_tool_call_extracts_command_from_json_arguments(
     dangerous_command_service: DangerousCommandService,
 ):


### PR DESCRIPTION
## Summary
- normalize dangerous command tool name checks so case-variants cannot bypass scanning
- add a regression test covering mixed-case tool names in tool calls

## Testing
- python -m pytest tests/unit/core/services/test_dangerous_command_service.py -o addopts=
- python -m pytest -o addopts= *(fails: missing pytest_asyncio, pytest_httpx, respx dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec26d70c8083338f26e9e0caaa409e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved dangerous-command detection to be case-insensitive for tool names, ensuring consistent protection regardless of capitalization.
- Tests
  - Added unit tests validating case-insensitive matching for tool-triggered dangerous commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->