### PR TITLE
Avoid redundant canonical chat request cloning

### DIFF
--- a/src/core/services/translation_service.py
+++ b/src/core/services/translation_service.py
@@ -130,7 +130,10 @@ class TranslationService:
             ChatRequest as _ChatRequest,
         )
 
-        if isinstance(request, _Canonical | _ChatRequest):
+        if isinstance(request, _Canonical):
+            return request
+
+        if isinstance(request, _ChatRequest):
             return _Canonical.model_validate(request.model_dump())
 
         if source_format == "responses":

--- a/tests/unit/core/services/test_translation_service.py
+++ b/tests/unit/core/services/test_translation_service.py
@@ -12,6 +12,18 @@ def test_translation_service_initialization():
     assert service is not None, "TranslationService should initialize without errors."
 
 
+def test_to_domain_request_returns_same_instance_for_canonical_request():
+    service = TranslationService()
+    canonical_request = CanonicalChatRequest(
+        model="test-model",
+        messages=[ChatMessage(role="user", content="ping")],
+    )
+
+    result = service.to_domain_request(canonical_request, "openai")
+
+    assert result is canonical_request
+
+
 def test_to_domain_request_gemini():
     service = TranslationService()
     gemini_request = {


### PR DESCRIPTION
## Summary
- return canonical chat requests directly in `TranslationService.to_domain_request` instead of cloning them
- add a regression test to ensure canonical requests bypass re-validation and reuse the existing object

## Testing
- `python -m pytest -o addopts= tests/unit/core/services/test_translation_service.py::test_to_domain_request_returns_same_instance_for_canonical_request`
- `python -m pytest -o addopts=` (fails: missing optional dev dependencies such as pytest-asyncio, respx, pytest-httpx)

------
https://chatgpt.com/codex/tasks/task_e_68ec27b5f5f08333be56cce2d6aca430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified internal request handling by using explicit branches for different input types, improving readability and maintainability without changing behavior or outputs.
* **Tests**
  * Added a unit test to verify canonical requests are returned unchanged, reinforcing contract and preventing regressions.

No user-facing changes; existing translation behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->