### PR TITLE
Ensure streaming JSON repair propagates validation errors

### DIFF
--- a/src/core/services/streaming/json_repair_processor.py
+++ b/src/core/services/streaming/json_repair_processor.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 import src.core.services.metrics_service as metrics
-from src.core.common.exceptions import JSONParsingError
+from src.core.common.exceptions import JSONParsingError, ValidationError
 from src.core.domain.streaming_response_processor import (
     IStreamProcessor,
     StreamingContent,
@@ -164,6 +164,8 @@ class JsonRepairProcessor(IStreamProcessor):
                 success = True
         except Exception as e:  # pragma: no cover - strict mode rethrow
             if self._strict_mode:
+                if isinstance(e, (JSONParsingError, ValidationError)):
+                    raise
                 raise JSONParsingError(
                     message=f"JSON repair failed in strict mode: {e}",
                     details={"original_buffer": self._buffer},

--- a/tests/unit/json_repair_processor_test.py
+++ b/tests/unit/json_repair_processor_test.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
+from src.core.common.exceptions import ValidationError
 from src.core.domain.streaming_content import StreamingContent
 from src.core.services.json_repair_service import JsonRepairService
 from src.core.services.streaming.json_repair_processor import JsonRepairProcessor
@@ -18,6 +20,18 @@ class FailingJsonRepairService(JsonRepairService):
         strict: bool = False,
     ) -> dict[str, Any] | None:
         return None
+
+
+class RaisingValidationService(JsonRepairService):
+    """Test double that raises a ValidationError when strict mode is enabled."""
+
+    def repair_and_validate_json(
+        self,
+        json_string: str,
+        schema: dict[str, Any] | None = None,
+        strict: bool = False,
+    ) -> dict[str, Any] | None:
+        raise ValidationError(message="invalid", details={})
 
 
 def test_json_repair_processor_flushes_raw_buffer_when_repair_returns_none() -> None:
@@ -46,3 +60,16 @@ def test_json_repair_processor_appends_null_when_value_missing() -> None:
     result = asyncio.run(processor.process(chunk))
 
     assert result.content == '{"foo": null'
+
+
+def test_json_repair_processor_propagates_validation_error_in_strict_mode() -> None:
+    processor = JsonRepairProcessor(
+        repair_service=RaisingValidationService(),
+        buffer_cap_bytes=1024,
+        strict_mode=True,
+    )
+
+    chunk = StreamingContent(content='{"foo": "bar"}', is_done=True)
+
+    with pytest.raises(ValidationError):
+        asyncio.run(processor.process(chunk))


### PR DESCRIPTION
## Summary
- ensure the streaming JSON repair processor re-raises existing JSONParsingError and ValidationError instances in strict mode instead of wrapping them
- add a regression test covering ValidationError propagation for strict streaming repair

## Testing
- python -m pytest --override-ini=addopts='' tests/unit/json_repair_processor_test.py
- python -m pytest --override-ini=addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68ec26ffb7448333ace9a74c4ba180a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict mode behavior in streaming JSON processing: validation-related failures are now surfaced directly to callers, aligning with parsing error handling and providing clearer, more actionable error feedback.

* **Tests**
  * Added unit tests to verify that strict mode correctly propagates validation failures during JSON repair and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->