### PR TITLE
Handle missing optional test dependencies

### DIFF
--- a/tests/integration/test_backend_probing.py
+++ b/tests/integration/test_backend_probing.py
@@ -5,8 +5,11 @@ from collections.abc import Generator
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.utils import require_pytest_asyncio
 from src.core.app.test_builder import ApplicationTestBuilder
 from src.core.interfaces.backend_config_provider_interface import IBackendConfigProvider
+
+pytest_asyncio = require_pytest_asyncio()
 
 
 @pytest.fixture
@@ -18,11 +21,6 @@ def test_env() -> Generator[None, None, None]:
     yield
     os.environ.clear()
     os.environ.update(old_env)
-
-
-import pytest_asyncio
-
-
 @pytest_asyncio.fixture
 async def app_client(test_env: None) -> TestClient:
     """Create a test client with the application."""

--- a/tests/integration/test_direct_controllers.py
+++ b/tests/integration/test_direct_controllers.py
@@ -7,9 +7,12 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
+from tests.utils import require_pytest_asyncio
 from src.core.app.controllers import get_chat_controller_if_available
 from src.core.app.controllers.chat_controller import ChatController
 from src.core.services.translation_service import TranslationService
+
+pytest_asyncio = require_pytest_asyncio()
 
 
 @pytest.fixture
@@ -18,11 +21,6 @@ def app() -> Generator[FastAPI, None, None]:
     app = FastAPI()
     app.state.config = {"command_prefix": "!/"}
     yield app
-
-
-import pytest_asyncio
-
-
 @pytest_asyncio.fixture
 async def setup_app(app: FastAPI) -> AsyncGenerator[dict[str, Any], None]:
     """Set up the app with necessary services for testing."""

--- a/tests/integration/test_hello_command_integration.py
+++ b/tests/integration/test_hello_command_integration.py
@@ -9,8 +9,10 @@ import pytest
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
-import pytest_asyncio
 from fastapi.testclient import TestClient
+from tests.utils import require_pytest_asyncio
+
+pytest_asyncio = require_pytest_asyncio()
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_oneoff_command_integration.py
+++ b/tests/integration/test_oneoff_command_integration.py
@@ -7,12 +7,15 @@ from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from tests.utils import require_pytest_asyncio
 from src.core.config.app_config import AppConfig
 from src.core.domain.commands.oneoff_command import OneoffCommand
 from src.core.interfaces.backend_service_interface import IBackendService
+
+
+pytest_asyncio = require_pytest_asyncio()
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_pwd_command_integration.py
+++ b/tests/integration/test_pwd_command_integration.py
@@ -1,10 +1,10 @@
-"""
-Integration tests for the PWD command in the new SOLID architecture.
-"""
+"""Integration tests for the PWD command in the SOLID architecture."""
 
 import pytest
-import pytest_asyncio
+from tests.utils import require_pytest_asyncio
 from src.core.app.test_builder import build_test_app as build_app
+
+pytest_asyncio = require_pytest_asyncio()
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_zai_coding_plan.py
+++ b/tests/integration/test_zai_coding_plan.py
@@ -1,9 +1,12 @@
 import pytest
 from httpx import Response
-from respx import MockRouter
 from starlette.testclient import TestClient
+from tests.utils import require_respx
 
 pytestmark = [pytest.mark.no_global_mock]
+
+
+MockRouter = require_respx().MockRouter
 
 
 @pytest.fixture

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,8 +12,11 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-import respx
+from tests.utils import require_respx
 from src.core.domain.session import Session, SessionState
+
+
+respx = require_respx()
 
 
 def generate_random_id(prefix: str = "", length: int = 8) -> str:

--- a/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
+++ b/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
@@ -9,8 +9,7 @@ from collections.abc import AsyncGenerator
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.anthropic import (
     ANTHROPIC_DEFAULT_BASE_URL,
     ANTHROPIC_VERSION_HEADER,
@@ -24,6 +23,10 @@ from src.core.domain.chat import (
 )
 
 TEST_ANTHROPIC_API_BASE_URL = ANTHROPIC_DEFAULT_BASE_URL
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="anthropic_backend")

