### PR TITLE
Handle optional test dependencies gracefully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ package-dir = {"" = "src"}
 [tool.pytest.ini_options]
 pythonpath = "."
 testpaths = ["tests"]
-addopts = "-v --asyncio-mode=auto --junit-xml=test-results.xml -W ignore --max-worker-restart=3 -n 7 --dist=loadfile --maxfail=10 -r fE"
+addopts = "-v --junit-xml=test-results.xml -W ignore --maxfail=10 -r fE"
 asyncio_mode = "auto"
 junit_duration_report = "call"
 log_cli_level = "INFO"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import asyncio
 import contextlib
+import importlib.util
 import inspect
 import warnings
+import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +17,100 @@ from src.core.interfaces.session_service_interface import ISessionService
 """Test fixtures and utilities."""
 
 
+def _module_is_available(name: str) -> bool:
+    """Return True if the optional module can be imported."""
+
+    return importlib.util.find_spec(name) is not None
+
+
+HAS_PYTEST_ASYNCIO = _module_is_available("pytest_asyncio")
+HAS_PYTEST_HTTPX = _module_is_available("pytest_httpx")
+HAS_PYTEST_XDIST = _module_is_available("xdist")
+
+
+if not HAS_PYTEST_ASYNCIO:
+    module = types.ModuleType("pytest_asyncio")
+
+    def _asyncio_fixture(*fixture_args, **fixture_kwargs):
+        def decorator(func):
+            async def _skipped_fixture(*_args: Any, **_kwargs: Any):
+                pytest.skip("pytest_asyncio not installed")
+
+            return pytest.fixture(*fixture_args, **fixture_kwargs)(_skipped_fixture)
+
+        return decorator
+
+    module.fixture = _asyncio_fixture  # type: ignore[assignment]
+    sys.modules.setdefault("pytest_asyncio", module)
+
+
+if not HAS_PYTEST_HTTPX:
+    module = types.ModuleType("pytest_httpx")
+    module.HTTPXMock = Any  # type: ignore[assignment]
+    sys.modules.setdefault("pytest_httpx", module)
+
+
+if not HAS_PYTEST_HTTPX:
+
+    @pytest.fixture
+    def httpx_mock():  # type: ignore[no-redef]
+        pytest.skip("pytest_httpx not installed")
+
+
+def _strip_option(args: list[str], option: str) -> None:
+    """Remove all occurrences of an option from the args list."""
+
+    while option in args:
+        index = args.index(option)
+        del args[index]
+        if option in {"-n", "--max-worker-restart", "--dist", "--asyncio-mode"}:
+            if index < len(args) and not args[index].startswith("-"):
+                del args[index]
+
+
+def _ensure_option(args: list[str], option: str, value: str | None = None) -> None:
+    """Append an option with an optional value when absent."""
+
+    if any(
+        item == option or (value is not None and item == value) or item.startswith(f"{option}=")
+        for item in args
+    ):
+        return
+
+    if value is None:
+        args.append(option)
+    elif option.startswith("--"):
+        args.append(f"{option}={value}")
+    else:
+        args.extend([option, value])
+
+
+def _configure_optional_plugin_args(args: list[str]) -> None:
+    """Apply default CLI options for optional plugins when available."""
+
+    if HAS_PYTEST_ASYNCIO:
+        _ensure_option(args, "--asyncio-mode", "auto")
+    else:
+        _strip_option(args, "--asyncio-mode")
+        _strip_option(args, "--asyncio-mode=auto")
+
+    if HAS_PYTEST_XDIST:
+        if "-n" not in args and not any(a.startswith("--numprocesses") for a in args):
+            _ensure_option(args, "-n", "7")
+        if not any(a.startswith("--dist") for a in args):
+            _ensure_option(args, "--dist", "loadfile")
+        if not any(a.startswith("--max-worker-restart") for a in args):
+            _ensure_option(args, "--max-worker-restart", "3")
+    else:
+        _strip_option(args, "-n")
+        _strip_option(args, "--dist")
+        _strip_option(args, "--dist=loadfile")
+        _strip_option(args, "--max-worker-restart")
+        _strip_option(args, "--max-worker-restart=3")
+
+
 def pytest_load_initial_conftests(args, early_config, parser):
+    _configure_optional_plugin_args(args)
     # If user already set -n/--numprocesses, respect it
     if "-n" in args or any(a.startswith("--numprocesses") for a in args):
         return
@@ -24,6 +120,20 @@ def pytest_load_initial_conftests(args, early_config, parser):
     if len(nodeids) == 1:
         # Prepend -n 1 so xdist sees it during option parsing
         args[:0] = ["-n", "1"]
+
+
+def pytest_collection_modifyitems(config, items):  # type: ignore[no-untyped-def]
+    if not HAS_PYTEST_HTTPX:
+        skip_httpx = pytest.mark.skip(reason="pytest_httpx not installed")
+        for item in items:
+            if "httpx_mock" in getattr(item, "fixturenames", ()):  # pragma: no branch
+                item.add_marker(skip_httpx)
+
+    if not HAS_PYTEST_ASYNCIO:
+        skip_asyncio = pytest.mark.skip(reason="pytest_asyncio not installed")
+        for item in items:
+            if item.get_closest_marker("asyncio"):
+                item.add_marker(skip_asyncio)
 
 
 # Provide env fixtures used by config tests
@@ -112,6 +222,12 @@ pytestmark = pytest.mark.filterwarnings(
 def pytest_configure(config) -> None:  # type: ignore[no-untyped-def]
     """Install warning filters in each worker process (xdist)."""
     _install_global_warning_filters()
+    config.addinivalue_line(
+        "markers", "httpx_mock: mark tests that require pytest_httpx"
+    )
+    config.addinivalue_line(
+        "markers", "asyncio: mark tests that require pytest_asyncio"
+    )
 
 
 # Test helper utilities expected by some tests


### PR DESCRIPTION
## Summary
- trim pytest addopts in pyproject to only include core options when optional plugins are absent
- install lightweight stubs and skip logic in tests/conftest.py for pytest-asyncio and pytest-httpx when those plugins are missing
- automatically skip tests that rely on pytest-httpx fixtures or asyncio markers if the corresponding plugin is unavailable

## Testing
- python -m pytest tests/unit/connectors/test_streaming_utils.py -k streaming --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68ec2b87b12883338f68e388c4672d08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified pytest setup: standardized verbosity, failure limits, warnings, and JUnit XML output; removed built-in parallelism.
  * Smarter optional plugin handling: tests that rely on asyncio or HTTPX are skipped when plugins are missing instead of failing.
  * New helper fixtures for environment variables, temporary config files, and a FastAPI test client.
  * Improved test session setup/teardown with automatic artifact cleanup.
* **Chores**
  * Consolidated pytest configuration into clearer top-level settings for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->