### PR TITLE
Handle optional test dependencies gracefully

### DIFF
--- a/tests/integration/test_backend_probing.py
+++ b/tests/integration/test_backend_probing.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 from src.core.app.test_builder import ApplicationTestBuilder
 from src.core.interfaces.backend_config_provider_interface import IBackendConfigProvider
 
+from tests.utils.optional_dependencies import require_module
+
 
 @pytest.fixture
 def test_env() -> Generator[None, None, None]:
@@ -20,6 +22,7 @@ def test_env() -> Generator[None, None, None]:
     os.environ.update(old_env)
 
 
+require_module("pytest_asyncio", reason="Backend probing tests need pytest-asyncio")
 import pytest_asyncio
 
 

--- a/tests/integration/test_direct_controllers.py
+++ b/tests/integration/test_direct_controllers.py
@@ -11,6 +11,8 @@ from src.core.app.controllers import get_chat_controller_if_available
 from src.core.app.controllers.chat_controller import ChatController
 from src.core.services.translation_service import TranslationService
 
+from tests.utils.optional_dependencies import require_module
+
 
 @pytest.fixture
 def app() -> Generator[FastAPI, None, None]:
@@ -20,6 +22,7 @@ def app() -> Generator[FastAPI, None, None]:
     yield app
 
 
+require_module("pytest_asyncio", reason="Integration tests need pytest-asyncio")
 import pytest_asyncio
 
 

--- a/tests/integration/test_hello_command_integration.py
+++ b/tests/integration/test_hello_command_integration.py
@@ -6,9 +6,12 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.utils.optional_dependencies import require_module
+
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
+require_module("pytest_asyncio", reason="Integration tests need pytest-asyncio")
 import pytest_asyncio
 from fastapi.testclient import TestClient
 

--- a/tests/integration/test_oneoff_command_integration.py
+++ b/tests/integration/test_oneoff_command_integration.py
@@ -7,6 +7,10 @@ from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Integration tests need pytest-asyncio")
 import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/tests/integration/test_pwd_command_integration.py
