### PR TITLE
Fix gemini-cli-acp backend caching without session context

### DIFF
--- a/src/core/services/backend_service.py
+++ b/src/core/services/backend_service.py
@@ -780,15 +780,17 @@ class BackendService(IBackendService):
     ) -> LLMBackend:
         """Get an existing backend or create a new one."""
 
-        cache_key = backend_type
-        if backend_type == "gemini-cli-acp":
-            cache_key = (
-                f"{backend_type}:{session_id}"
-                if session_id
-                else f"{backend_type}:default"
-            )
+        cache_key: str | None = backend_type
+        should_cache_backend = True
 
-        if cache_key in self._backends:
+        if backend_type == "gemini-cli-acp":
+            if session_id:
+                cache_key = f"{backend_type}:{session_id}"
+            else:
+                cache_key = None
+                should_cache_backend = False
+
+        if cache_key is not None and cache_key in self._backends:
             return self._backends[cache_key]
 
         try:
@@ -818,7 +820,8 @@ class BackendService(IBackendService):
             backend: LLMBackend = await self._factory.ensure_backend(
                 backend_type, app_config, provider_backend_config
             )
-            self._backends[cache_key] = backend
+            if should_cache_backend and cache_key is not None:
+                self._backends[cache_key] = backend
             return backend
         except (TypeError, ValueError, AttributeError, KeyError) as e:
             raise BackendError(

--- a/tests/unit/core/services/test_backend_service_targeted.py
+++ b/tests/unit/core/services/test_backend_service_targeted.py
@@ -256,6 +256,29 @@ class TestBackendServiceTargeted:
         assert ensure_mock.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_gemini_cli_acp_without_session_id_creates_fresh_backend(self):
+        """Anonymous gemini-cli-acp calls must not reuse cached connectors."""
+
+        service = create_backend_service()
+
+        backend_one = MockBackend(httpx.AsyncClient())
+        backend_two = MockBackend(httpx.AsyncClient())
+
+        ensure_mock = AsyncMock(side_effect=[backend_one, backend_two])
+
+        with patch.object(service._factory, "ensure_backend", ensure_mock):
+            first = await service._get_or_create_backend(
+                "gemini-cli-acp", session_id=None
+            )
+            second = await service._get_or_create_backend(
+                "gemini-cli-acp", session_id=None
+            )
+
+        assert first is backend_one
+        assert second is backend_two
+        assert ensure_mock.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_chat_completions_forwards_control_flags(self):
         """Ensure chat_completions forwards failover and context to call_completion."""
 


### PR DESCRIPTION
## Summary
- avoid caching gemini-cli-acp backend instances when no session id is available to prevent state from bleeding across sessions
- add coverage that anonymous gemini-cli-acp calls resolve to fresh backend instances

## Testing
- python -m pytest tests/unit/core/services/test_backend_service_targeted.py -k gemini --override-ini addopts=""
- python -m pytest --override-ini addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68ec2612fdc483338010970ed1903ec5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a unit test to verify that anonymous CLI calls without a session ID create fresh backend instances rather than reusing cached connections.
  * Ensures multiple invocations produce distinct instances and strengthens coverage of backend creation behavior.
  * Improves reliability and guards against unintended cross-session leakage.
  * No runtime or API changes; this is a non-functional improvement focused on test robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->