### PR TITLE
Fix session service validator coroutine handling

### DIFF
--- a/src/core/testing/interfaces.py
+++ b/src/core/testing/interfaces.py
@@ -68,11 +68,7 @@ class TestServiceValidator:
                     "properly configured MagicMock instead."
                 )
 
-            if inspect.iscoroutinefunction(method):
-                raise TypeError(
-                    f"Session service {type(service).__name__}.get_session is a coroutine "
-                    "function but should be synchronous. This will cause coroutine warnings."
-                )
+            is_coroutine = inspect.iscoroutinefunction(method)
 
             try:
                 result = method("test_session_id")
@@ -87,11 +83,25 @@ class TestServiceValidator:
                 if inspect.isawaitable(result):
                     close = getattr(result, "close", None)
                     if callable(close):
-                        close()
+                        try:
+                            close()
+                        except Exception:
+                            if logger.isEnabledFor(logging.DEBUG):
+                                logger.debug(
+                                    "Failed to close coroutine produced during validation",
+                                    exc_info=True,
+                                )
+
+                    if not is_coroutine:
+                        raise TypeError(
+                            f"Session service {type(service).__name__}.get_session() returns an "
+                            "awaitable but the method is not async. This will cause coroutine "
+                            "warnings."
+                        )
+                elif is_coroutine:
                     raise TypeError(
-                        f"Session service {type(service).__name__}.get_session() returns an "
-                        "awaitable but the method is not async. This will cause coroutine "
-                        "warnings."
+                        f"Session service {type(service).__name__}.get_session is async but "
+                        "returned a non-awaitable result when called."
                     )
 
             except (TypeError, AttributeError) as e:

--- a/tests/unit/core/testing/test_interfaces.py
+++ b/tests/unit/core/testing/test_interfaces.py
@@ -72,19 +72,16 @@ class TestTestServiceValidator:
             TestServiceValidator.validate_session_service(mock_service)
 
     def test_validate_session_service_with_coroutine(self) -> None:
-        """Test validation with a service that returns coroutine function (should raise TypeError)."""
+        """Test validation with a proper coroutine implementation."""
         mock_service = MagicMock(spec=ISessionService)
 
-        async def bad_get_session(session_id: str) -> Session:
+        async def good_get_session(session_id: str) -> Session:
             return Session(session_id)
 
-        mock_service.get_session = bad_get_session
+        mock_service.get_session = good_get_session
 
-        # Should raise exception - coroutine functions cause coroutine warnings
-        with pytest.raises(
-            TypeError, match="is a coroutine function but should be synchronous"
-        ):
-            TestServiceValidator.validate_session_service(mock_service)
+        # Should not raise any exception for well-behaved coroutine implementations
+        TestServiceValidator.validate_session_service(mock_service)
 
     def test_validate_sync_method_with_async_mock(self) -> None:
         """Test validation of sync method that is AsyncMock."""


### PR DESCRIPTION
## Summary
- allow `TestServiceValidator.validate_session_service` to handle coroutine-based `get_session` implementations while preserving AsyncMock safeguards
- update the validator test suite to assert the coroutine-friendly behavior

## Testing
- python -m pytest --override-ini=addopts="" tests/unit/core/testing/test_interfaces.py
- python -m pytest --override-ini=addopts="" *(fails: missing pytest_asyncio, respx, pytest_httpx, hypothesis dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec26ffb7448333ace9a74c4ba180a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly handles async get_session implementations without raising erroneous TypeErrors.
  - Adds guarded close() handling for awaitable results with debug logging on failures.
  - Provides clearer, more accurate error messages for mismatched async/sync implementations.
- Refactor
  - Centralized coroutine detection and validation for session services to improve reliability.
- Tests
  - Updated unit tests to validate proper coroutine behavior and remove outdated TypeError expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->