### PR TITLE
Fix streaming guard in JSON repair middleware

### DIFF
--- a/src/core/app/middleware/json_repair_middleware.py
+++ b/src/core/app/middleware/json_repair_middleware.py
@@ -40,7 +40,7 @@ class JsonRepairMiddleware(IResponseMiddleware):
             return response
 
         # Skip for streaming chunks; handled by JsonRepairProcessor in pipeline
-        if context.get("response_type") == "stream":
+        if is_streaming or context.get("response_type") == "stream":
             return response
 
         if isinstance(response.content, str):

--- a/tests/unit/core/services/test_json_repair_middleware.py
+++ b/tests/unit/core/services/test_json_repair_middleware.py
@@ -103,3 +103,30 @@ async def test_process_response_best_effort_failure_metrics(
 
     assert metric_calls
     assert metric_calls[-1] == "json_repair.non_streaming.best_effort_fail"
+
+
+async def test_streaming_response_skips_repair(
+    json_repair_middleware: JsonRepairMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_repair(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Streaming responses should bypass JSON repair")
+
+    monkeypatch.setattr(
+        json_repair_middleware.json_repair_service,
+        "repair_and_validate_json",
+        fail_repair,
+    )
+
+    response = ProcessedResponse(content='{"partial": ')
+
+    processed_response = await json_repair_middleware.process(
+        response,
+        "session_id",
+        {},
+        is_streaming=True,
+    )
+
+    assert processed_response is response
+    assert processed_response.content == '{"partial": '
+    assert "repaired" not in processed_response.metadata


### PR DESCRIPTION
## Summary
- update the JSON repair middleware to respect the `is_streaming` flag so streaming chunks bypass post-processing
- add a unit test that asserts streaming responses skip the repair service

## Testing
- python -m pytest -c /tmp/pytest.ini tests/unit/core/services/test_json_repair_middleware.py
- python -m pytest -c /tmp/pytest_repo.ini *(fails: missing pytest_asyncio, respx, pytest_httpx, hypothesis dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec26ffb7448333ace9a74c4ba180a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streaming responses now explicitly bypass JSON repair when streaming is detected, reducing latency and preserving original streamed content. Non-streaming behavior remains unchanged.
- Bug Fixes
  - Prevents unnecessary JSON repair attempts during streaming, improving reliability of live outputs.
- Tests
  - Added unit test to verify that streaming responses skip the repair path and return content unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->