+++ b/tests/integration/test_pwd_command_integration.py
@@ -3,6 +3,10 @@ Integration tests for the PWD command in the new SOLID architecture.
 """
 
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Integration tests need pytest-asyncio")
 import pytest_asyncio
 from src.core.app.test_builder import build_test_app as build_app
 

--- a/tests/integration/test_zai_coding_plan.py
+++ b/tests/integration/test_zai_coding_plan.py
@@ -1,5 +1,9 @@
 import pytest
 from httpx import Response
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("respx", reason="ZAI integration tests need respx for HTTP mocking")
 from respx import MockRouter
 from starlette.testclient import TestClient
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,6 +12,10 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("respx", reason="Test helpers rely on respx for HTTP mocking")
 import respx
 from src.core.domain.session import Session, SessionState
 

--- a/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
+++ b/tests/unit/anthropic_connector_tests/test_domain_to_connector.py
@@ -9,7 +9,12 @@ from collections.abc import AsyncGenerator
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Anthropic connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="Anthropic connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.anthropic import (
     ANTHROPIC_DEFAULT_BASE_URL,

--- a/tests/unit/chat_completions_tests/test_rate_limiting.py
+++ b/tests/unit/chat_completions_tests/test_rate_limiting.py
@@ -3,6 +3,10 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_httpx", reason="Chat completion tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.core.app.test_builder import build_httpx_mock_test_app
 

--- a/tests/unit/connectors/test_anthropic_oauth.py
+++ b/tests/unit/connectors/test_anthropic_oauth.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Anthropic connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="Anthropic connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.anthropic import (
     ANTHROPIC_DEFAULT_BASE_URL,

--- a/tests/unit/connectors/test_openai_oauth.py
+++ b/tests/unit/connectors/test_openai_oauth.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenAI connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="OpenAI connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openai_oauth import (
     OpenAICredentialsFileHandler,

--- a/tests/unit/connectors/test_streaming_utils.py
+++ b/tests/unit/connectors/test_streaming_utils.py
@@ -4,10 +4,13 @@ Tests for the streaming utilities module using Hypothesis for property-based tes
 
 import pytest
 
+from tests.utils.optional_dependencies import require_module
+
 # Suppress Windows ProactorEventLoop ResourceWarnings for this module
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
+require_module("hypothesis", reason="Streaming utility tests need Hypothesis")
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from hypothesis.strategies import composite

--- a/tests/unit/core/services/test_backend_service_hypothesis.py
+++ b/tests/unit/core/services/test_backend_service_hypothesis.py
@@ -7,6 +7,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("hypothesis", reason="Backend service tests need Hypothesis")
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from src.connectors.base import LLMBackend

--- a/tests/unit/core/services/test_tool_call_repair.py
+++ b/tests/unit/core/services/test_tool_call_repair.py
@@ -2,6 +2,10 @@ import json
 from collections.abc import AsyncGenerator  # Added import
 
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_mock", reason="Tool call repair tests need pytest-mock")
 from pytest_mock import MockerFixture
 from src.core.interfaces.response_processor_interface import ProcessedResponse
 from src.core.services.streaming.tool_call_repair_processor import (

--- a/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
+++ b/tests/unit/gemini_connector_tests/test_model_prefix_handling.py
@@ -3,7 +3,12 @@
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Gemini connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="Gemini connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import ChatMessage, ChatRequest

--- a/tests/unit/gemini_connector_tests/test_multimodal_payload.py
+++ b/tests/unit/gemini_connector_tests/test_multimodal_payload.py
@@ -2,7 +2,12 @@ import json
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Gemini connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="Gemini connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import (

--- a/tests/unit/gemini_connector_tests/test_part_conversion.py
+++ b/tests/unit/gemini_connector_tests/test_part_conversion.py
@@ -2,7 +2,12 @@ import json
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Gemini connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="Gemini connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import ChatMessage, ChatRequest, MessageContentPartText

--- a/tests/unit/gemini_connector_tests/test_streaming_success.py
+++ b/tests/unit/gemini_connector_tests/test_streaming_success.py
@@ -4,12 +4,13 @@ from typing import Any
 
 import httpx
 import pytest
-import pytest_asyncio
 
-try:  # pragma: no cover - optional test dependency
-    from pytest_httpx import HTTPXMock
-except ModuleNotFoundError:  # pragma: no cover - optional test dependency
-    HTTPXMock = None  # type: ignore[assignment]
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="Gemini connector tests need pytest-asyncio")
+import pytest_asyncio
+require_module("pytest_httpx", reason="Gemini connector tests need pytest-httpx")
+from pytest_httpx import HTTPXMock
 from src.connectors.gemini import GeminiBackend
 from src.core.domain.chat import ChatMessage, ChatRequest
 
@@ -41,7 +42,6 @@ def sample_processed_messages() -> list[ChatMessage]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(HTTPXMock is None, reason="pytest_httpx not installed")
 async def test_chat_completions_streaming_success(
     gemini_backend: GeminiBackend,
     httpx_mock: HTTPXMock,

--- a/tests/unit/loop_detection/test_streaming_comprehensive.py
+++ b/tests/unit/loop_detection/test_streaming_comprehensive.py
@@ -8,6 +8,10 @@ import asyncio
 from collections.abc import AsyncIterator
 
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_mock", reason="Loop detection tests need pytest-mock")
 from pytest_mock import MockerFixture
 from src.core.domain.streaming_response_processor import (
     LoopDetectionProcessor,

--- a/tests/unit/openrouter_connector_tests/test_headers_plumbing.py
+++ b/tests/unit/openrouter_connector_tests/test_headers_plumbing.py
@@ -1,6 +1,11 @@
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.domain.chat import ChatMessage, ChatRequest

--- a/tests/unit/openrouter_connector_tests/test_headers_provider_config_dict.py
+++ b/tests/unit/openrouter_connector_tests/test_headers_provider_config_dict.py
@@ -4,6 +4,10 @@ import asyncio
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.config.app_config import AppConfig, get_openrouter_headers

--- a/tests/unit/openrouter_connector_tests/test_http_error_non_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_non_streaming.py
@@ -2,8 +2,13 @@
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
 from fastapi import HTTPException
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 

--- a/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
+++ b/tests/unit/openrouter_connector_tests/test_http_error_streaming.py
@@ -2,6 +2,10 @@
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
 from src.connectors.openrouter import OpenRouterBackend
 

--- a/tests/unit/openrouter_connector_tests/test_non_streaming_success.py
+++ b/tests/unit/openrouter_connector_tests/test_non_streaming_success.py
@@ -2,9 +2,14 @@ import json
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
 
 # from fastapi import HTTPException # F401: Removed
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.domain.chat import ChatMessage, ChatRequest

--- a/tests/unit/openrouter_connector_tests/test_payload_construction_and_headers.py
+++ b/tests/unit/openrouter_connector_tests/test_payload_construction_and_headers.py
@@ -2,9 +2,14 @@ import json
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
 
 # from fastapi import HTTPException # F401: Removed
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 

--- a/tests/unit/openrouter_connector_tests/test_request_error.py
+++ b/tests/unit/openrouter_connector_tests/test_request_error.py
@@ -2,7 +2,12 @@
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.common.exceptions import ServiceUnavailableError

--- a/tests/unit/openrouter_connector_tests/test_streaming_success.py
+++ b/tests/unit/openrouter_connector_tests/test_streaming_success.py
@@ -1,11 +1,15 @@
 import httpx
 import pytest
 
+from tests.utils.optional_dependencies import require_module
+
 # Suppress Windows ProactorEventLoop ResourceWarnings for this module
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"
 )
+require_module("pytest_asyncio", reason="OpenRouter connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="OpenRouter connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.openrouter import OpenRouterBackend
 from src.core.domain.chat import ChatMessage, ChatRequest

--- a/tests/unit/test_dependency_validation.py
+++ b/tests/unit/test_dependency_validation.py
@@ -16,6 +16,7 @@ import re
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,15 @@ pytestmark = [
         "ignore:.*Construction of dict of EntryPoints is deprecated.*:DeprecationWarning"
     ),
 ]
+
+
+@dataclass
+class DependencyCheckResult:
+    """Structured result returned by :meth:`DependencyValidator.validate_dependencies`."""
+
+    installed: list[str]
+    missing_required: list[str]
+    missing_optional: list[str]
 
 
 class DependencyValidator:
@@ -142,27 +152,31 @@ class DependencyValidator:
         with open(self.pyproject_path, "rb") as f:
             return tomli.load(f)
 
-    def _extract_dependencies(self, pyproject_data: dict[str, Any]) -> list[str]:
-        """Extract all dependencies from pyproject.toml.
+    def _extract_dependencies(
+        self, pyproject_data: dict[str, Any]
+    ) -> list[tuple[str, str | None]]:
+        """Extract dependencies and record whether they are optional extras.
 
         Args:
-            pyproject_data: The parsed pyproject.toml content
+            pyproject_data: The parsed pyproject.toml content.
 
         Returns:
-            List of all dependency specifications (main + optional dev dependencies)
+            A list of ``(requirement, group_name)`` tuples where ``group_name`` is
+            ``None`` for required dependencies and contains the optional group name
+            for extras (e.g. ``"dev"``).
         """