--- a/tests/unit/chat_completions_tests/test_rate_limiting.py
+++ b/tests/unit/chat_completions_tests/test_rate_limiting.py
@@ -1,15 +1,17 @@
 import re
 import uuid
-
 import pytest
 from fastapi.testclient import TestClient
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_httpx
 from src.core.app.test_builder import build_httpx_mock_test_app
 
 # Suppress Windows ProactorEventLoop ResourceWarnings for this module
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
+
+
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest.fixture
@@ -131,3 +133,5 @@ def test_rate_limit_memory(
             # Skip assertion if we can't parse the JSON or it's not in the expected format
             # This is a temporary workaround for the coroutine serialization issue
             pass
+HTTPXMock = require_pytest_httpx().HTTPXMock
+

--- a/tests/unit/connectors/test_anthropic_oauth.py
+++ b/tests/unit/connectors/test_anthropic_oauth.py
@@ -3,14 +3,17 @@ from pathlib import Path
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.anthropic import (
     ANTHROPIC_DEFAULT_BASE_URL,
     ANTHROPIC_VERSION_HEADER,
 )
 from src.connectors.anthropic_oauth import AnthropicOAuthBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="oauth_creds_tmp")

--- a/tests/unit/connectors/test_openai_oauth.py
+++ b/tests/unit/connectors/test_openai_oauth.py
@@ -6,13 +6,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.openai_oauth import (
     OpenAICredentialsFileHandler,
     OpenAIOAuthConnector,
 )
 from src.core.domain.chat import ChatMessage, ChatRequest
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="auth_dir")

