### PR TITLE
Ensure Gemini endpoints resolve session contexts

### DIFF
--- a/src/core/app/controllers/__init__.py
+++ b/src/core/app/controllers/__init__.py
@@ -43,12 +43,67 @@ from src.core.constants import (
 
 # Import domain models for type annotations
 from src.core.domain.chat import ChatRequest as DomainChatRequest
+from src.core.domain.request_context import RequestContext
 
 # Using SOLID architecture directly with DI-managed services
 from src.core.interfaces.di_interface import IServiceProvider
 from src.core.interfaces.request_processor_interface import IRequestProcessor
+from src.core.interfaces.session_resolver_interface import ISessionResolver
+from src.core.transport.fastapi.request_adapters import (
+    fastapi_to_domain_request_context,
+)
 
 logger = logging.getLogger(__name__)
+
+
+async def _attach_session_context(
+    service_provider: IServiceProvider,
+    request: Request,
+    domain_request: DomainChatRequest,
+) -> tuple[DomainChatRequest, RequestContext]:
+    """Resolve and attach session context information to a chat request."""
+
+    ctx = fastapi_to_domain_request_context(request, attach_original=True)
+    with contextlib.suppress(Exception):
+        ctx.domain_request = domain_request  # type: ignore[attr-defined]
+
+    session_resolver = service_provider.get_required_service(ISessionResolver)
+
+    session_id_candidate = getattr(domain_request, "session_id", None)
+    if isinstance(session_id_candidate, str):
+        session_id_candidate = session_id_candidate.strip() or None
+    else:
+        session_id_candidate = None
+
+    extra_body_source = (
+        domain_request.extra_body
+        if isinstance(domain_request.extra_body, dict)
+        else {}
+    )
+    if not session_id_candidate:
+        extra_candidate = extra_body_source.get("session_id")
+        if isinstance(extra_candidate, str):
+            session_id_candidate = extra_candidate.strip() or None
+
+    if session_id_candidate:
+        ctx.session_id = session_id_candidate
+
+    resolved_session_id = await session_resolver.resolve_session_id(ctx)
+    ctx.session_id = resolved_session_id
+
+    updated_extra_body = dict(extra_body_source)
+    updated_extra_body["session_id"] = resolved_session_id
+    domain_request = domain_request.model_copy(
+        update={
+            "session_id": resolved_session_id,
+            "extra_body": updated_extra_body,
+        }
+    )
+
+    with contextlib.suppress(Exception):
+        ctx.domain_request = domain_request  # type: ignore[attr-defined]
+
+    return domain_request, ctx
 
 
 def _get_strict_controller_errors() -> bool:
@@ -467,8 +522,11 @@ def register_versioned_endpoints(app: FastAPI) -> None:
 
             # Try to call the backend - if it fails, provide fallback response
             try:
-                # Check if there's a mock backend on app.state (test scenario)
                 app_state = request.app.state
+                domain_request, ctx = await _attach_session_context(
+                    service_provider, request, domain_request
+                )
+
                 if (
                     hasattr(app_state, "openrouter_backend")
                     and app_state.openrouter_backend
@@ -490,48 +548,31 @@ def register_versioned_endpoints(app: FastAPI) -> None:
                     )
 
                     return canonical_response_to_gemini_response(mock_content)
-                else:
-                    # Call the backend service using the public call_completion method
-                    result = await backend_service.call_completion(domain_request)
 
-                    # Convert the domain response to Gemini format
-                    if hasattr(result, "content"):
-                        if isinstance(result.content, dict):
-                            # Convert OpenAI format response to Gemini format
-                            from src.core.domain.gemini_translation import (
-                                canonical_response_to_gemini_response,
-                            )
+                # Call the backend service using the public call_completion method
+                result = await backend_service.call_completion(
+                    domain_request,
+                    stream=bool(domain_request.stream),
+                    context=ctx,
+                )
 
-                            return canonical_response_to_gemini_response(result.content)
-                        else:
-                            # For other response types, provide a basic Gemini response
-                            response_text = str(result.content)
-                            return {
-                                "candidates": [
-                                    {
-                                        "content": {
-                                            "parts": [{"text": response_text}],
-                                            "role": "model",
-                                        },
-                                        "finishReason": "STOP",
-                                        "index": 0,
-                                    }
-                                ],
-                                "usageMetadata": {
-                                    "promptTokenCount": 10,
-                                    "candidatesTokenCount": 20,
-                                    "totalTokenCount": 30,
-                                },
-                            }
+                # Convert the domain response to Gemini format
+                if hasattr(result, "content"):
+                    if isinstance(result.content, dict):
+                        # Convert OpenAI format response to Gemini format
+                        from src.core.domain.gemini_translation import (
+                            canonical_response_to_gemini_response,
+                        )
+
+                        return canonical_response_to_gemini_response(result.content)
                     else:
-                        # Fallback for unexpected response format
+                        # For other response types, provide a basic Gemini response
+                        response_text = str(result.content)
                         return {
                             "candidates": [
                                 {
                                     "content": {
-                                        "parts": [
-                                            {"text": "Response processed successfully."}
-                                        ],
+                                        "parts": [{"text": response_text}],
                                         "role": "model",
                                     },
                                     "finishReason": "STOP",
@@ -544,6 +585,27 @@ def register_versioned_endpoints(app: FastAPI) -> None:
                                 "totalTokenCount": 30,
                             },
                         }
+                else:
+                    # Fallback for unexpected response format
+                    return {
+                        "candidates": [
+                            {
+                                "content": {
+                                    "parts": [
+                                        {"text": "Response processed successfully."}
+                                    ],
+                                    "role": "model",
+                                },
+                                "finishReason": "STOP",
+                                "index": 0,
+                            }
+                        ],
+                        "usageMetadata": {
+                            "promptTokenCount": 10,
+                            "candidatesTokenCount": 20,
+                            "totalTokenCount": 30,
+                        },
+                    }
             except Exception as e:
                 # Check if it's an HTTPException that should be re-raised
                 if isinstance(e, HTTPException):
@@ -638,11 +700,17 @@ def register_versioned_endpoints(app: FastAPI) -> None:
             # Get backend service
             backend_service = service_provider.get_required_service(IBackendService)  # type: ignore[type-abstract]
 
+            domain_request, ctx = await _attach_session_context(
+                service_provider, request, domain_request
+            )
+
             async def generate_stream() -> AsyncGenerator[bytes, None]:
 
                 try:
                     # Call the backend service
-                    result = await backend_service.call_completion(domain_request)
+                    result = await backend_service.call_completion(
+                        domain_request, stream=True, context=ctx
+                    )
 
                     if hasattr(result, "content") and hasattr(
                         result.content, "__aiter__"

--- a/tests/unit/chat_completions_tests/test_gemini_api_compatibility_di.py
+++ b/tests/unit/chat_completions_tests/test_gemini_api_compatibility_di.py
@@ -7,6 +7,7 @@ refactored to use proper dependency injection instead of direct app.state access
 
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -16,9 +17,12 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
 from fastapi.testclient import TestClient
+from src.core.domain.chat import ChatMessage, ChatRequest
 from src.core.domain.responses import StreamingResponseEnvelope
 from src.core.interfaces.backend_service_interface import IBackendService
 from src.core.interfaces.response_processor_interface import ProcessedResponse
+from src.core.interfaces.session_resolver_interface import ISessionResolver
+from src.core.services.translation_service import TranslationService
 from src.rate_limit import RateLimitRegistry
 
 from tests.utils.test_di_utils import (
@@ -234,6 +238,84 @@ class TestGeminiGenerateContent:
                 assert "message" in data["error"]
                 assert "Model not found" in data["error"]["message"]
 
+    def test_generate_content_resolves_session_context(
+        self, gemini_client, monkeypatch
+    ) -> None:
+        """Gemini compatibility endpoint should isolate sessions via resolver."""
+
+        backend_service = get_required_service_from_app(
+            gemini_client.app, IBackendService
+        )
+        backend_service.call_completion = AsyncMock(
+            return_value=SimpleNamespace(content="ok")
+        )
+
+        session_resolver = AsyncMock(spec=ISessionResolver)
+        session_resolver.resolve_session_id.return_value = "resolved-session"
+        service_provider = gemini_client.app.state.service_provider
+
+        original_get_required = service_provider.get_required_service
+        original_get_service = service_provider.get_service
+
+        def _get_required(service_type: type[Any]) -> Any:
+            if service_type is ISessionResolver:
+                return session_resolver
+            return original_get_required(service_type)
+
+        def _get_service(service_type: type[Any]) -> Any:
+            if service_type is ISessionResolver:
+                return session_resolver
+            return original_get_service(service_type)
+
+        monkeypatch.setattr(service_provider, "get_required_service", _get_required)
+        monkeypatch.setattr(service_provider, "get_service", _get_service)
+
+        gemini_client.app.state.openrouter_backend = None
+
+        translation_service = service_provider.get_required_service(TranslationService)
+
+        def _to_domain_request(
+            data: dict[str, Any], source_format: str = "gemini"
+        ) -> ChatRequest:
+            return ChatRequest(
+                model="gemini-pro",
+                messages=[ChatMessage(role="user", content="Tell me a joke")],
+                stream=bool(data.get("stream")),
+                extra_body={},
+            )
+
+        monkeypatch.setattr(translation_service, "to_domain_request", _to_domain_request)
+
+        request_data = {
+            "contents": [
+                {
+                    "parts": [{"text": "Tell me a joke"}],
+                    "role": "user",
+                }
+            ],
+            "generationConfig": {"temperature": 0.5},
+        }
+
+        response = gemini_client.post(
+            "/v1beta/models/gemini-pro:generateContent", json=request_data
+        )
+
+        assert response.status_code == 200
+        assert session_resolver.resolve_session_id.await_count == 1
+
+        call = backend_service.call_completion.await_args
+        ctx = call.kwargs.get("context")
+        assert ctx is not None
+        assert ctx.session_id == "resolved-session"
+
+        request_arg = call.args[0]
+        assert request_arg.session_id == "resolved-session"
+        assert request_arg.extra_body is not None
+        assert request_arg.extra_body.get("session_id") == "resolved-session"
+
+        resolver_context = session_resolver.resolve_session_id.await_args.args[0]
+        assert resolver_context is ctx
+
 
 class TestGeminiStreamGenerateContent:
     """Test the Gemini streaming content generation endpoint."""
@@ -355,6 +437,95 @@ class TestGeminiStreamGenerateContent:
             assert data["candidates"]
             first_part = data["candidates"][0]["content"]["parts"][0]
             assert first_part["text"] == "Hello"
+
+    def test_stream_generate_content_resolves_session_context(
+        self, gemini_client, monkeypatch
+    ) -> None:
+        """Streaming endpoint should also resolve session context."""
+
+        backend_service = get_required_service_from_app(
+            gemini_client.app, IBackendService
+        )
+
+        async def stream_chunks():
+            yield ProcessedResponse(content="chunk")
+
+        backend_service.call_completion = AsyncMock(
+            return_value=SimpleNamespace(content=stream_chunks())
+        )
+
+        session_resolver = AsyncMock(spec=ISessionResolver)
+        session_resolver.resolve_session_id.return_value = "stream-session"
+        service_provider = gemini_client.app.state.service_provider
+
+        original_get_required = service_provider.get_required_service
+        original_get_service = service_provider.get_service
+
+        def _get_required(service_type: type[Any]) -> Any:
+            if service_type is ISessionResolver:
+                return session_resolver
+            return original_get_required(service_type)
+
+        def _get_service(service_type: type[Any]) -> Any:
+            if service_type is ISessionResolver:
+                return session_resolver
+            return original_get_service(service_type)
+
+        monkeypatch.setattr(service_provider, "get_required_service", _get_required)
+        monkeypatch.setattr(service_provider, "get_service", _get_service)
+
+        gemini_client.app.state.openrouter_backend = None
+
+        translation_service = service_provider.get_required_service(TranslationService)
+
+        def _to_domain_request(
+            data: dict[str, Any], source_format: str = "gemini"
+        ) -> ChatRequest:
+            return ChatRequest(
+                model="gemini-pro",
+                messages=[
+                    ChatMessage(role="user", content="Stream context please")
+                ],
+                stream=bool(data.get("stream")),
+                extra_body={},
+            )
+
+        monkeypatch.setattr(translation_service, "to_domain_request", _to_domain_request)
+
+        request_data = {
+            "contents": [
+                {
+                    "parts": [{"text": "Stream context please"}],
+                    "role": "user",
+                }
+            ],
+            "generationConfig": {"temperature": 0.1},
+            "stream": True,
+        }
+
+        with gemini_client.stream(
+            "POST",
+            "/v1beta/models/gemini-pro:streamGenerateContent",
+            json=request_data,
+        ) as response:
+            assert response.status_code == 200
+            list(response.iter_lines())
+
+        assert session_resolver.resolve_session_id.await_count == 1
+
+        call = backend_service.call_completion.await_args
+        ctx = call.kwargs.get("context")
+        assert ctx is not None
+        assert ctx.session_id == "stream-session"
+        assert call.kwargs.get("stream") is True
+
+        request_arg = call.args[0]
+        assert request_arg.session_id == "stream-session"
+        assert request_arg.extra_body is not None
+        assert request_arg.extra_body.get("session_id") == "stream-session"
+
+        resolver_context = session_resolver.resolve_session_id.await_args.args[0]
+        assert resolver_context is ctx
 
 
 class TestGeminiAuthentication:


### PR DESCRIPTION
## Summary
- add a reusable helper that resolves session IDs for Gemini requests and ensures the backend call receives the prepared context
- teach both synchronous and streaming Gemini endpoints to use the helper while respecting any test double shortcuts
- extend Gemini compatibility tests with coverage that verifies the resolver is invoked for each request

## Testing
- pytest -o addopts="" tests/unit/chat_completions_tests/test_gemini_api_compatibility_di.py
- pytest -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68ec2612fdc483338010970ed1903ec5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session-aware chat responses for Gemini endpoints, with session context propagated to both standard and streaming requests.
  * Support for a mock backend in development, with outputs normalized to Gemini format.

* **Bug Fixes**
  * Consistent Gemini-formatted responses across edge cases, including non-dict or missing content.
  * Improved fallbacks and error handling for unexpected backend outputs in both streaming and non-streaming paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->