-        dependencies = []
+        dependencies: list[tuple[str, str | None]] = []
 
         # Extract main dependencies
         project_deps = pyproject_data.get("project", {}).get("dependencies", [])
-        dependencies.extend(project_deps)
+        dependencies.extend((dep, None) for dep in project_deps)
 
         # Extract optional dependencies (like dev dependencies)
         optional_deps = pyproject_data.get("project", {}).get(
             "optional-dependencies", {}
         )
-        for dep_group in optional_deps.values():
-            dependencies.extend(dep_group)
+        for group_name, dep_group in optional_deps.items():
+            dependencies.extend((dep, group_name) for dep in dep_group)
 
         return dependencies
 
@@ -282,27 +296,38 @@ class DependencyValidator:
 
         return False
 
-    def validate_dependencies(self) -> tuple[list[str], list[str]]:
+    def validate_dependencies(self) -> DependencyCheckResult:
         """Validate all dependencies from pyproject.toml.
 
         Returns:
-            A tuple of (installed_dependencies, missing_dependencies)
+            A :class:`DependencyCheckResult` with installed and missing packages
+            separated into required dependencies and optional extras.
         """
         pyproject_data = self._load_pyproject_toml()
         dependencies = self._extract_dependencies(pyproject_data)
 
-        installed = []
-        missing = []
+        installed: list[str] = []
+        missing_required: list[str] = []
+        missing_optional: list[str] = []
 
-        for dep_spec in dependencies:
+        for dep_spec, group_name in dependencies:
             package_name = self._normalize_package_name(dep_spec)
 
             if self._is_package_installed(package_name):
                 installed.append(dep_spec)
             else:
-                missing.append(dep_spec)
+                if group_name is None:
+                    missing_required.append(dep_spec)
+                else:
+                    missing_optional.append(
+                        f"{dep_spec} (optional group: {group_name})"
+                    )
 
-        return installed, missing
+        return DependencyCheckResult(
+            installed=installed,
+            missing_required=missing_required,
+            missing_optional=missing_optional,
+        )
 
 
 class TestDependencyValidation:
