### PR TITLE
Optimize tool call reactor handler ordering cache

### DIFF
--- a/src/core/services/tool_call_reactor_service.py
+++ b/src/core/services/tool_call_reactor_service.py
@@ -41,6 +41,7 @@ class ToolCallReactorService(IToolCallReactor):
         self._handlers: dict[str, IToolCallHandler] = {}
         self._history_tracker = history_tracker
         self._lock = asyncio.Lock()
+        self._handlers_cache: tuple[IToolCallHandler, ...] | None = None
 
     def register_handler_sync(self, handler: IToolCallHandler) -> None:
         """Register a tool call handler synchronously.
@@ -61,6 +62,7 @@ class ToolCallReactorService(IToolCallReactor):
             )
 
         self._handlers[handler.name] = handler
+        self._invalidate_handler_cache()
         logger.info(f"Registered tool call handler synchronously: {handler.name}")
 
     async def register_handler(self, handler: IToolCallHandler) -> None:
@@ -79,6 +81,7 @@ class ToolCallReactorService(IToolCallReactor):
                 )
 
             self._handlers[handler.name] = handler
+            self._invalidate_handler_cache()
             logger.info(f"Registered tool call handler: {handler.name}")
 
     async def unregister_handler(self, handler_name: str) -> None:
@@ -97,6 +100,7 @@ class ToolCallReactorService(IToolCallReactor):
                 )
 
             del self._handlers[handler_name]
+            self._invalidate_handler_cache()
             logger.info(f"Unregistered tool call handler: {handler_name}")
 
     async def process_tool_call(
@@ -139,11 +143,7 @@ class ToolCallReactorService(IToolCallReactor):
             )
 
         # Get handlers sorted by priority (highest first)
-        handlers = sorted(
-            self._handlers.values(),
-            key=lambda h: h.priority,
-            reverse=True,
-        )
+        handlers = self._get_handlers_by_priority()
 
         # Process through handlers
         for handler in handlers:
@@ -182,6 +182,24 @@ class ToolCallReactorService(IToolCallReactor):
             List of handler names.
         """
         return list(self._handlers.keys())
+
+    def _invalidate_handler_cache(self) -> None:
+        """Invalidate the cached handler ordering."""
+        self._handlers_cache = None
+
+    def _get_handlers_by_priority(self) -> tuple[IToolCallHandler, ...]:
+        """Return handlers sorted by priority, caching the order."""
+        cached_handlers = self._handlers_cache
+        if cached_handlers is None:
+            cached_handlers = tuple(
+                sorted(
+                    self._handlers.values(),
+                    key=lambda handler: handler.priority,
+                    reverse=True,
+                )
+            )
+            self._handlers_cache = cached_handlers
+        return cached_handlers
 
 
 class InMemoryToolCallHistoryTracker(IToolCallHistoryTracker):

--- a/tests/unit/core/services/test_tool_call_reactor_service.py
+++ b/tests/unit/core/services/test_tool_call_reactor_service.py
@@ -275,6 +275,50 @@ class TestToolCallReactorService:
         assert low_priority_handler.handle_call_count == 1
 
     @pytest.mark.asyncio
+    async def test_handler_cache_refresh_after_unregister(self, reactor):
+        """Handler ordering cache should refresh after unregister events."""
+
+        swallowing_result = ToolCallReactionResult(
+            should_swallow=True,
+            replacement_response="handled",
+        )
+        primary_handler = MockToolCallHandler(
+            "primary",
+            priority=100,
+            can_handle_return=True,
+            handle_result=swallowing_result,
+        )
+        secondary_handler = MockToolCallHandler(
+            "secondary",
+            priority=10,
+            can_handle_return=True,
+            handle_result=swallowing_result,
+        )
+
+        await reactor.register_handler(secondary_handler)
+        await reactor.register_handler(primary_handler)
+
+        context = ToolCallContext(
+            session_id="test_session",
+            backend_name="test_backend",
+            model_name="test_model",
+            full_response='{"content": "test"}',
+            tool_name="test_tool",
+            tool_arguments={"arg": "value"},
+        )
+
+        result_first = await reactor.process_tool_call(context)
+        assert result_first is not None and result_first.should_swallow is True
+        assert primary_handler.handle_call_count == 1
+        assert secondary_handler.handle_call_count == 0
+
+        await reactor.unregister_handler(primary_handler.name)
+
+        result_second = await reactor.process_tool_call(context)
+        assert result_second is not None and result_second.should_swallow is True
+        assert secondary_handler.handle_call_count == 1
+
+    @pytest.mark.asyncio
     async def test_process_tool_call_handler_error_handling(self, reactor):
         """Test that handler errors don't crash the reactor."""
 


### PR DESCRIPTION
## Summary
- cache the priority-sorted handler list inside `ToolCallReactorService` and refresh it on registration changes
- add a regression test to ensure the cached ordering updates after a handler is unregistered

## Testing
- `python -m pytest -c /tmp/pytest.ini tests/unit/core/services/test_tool_call_reactor_service.py`
- `python -m pytest -c /tmp/pytest.ini` *(fails: missing optional test dependencies such as pytest_asyncio, respx, pytest_httpx, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68ec27b5f5f08333be56cce2d6aca430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures the correct handler is selected after unregistering, preventing stale ordering issues during processing.
- Refactor
  - Introduced caching for handler prioritization to reduce redundant work and improve responsiveness, with automatic cache refresh on handler changes.
- Tests
  - Added coverage to verify the handler ordering cache refreshes correctly after a handler is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->