### PR TITLE
Fix loop detector cross-session leakage

### DIFF
--- a/src/core/domain/streaming_response_processor.py
+++ b/src/core/domain/streaming_response_processor.py
@@ -7,8 +7,10 @@ responses in a consistent way, regardless of the source or format.
 
 from __future__ import annotations
 
+import copy
 import logging
 from abc import ABC, abstractmethod
+from typing import Any
 
 from src.core.domain.streaming_content import StreamingContent
 
@@ -49,7 +51,8 @@ class LoopDetectionProcessor(IStreamProcessor):
         Args:
             loop_detector: The loop detector instance to use.
         """
-        self.loop_detector = loop_detector
+        self._base_detector = loop_detector
+        self._stream_detectors: dict[str, ILoopDetector] = {}
 
     async def process(self, content: StreamingContent) -> StreamingContent:
         """Process a streaming content chunk and check for loops.
@@ -67,16 +70,76 @@ class LoopDetectionProcessor(IStreamProcessor):
         # Process the content for loop detection
         # Ensure content is a string for the loop detector
         content_str = content.content
-        detection_event = self.loop_detector.process_chunk(content_str)
+        stream_id = self._extract_stream_id(content)
+        detector = self._get_detector_for_stream(stream_id)
+        detection_event = detector.process_chunk(content_str)
 
         if detection_event:
             logger.warning(
                 f"Loop detected in streaming response by LoopDetectionProcessor: {detection_event.pattern[:50]}..."
             )
+            self._cleanup_stream_detector(stream_id)
             return self._create_cancellation_content(detection_event)
