### PR TITLE
Prevent usage data leak when session id is blank

### DIFF
--- a/src/core/services/usage_tracking_service.py
+++ b/src/core/services/usage_tracking_service.py
@@ -341,10 +341,20 @@ class UsageTrackingService(IUsageTrackingService):
         Returns:
             List of usage data entities
         """
-        if session_id:
-            data = await self._repository.get_by_session_id(session_id)
-        else:
+        # Normalize session identifier to avoid leaking global usage data when
+        # clients accidentally (or maliciously) submit blank values. Prior to
+        # this guard, passing an empty string would fall through to the
+        # repository's ``get_all`` path and expose usage information for every
+        # session.
+        if session_id is None:
             data = await self._repository.get_all()
+        else:
+            normalized_session_id = session_id.strip()
+
+            if not normalized_session_id:
+                return []
+
+            data = await self._repository.get_by_session_id(normalized_session_id)
 
         # Sort by timestamp (newest first) and limit
         sorted_data = sorted(data, key=lambda x: x.timestamp, reverse=True)

--- a/tests/unit/core/services/test_usage_tracking_service_comprehensive.py
+++ b/tests/unit/core/services/test_usage_tracking_service_comprehensive.py
@@ -617,17 +617,19 @@ class TestUsageTrackingService:
         self, service: UsageTrackingService, mock_repository: IUsageRepository
     ) -> None:
         """Test get_recent_usage with edge cases."""
-        # Test with empty session_id (should use get_all)
+        # Test with empty session_id (should not leak global usage data)
         mock_repository.get_all.return_value = []
-        await service.get_recent_usage(session_id="")
+        result = await service.get_recent_usage(session_id="")
 
-        assert mock_repository.get_all.call_count == 1
+        assert result == []
+        assert mock_repository.get_all.call_count == 0
+        assert mock_repository.get_by_session_id.call_count == 0
 
         # Test with very large limit
         mock_repository.get_all.return_value = []
         await service.get_recent_usage(limit=1000000)
 
-        assert mock_repository.get_all.call_count == 2
+        assert mock_repository.get_all.call_count == 1
 
     @pytest.mark.asyncio
     async def test_track_usage_special_model_names(


### PR DESCRIPTION
## Summary
- normalize blank session identifiers in the usage tracking service so they no longer fall back to returning all sessions
- extend the usage tracking service edge-case test to cover blank session ids and updated expectations

## Testing
- python -m pytest --override-ini addopts="" tests/unit/core/services/test_usage_tracking_service_comprehensive.py
- python -m pytest --override-ini addopts="" *(fails: missing pytest_asyncio/respx/pytest_httpx dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2612fdc483338010970ed1903ec5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents blank session IDs from returning all usage data; empty or whitespace-only inputs now yield no results.
  * Normalizes session ID input and ensures recent usage is consistently sorted by newest first with existing limits preserved.
  * Improves predictability and privacy of usage views in edge cases.

* **Tests**
  * Updated and expanded tests to validate new behavior for empty/blank session IDs.
  * Adjusted expectations to reflect no fallback to global data retrieval in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->