--- a/tests/unit/connectors/test_streaming_utils.py
+++ b/tests/unit/connectors/test_streaming_utils.py
@@ -11,9 +11,9 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 require_hypothesis()
-from hypothesis import HealthCheck, given, settings  # type: ignore[missing-import]
-from hypothesis import strategies as st  # type: ignore[missing-import]
-from hypothesis.strategies import composite  # type: ignore[missing-import]
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from hypothesis.strategies import composite
 from src.connectors.streaming_utils import (
     _ensure_async_iterator,
     normalize_streaming_response,

--- a/tests/unit/connectors/test_streaming_utils.py
+++ b/tests/unit/connectors/test_streaming_utils.py
@@ -3,6 +3,7 @@ Tests for the streaming utilities module using Hypothesis for property-based tes
 """
 
 import pytest
+
 from tests.utils import require_hypothesis
 
 # Suppress Windows ProactorEventLoop ResourceWarnings for this module

--- a/tests/unit/connectors/test_streaming_utils.py
+++ b/tests/unit/connectors/test_streaming_utils.py
@@ -3,14 +3,17 @@ Tests for the streaming utilities module using Hypothesis for property-based tes
 """
 
 import pytest
+from tests.utils import require_hypothesis
 
 # Suppress Windows ProactorEventLoop ResourceWarnings for this module
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
-from hypothesis import HealthCheck, given, settings
-from hypothesis import strategies as st
-from hypothesis.strategies import composite
+
+require_hypothesis()
+from hypothesis import HealthCheck, given, settings  # type: ignore[missing-import]
+from hypothesis import strategies as st  # type: ignore[missing-import]
+from hypothesis.strategies import composite  # type: ignore[missing-import]
 from src.connectors.streaming_utils import (
     _ensure_async_iterator,
     normalize_streaming_response,

--- a/tests/unit/core/services/test_backend_service_hypothesis.py
+++ b/tests/unit/core/services/test_backend_service_hypothesis.py
@@ -19,8 +19,8 @@ from src.core.services.backend_factory import BackendFactory
 from src.core.services.backend_service import BackendService
 
 require_hypothesis()
-from hypothesis import HealthCheck, given, settings  # type: ignore[missing-import]
-from hypothesis import strategies as st  # type: ignore[missing-import]
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 
 class MockBackend(LLMBackend):

--- a/tests/unit/core/services/test_backend_service_hypothesis.py
+++ b/tests/unit/core/services/test_backend_service_hypothesis.py
@@ -7,8 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
-from hypothesis import HealthCheck, given, settings
-from hypothesis import strategies as st
+from tests.utils import require_hypothesis
 from src.connectors.base import LLMBackend
 from src.core.common.exceptions import BackendError, RateLimitExceededError
 from src.core.domain.backend_type import BackendType
@@ -18,6 +17,10 @@ from src.core.interfaces.application_state_interface import IApplicationState
 from src.core.interfaces.session_service_interface import ISessionService
 from src.core.services.backend_factory import BackendFactory
 from src.core.services.backend_service import BackendService
+
+require_hypothesis()
+from hypothesis import HealthCheck, given, settings  # type: ignore[missing-import]
+from hypothesis import strategies as st  # type: ignore[missing-import]
 
 
 class MockBackend(LLMBackend):

--- a/tests/unit/core/services/test_backend_service_hypothesis.py
+++ b/tests/unit/core/services/test_backend_service_hypothesis.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
-from tests.utils import require_hypothesis
 from src.connectors.base import LLMBackend
 from src.core.common.exceptions import BackendError, RateLimitExceededError
 from src.core.domain.backend_type import BackendType
@@ -17,6 +16,8 @@ from src.core.interfaces.application_state_interface import IApplicationState
 from src.core.interfaces.session_service_interface import ISessionService
 from src.core.services.backend_factory import BackendFactory
 from src.core.services.backend_service import BackendService
+
+from tests.utils import require_hypothesis
 
 require_hypothesis()
 from hypothesis import HealthCheck, given, settings

--- a/tests/unit/core/services/test_tool_call_repair.py
+++ b/tests/unit/core/services/test_tool_call_repair.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import AsyncGenerator  # Added import
 
 import pytest
-from pytest_mock import MockerFixture
+from tests.utils import require_pytest_mock
 from src.core.interfaces.response_processor_interface import ProcessedResponse
 from src.core.services.streaming.tool_call_repair_processor import (
     ToolCallRepairProcessor,
@@ -11,6 +11,9 @@ from src.core.services.streaming_tool_call_repair_processor import (
     StreamingToolCallRepairProcessor,
 )
 from src.core.services.tool_call_repair_service import ToolCallRepairService
+
+
+MockerFixture = require_pytest_mock().MockerFixture
 
 
 @pytest.fixture

--- a/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
+++ b/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
@@ -3,12 +3,15 @@
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
 
 TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="gemini_backend")

--- a/tests/unit/gemini_connector_tests/test_multimodal_payload.py
+++ b/tests/unit/gemini_connector_tests/test_multimodal_payload.py
@@ -2,8 +2,7 @@ import json
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import (
     ChatMessage,
@@ -14,6 +13,10 @@ from src.core.domain.chat import (
 )
 
 TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="gemini_backend")

--- a/tests/unit/gemini_connector_tests/test_part_conversion.py
+++ b/tests/unit/gemini_connector_tests/test_part_conversion.py
@@ -2,12 +2,15 @@ import json
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import ChatMessage, ChatRequest, MessageContentPartText
 
 TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="gemini_backend")

--- a/tests/unit/gemini_connector_tests/test_streaming_success.py
+++ b/tests/unit/gemini_connector_tests/test_streaming_success.py
@@ -4,16 +4,15 @@ from typing import Any
 
 import httpx
 import pytest
-import pytest_asyncio
-
-try:  # pragma: no cover - optional test dependency
-    from pytest_httpx import HTTPXMock
-except ModuleNotFoundError:  # pragma: no cover - optional test dependency
-    HTTPXMock = None  # type: ignore[assignment]
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
 
 TEST_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com"
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="gemini_backend")
@@ -41,7 +40,6 @@ def sample_processed_messages() -> list[ChatMessage]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(HTTPXMock is None, reason="pytest_httpx not installed")
 async def test_chat_completions_streaming_success(
     gemini_backend: GeminiBackend,
     httpx_mock: HTTPXMock,

--- a/tests/unit/loop_detection/test_streaming_comprehensive.py
+++ b/tests/unit/loop_detection/test_streaming_comprehensive.py
@@ -8,7 +8,7 @@ import asyncio
 from collections.abc import AsyncIterator
 
 import pytest
-from pytest_mock import MockerFixture
+from tests.utils import require_pytest_mock
 from src.core.domain.streaming_response_processor import (
     LoopDetectionProcessor,
     StreamingContent,
@@ -16,6 +16,9 @@ from src.core.domain.streaming_response_processor import (
 from src.core.services.streaming.stream_normalizer import StreamNormalizer
 from src.loop_detection.analyzer import LoopDetectionEvent
 from src.loop_detection.hybrid_detector import HybridLoopDetector
+
+
+MockerFixture = require_pytest_mock().MockerFixture
 
 
 class TestLoopDetectionStreaming:

--- a/tests/unit/openai_connector_tests/test_streaming_response.py
+++ b/tests/unit/openai_connector_tests/test_streaming_response.py
@@ -16,8 +16,11 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 from fastapi import HTTPException
+from tests.utils import require_pytest_mock
 from src.connectors.openai import OpenAIConnector
 from src.core.common.exceptions import ServiceUnavailableError
+
+require_pytest_mock()
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture

--- a/tests/unit/openrouter_connector_tests/test_headers_plumbing.py
+++ b/tests/unit/openrouter_connector_tests/test_headers_plumbing.py
@@ -1,13 +1,14 @@
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
 
 
 def mock_headers_provider(_: str, api_key: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="openrouter_backend")

--- a/tests/unit/openrouter_connector_tests/test_headers_provider_config_dict.py
+++ b/tests/unit/openrouter_connector_tests/test_headers_provider_config_dict.py
@@ -4,12 +4,15 @@ import asyncio
 
 import httpx
 import pytest
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_httpx
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.config.app_config import AppConfig, get_openrouter_headers
 from src.core.domain.chat import ChatMessage, ChatRequest
 from src.core.domain.configuration.app_identity_config import AppIdentityConfig
 from src.core.domain.configuration.header_config import HeaderConfig, HeaderOverrideMode
+
+
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 def test_openrouter_headers_provider_accepts_config_dict() -> None:
@@ -91,3 +94,4 @@ async def test_chat_completions_supports_config_dict_headers(
     assert req.headers.get("Authorization") == "Bearer integration-key"
     assert req.headers.get("HTTP-Referer") == "https://example.invalid/test"
     assert req.headers.get("X-Title") == "ExampleProxy"
+

--- a/tests/unit/openrouter_connector_tests/test_http_error_non_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_non_streaming.py
@@ -1,10 +1,7 @@
-# import json # F401: Removed
-
 import httpx
 import pytest
-import pytest_asyncio
 from fastapi import HTTPException
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.openrouter import OpenRouterBackend
 
 # from starlette.responses import StreamingResponse # F401: Removed
@@ -14,6 +11,10 @@ from src.core.domain.chat import ChatMessage, ChatRequest
 TEST_OPENROUTER_API_BASE_URL = (
     "https://openrouter.ai/api/v1"  # Real one for realistic requests
 )
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 def mock_get_openrouter_headers(_: str, api_key: str) -> dict[str, str]:

--- a/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
@@ -2,7 +2,7 @@
 
 import httpx
 import pytest
-import pytest_asyncio
+from tests.utils import require_pytest_asyncio
 from src.connectors.openrouter import OpenRouterBackend
 
 # from pytest_httpx import HTTPXMock # F401: Removed
@@ -26,6 +26,9 @@ def mock_get_openrouter_headers(_: str, api_key: str) -> dict[str, str]:
         "HTTP-Referer": mock_config["app_site_url"],
         "X-Title": mock_config["app_x_title"],
     }
+
+
+pytest_asyncio = require_pytest_asyncio()
 
 
 @pytest_asyncio.fixture(name="openrouter_backend")

--- a/tests/unit/openrouter_connector_tests/test_non_streaming_success.py
+++ b/tests/unit/openrouter_connector_tests/test_non_streaming_success.py
@@ -2,10 +2,9 @@ import json
 
 import httpx
 import pytest
-import pytest_asyncio
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 
 # from fastapi import HTTPException # F401: Removed
-from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
 from src.core.domain.responses import ResponseEnvelope
@@ -14,6 +13,10 @@ from src.core.domain.responses import ResponseEnvelope
 TEST_OPENROUTER_API_BASE_URL = (
     "https://openrouter.ai/api/v1"  # Real one for realistic requests
 )
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 def mock_get_openrouter_headers(_: str, api_key: str) -> dict[str, str]:

--- a/tests/unit/openrouter_connector_tests/test_payload_construction_and_headers.py
+++ b/tests/unit/openrouter_connector_tests/test_payload_construction_and_headers.py
@@ -2,10 +2,9 @@ import json
 
 import httpx
 import pytest
-import pytest_asyncio
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 
 # from fastapi import HTTPException # F401: Removed
-from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 
 # from starlette.responses import StreamingResponse # F401: Removed
@@ -21,6 +20,10 @@ from src.core.domain.chat import (
 TEST_OPENROUTER_API_BASE_URL = (
     "https://openrouter.ai/api/v1"  # Real one for realistic requests
 )
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 def mock_get_openrouter_headers(_: str, api_key: str) -> dict[str, str]:

--- a/tests/unit/openrouter_connector_tests/test_request_error.py
+++ b/tests/unit/openrouter_connector_tests/test_request_error.py
@@ -2,8 +2,7 @@
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.common.exceptions import ServiceUnavailableError
 
@@ -14,6 +13,10 @@ from src.core.domain.chat import ChatMessage, ChatRequest
 TEST_OPENROUTER_API_BASE_URL = (
     "https://openrouter.ai/api/v1"  # Real one for realistic requests
 )
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 def mock_get_openrouter_headers(_: str, api_key: str) -> dict[str, str]:

--- a/tests/unit/openrouter_connector_tests/test_streaming_success.py
+++ b/tests/unit/openrouter_connector_tests/test_streaming_success.py
@@ -5,8 +5,7 @@ import pytest
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
 from src.core.domain.responses import StreamingResponseEnvelope
@@ -15,6 +14,10 @@ from src.core.domain.responses import StreamingResponseEnvelope
 TEST_OPENROUTER_API_BASE_URL = (
     "https://openrouter.ai/api/v1"  # Real one for realistic requests
 )
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 def mock_get_openrouter_headers(_: str, api_key: str) -> dict[str, str]:

--- a/tests/unit/zai_connector_tests/test_domain_to_connector.py
+++ b/tests/unit/zai_connector_tests/test_domain_to_connector.py
@@ -9,8 +9,7 @@ from collections.abc import AsyncGenerator
 
 import httpx
 import pytest
-import pytest_asyncio
-from pytest_httpx import HTTPXMock
+from tests.utils import require_pytest_asyncio, require_pytest_httpx
 from src.connectors.zai import ZAIConnector
 from src.core.domain.chat import (
     ChatMessage,
@@ -20,6 +19,10 @@ from src.core.domain.chat import (
 )
 
 TEST_ZAI_API_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
+
+
+pytest_asyncio = require_pytest_asyncio()
+HTTPXMock = require_pytest_httpx().HTTPXMock
 
 
 @pytest_asyncio.fixture(name="zai_backend")

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,1 +1,9 @@
 """Test utilities package."""
+
+from .optional_dependencies import (  # noqa: F401
+    require_hypothesis,
+    require_pytest_mock,
+    require_pytest_asyncio,
+    require_pytest_httpx,
+    require_respx,
+)

--- a/tests/utils/optional_dependencies.py
+++ b/tests/utils/optional_dependencies.py
@@ -42,6 +42,7 @@ def _require_module(module_name: str, package_name: str) -> ModuleType:
             ),
             allow_module_level=True,
         )
+        # Unreachable: pytest.skip raises. Present for type checker.
         raise RuntimeError from exc
 
 

--- a/tests/utils/optional_dependencies.py
+++ b/tests/utils/optional_dependencies.py
@@ -1,0 +1,76 @@
+"""Helpers for managing optional test dependencies.
+
+The cloud execution environment used by Codex runs a lean Python image that
+omits a number of optional packages such as ``pytest-asyncio`` and
+``pytest-httpx``.  Several test modules rely on these packages.  When they are
+missing the standard imports raise ``ModuleNotFoundError`` during test
+collection which prevents *all* tests from running.
+
+To keep the suite runnable in minimal environments we provide small helper
+functions that attempt to import the optional dependency and skip the
+requesting test module if it is unavailable.  Each helper returns the imported
+module so test files can continue to use their normal APIs when the dependency
+is present.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+import pytest
+
+
+def _require_module(module_name: str, package_name: str) -> ModuleType:
+    """Import *module_name* or skip the calling test module.
+
+    Parameters
+    ----------
+    module_name:
+        The fully-qualified module name to import.
+    package_name:
+        The corresponding package name used for the user-facing skip message.
+    """
+
+    try:
+        return import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in CI
+        pytest.skip(
+            (
+                f"Optional test dependency '{package_name}' is not installed. "
+                "Install it via the '[dev]' extras to run these tests."
+            ),
+            allow_module_level=True,
+        )
+        raise RuntimeError from exc
+
+
+def require_pytest_asyncio() -> ModuleType:
+    """Return the ``pytest_asyncio`` module or skip if absent."""
+
+    return _require_module("pytest_asyncio", "pytest-asyncio")
+
+
+def require_pytest_httpx() -> ModuleType:
+    """Return the ``pytest_httpx`` module or skip if absent."""
+
+    return _require_module("pytest_httpx", "pytest-httpx")
+
+
+def require_respx() -> ModuleType:
+    """Return the ``respx`` module or skip if absent."""
+
+    return _require_module("respx", "respx")
+
+
+def require_hypothesis() -> ModuleType:
+    """Return the ``hypothesis`` module or skip if absent."""
+
+    return _require_module("hypothesis", "hypothesis")
+
+
+def require_pytest_mock() -> ModuleType:
+    """Return the ``pytest_mock`` module or skip if absent."""
+
+    return _require_module("pytest_mock", "pytest-mock")
+


### PR DESCRIPTION
## Summary
- add a `tests/utils/optional_dependencies` helper that skips modules when optional test libraries are unavailable
- update async and HTTPX-based tests to import optional dependencies through the helper so missing packages no longer break collection
- guard Hypothesis- and pytest-mock-based suites to ensure they skip cleanly in minimal environments

## Testing
- python -m pytest -o addopts='' --collect-only

------
https://chatgpt.com/codex/tasks/task_e_68ec2b87b12883338f68e388c4672d08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Centralized optional test dependencies behind utilities, enabling graceful skips when missing (asyncio support, HTTPX mocking, respx, hypothesis, pytest-mock).
  - Updated tests to use standardized helpers and aliases, removing direct imports and improving consistency.
  - Minor test harness adjustments; one test now runs an async flow via asyncio.run inside a normal test.

- Refactor
  - Consolidated test dependency access through a shared utilities module for simpler setup and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->