-        else:
-            # No loop detected, pass through the content
-            return content
+
+        if content.is_done or content.is_cancellation:
+            self._cleanup_stream_detector(stream_id)
+
+        # No loop detected, pass through the content
+        return content
+
+    def reset(self) -> None:
+        """Reset cached detector state for all active streams."""
+
+        self._stream_detectors.clear()
+        self._reset_detector(self._base_detector)
+
+    def _extract_stream_id(self, content: StreamingContent) -> str | None:
+        metadata: dict[str, Any] = content.metadata if isinstance(content.metadata, dict) else {}
+        stream_id = metadata.get("stream_id")
+        if stream_id is None:
+            return None
+        return str(stream_id)
+
+    def _get_detector_for_stream(self, stream_id: str | None) -> ILoopDetector:
+        if not stream_id:
+            return self._base_detector
+
+        detector = self._stream_detectors.get(stream_id)
+        if detector is None:
+            detector = self._clone_base_detector()
+            self._stream_detectors[stream_id] = detector
+        return detector
+
+    def _clone_base_detector(self) -> ILoopDetector:
+        try:
+            clone = copy.deepcopy(self._base_detector)
+        except Exception:
+            logger.warning(
+                "Falling back to shared loop detector instance; could not isolate stream state",
+                exc_info=True,
+            )
+            clone = self._base_detector
+
+        self._reset_detector(clone)
+        return clone
+
+    def _cleanup_stream_detector(self, stream_id: str | None) -> None:
+        if not stream_id:
+            self._reset_detector(self._base_detector)
+            return
+
+        detector = self._stream_detectors.pop(stream_id, None)
+        if detector is not None:
+            self._reset_detector(detector)
+
+    @staticmethod
+    def _reset_detector(detector: ILoopDetector) -> None:
+        reset = getattr(detector, "reset", None)
+        if callable(reset):
+            try:
+                reset()
+            except Exception:
+                logger.debug("Failed to reset loop detector instance", exc_info=True)
 
     def _create_cancellation_content(
         self, detection_event: LoopDetectionEvent

--- a/tests/unit/loop_detection/test_streaming_wrapper.py
+++ b/tests/unit/loop_detection/test_streaming_wrapper.py
@@ -1,12 +1,69 @@
 from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
-from src.core.domain.streaming_response_processor import (  # Added StreamingContent
+from src.core.domain.streaming_response_processor import (
     LoopDetectionProcessor,
     StreamingContent,
 )
+from src.core.interfaces.loop_detector_interface import (
+    ILoopDetector,
+    LoopDetectionResult,
+)
 from src.core.services.streaming.stream_normalizer import StreamNormalizer
+from src.loop_detection.event import LoopDetectionEvent
 from src.loop_detection.hybrid_detector import HybridLoopDetector
+
+
+class _CountingLoopDetector(ILoopDetector):
+    """Simple detector used to verify per-stream isolation."""
+
+    def __init__(self) -> None:
+        self._enabled = True
+        self._history: list[str] = []
+
+    def is_enabled(self) -> bool:
+        return self._enabled
+
+    def process_chunk(self, chunk: str) -> LoopDetectionEvent | None:
+        if not self._enabled:
+            return None
+
+        self._history.append(chunk)
+        if len(self._history) >= 2 and self._history[-1] == self._history[-2]:
+            return LoopDetectionEvent(
+                pattern=chunk,
+                repetition_count=2,
+                total_length=len(chunk) * 2,
+                confidence=1.0,
+                buffer_content="".join(self._history),
+                timestamp=0.0,
+            )
+        return None
+
+    def reset(self) -> None:
+        self._history.clear()
+
+    def get_loop_history(self) -> list[LoopDetectionEvent]:
+        return []
+
+    def get_current_state(self) -> dict[str, Any]:
+        return {"history": list(self._history)}
+
+    def get_stats(self) -> dict[str, Any]:
+        return {"history_length": len(self._history)}
+
+    def update_config(self, new_config: Any) -> None:
+        return None
+
+    def enable(self) -> None:
+        self._enabled = True
+
+    def disable(self) -> None:
+        self._enabled = False
+
+    async def check_for_loops(self, content: str) -> LoopDetectionResult:
+        return LoopDetectionResult(has_loop=False)
 
 
 @pytest.mark.asyncio
@@ -99,3 +156,55 @@ async def test_stream_cancellation_on_loop() -> None:
     assert (
         "Response cancelled:" in joined or "Should not reach here" not in joined
     ), f"Neither cancellation message found nor stream stopped. Content: {joined}"
+
+
+@pytest.mark.asyncio
+async def test_loop_detection_processor_isolates_streams() -> None:
+    """Ensure concurrent streams do not leak loop detection state."""
+
+    processor = LoopDetectionProcessor(loop_detector=_CountingLoopDetector())
+
+    first_stream_chunk = StreamingContent(
+        content="repeat",
+        metadata={"stream_id": "stream-a"},
+    )
+    second_stream_chunk = StreamingContent(
+        content="repeat",
+        metadata={"stream_id": "stream-b"},
+    )
+
+    first_result = await processor.process(first_stream_chunk)
+    assert not first_result.is_cancellation
+
+    second_result = await processor.process(second_stream_chunk)
+    assert not second_result.is_cancellation
+    assert "Response cancelled" not in second_result.content
+
+    loop_trigger = await processor.process(
+        StreamingContent(content="repeat", metadata={"stream_id": "stream-a"})
+    )
+    assert loop_trigger.is_cancellation
+    assert "Response cancelled" in loop_trigger.content
+
+
+@pytest.mark.asyncio
+async def test_loop_detection_processor_reset_clears_per_stream_state() -> None:
+    """Reset should drop cached detectors so new streams start clean."""
+
+    processor = LoopDetectionProcessor(loop_detector=_CountingLoopDetector())
+
+    await processor.process(
+        StreamingContent(content="repeat", metadata={"stream_id": "stream-a"})
+    )
+
+    processor.reset()
+
+    after_reset = await processor.process(
+        StreamingContent(content="repeat", metadata={"stream_id": "stream-a"})
+    )
+    assert not after_reset.is_cancellation
+
+    second_chunk = await processor.process(
+        StreamingContent(content="repeat", metadata={"stream_id": "stream-a"})
+    )
+    assert second_chunk.is_cancellation


### PR DESCRIPTION
## Summary
- isolate LoopDetectionProcessor state per streaming session by caching per-stream detectors
- add unit coverage ensuring per-stream isolation and reset behavior

## Testing
- python -m pytest -o addopts="" tests/unit/loop_detection/test_streaming_wrapper.py
- python -m pytest -o addopts="" *(fails: missing pytest_asyncio, pytest_httpx, respx, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2612fdc483338010970ed1903ec5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-stream loop detection for streaming content, improving accuracy and isolation between concurrent streams.
  * Automatic detector reset on completion or cancellation to keep new streams clean.
* **Bug Fixes**
  * Prevents unintended cancellations leaking across streams.
  * Reduces false positives by scoping detection to the correct stream.
  * Ensures stable behavior even if detector cloning fails, with safe fallback.
* **Tests**
  * Added unit tests covering per-stream isolation, cancellation behavior, and reset flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->