@@ -328,16 +353,25 @@ class TestDependencyValidation:
         2. Check if each dependency is installed and importable
         3. Fail with an informative message listing any missing dependencies
         """
-        installed, missing = validator.validate_dependencies()
+        result = validator.validate_dependencies()
 
-        # Create informative error message if any dependencies are missing
-        if missing:
-            missing_list = "\n  - ".join(missing)
-            total_deps = len(installed) + len(missing)
+        # If optional dependencies are missing but required ones are present, skip with context
+        if result.missing_optional and not result.missing_required:
+            missing_optional_list = "\n  - ".join(result.missing_optional)
+            pytest.skip(
+                "Optional development dependencies are not installed in this "
+                "environment:\n  - " + missing_optional_list
+            )
+
+        # Create informative error message if any required dependencies are missing
+        if result.missing_required:
+            missing_list = "\n  - ".join(result.missing_required)
+            total_deps = len(result.installed) + len(result.missing_required)
 
             error_msg = (
-                f"Missing dependencies detected!\n\n"
-                f"Found {len(missing)} missing dependencies out of {total_deps} total:\n"
+                f"Missing required dependencies detected!\n\n"
+                f"Found {len(result.missing_required)} missing required dependencies "
+                f"out of {total_deps} required packages:\n"
                 f"  - {missing_list}\n\n"
                 f"To fix this issue, run:\n"
                 f"  ./.venv/Scripts/python.exe -m pip install -e .[dev]\n\n"
@@ -347,9 +381,11 @@ class TestDependencyValidation:
             )
             pytest.fail(error_msg)
 
-        # If we get here, all dependencies are installed
-        assert len(missing) == 0, "All dependencies should be installed"
-        assert len(installed) > 0, "Should have found some installed dependencies"
+        # If we get here, all required dependencies are installed
+        assert not result.missing_required, "All required dependencies should be installed"
+        assert (
+            len(result.installed) > 0
+        ), "Should have found some installed dependencies"
 
     def test_pyproject_toml_exists_and_is_valid(
         self, validator: DependencyValidator

--- a/tests/unit/zai_connector_tests/test_domain_to_connector.py
+++ b/tests/unit/zai_connector_tests/test_domain_to_connector.py
@@ -9,7 +9,12 @@ from collections.abc import AsyncGenerator
 
 import httpx
 import pytest
+
+from tests.utils.optional_dependencies import require_module
+
+require_module("pytest_asyncio", reason="ZAI connector tests need pytest-asyncio")
 import pytest_asyncio
+require_module("pytest_httpx", reason="ZAI connector tests need pytest-httpx")
 from pytest_httpx import HTTPXMock
 from src.connectors.zai import ZAIConnector
 from src.core.domain.chat import (

--- a/tests/utils/optional_dependencies.py
+++ b/tests/utils/optional_dependencies.py
@@ -1,0 +1,38 @@
+"""Utilities for handling optional test dependencies.
+
+These helpers allow tests to gracefully skip when optional third-party
+packages are not installed in the execution environment. This is
+particularly useful for CI environments that only install the core
+project dependencies but omit heavyweight testing extras.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Optional
+
+import pytest
+
+
+def require_module(module_name: str, *, reason: Optional[str] = None) -> ModuleType:
+    """Import ``module_name`` or skip the current test module.
+
+    The function attempts to import the requested module. If the module is
+    unavailable, ``pytest.skip`` is invoked with ``allow_module_level=True`` so
+    that the entire test module is skipped during collection instead of raising
+    an import error.
+
+    Args:
+        module_name: The dotted path of the module to import.
+        reason: Optional human-readable explanation for the skip message.
+
+    Returns:
+        The imported module when available.
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in CI
+        skip_reason = reason or f"Optional dependency '{module_name}' is not installed"
+        pytest.skip(skip_reason, allow_module_level=True)
+        raise AssertionError("pytest.skip should halt execution") from exc


### PR DESCRIPTION
## Summary
- add a shared helper for importing optional test dependencies and skipping modules when they are absent
- update pytest modules that rely on pytest-asyncio, pytest-httpx, respx, pytest-mock, or hypothesis to use the new helper
- refine dependency validation so optional extras are reported separately and skipped when missing instead of failing the suite

## Testing
- python -m pytest -o addopts='' *(fails: numerous pre-existing integration/unit failures once collection succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2b87b12883338f68e388c4672d08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added optional dependency checks across integration and unit tests to gracefully skip when tools aren’t installed, improving stability and consistency.
  * Streamlined async and HTTP-mocking test setup by centralizing dependency gating and removing ad hoc skip patterns.
  * Enhanced dependency validation tests to use structured results with clearer reporting of installed, missing required, and missing optional items, improving diagnostics.
  * Overall, test runs now fail or skip earlier with clearer reasons, reducing noise and flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->