### PR TITLE
Cache tiktoken encoding in Gemini CLI ACP connector

### DIFF
--- a/src/connectors/gemini_cli_acp.py
+++ b/src/connectors/gemini_cli_acp.py
@@ -54,6 +54,7 @@ import logging
 import os
 import subprocess
 import uuid
+from functools import lru_cache
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
@@ -90,6 +91,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_PROCESS_TIMEOUT = 300.0  # 5 minutes for complex operations
 DEFAULT_CONNECTION_TIMEOUT = 60.0
 DEFAULT_IDLE_TIMEOUT = 30.0  # Kill process if idle for this long
+
+
+@lru_cache(maxsize=1)
+def _cl100k_encoding() -> tiktoken.Encoding:
+    """Lazily load and cache the cl100k_base encoding."""
+
+    return tiktoken.get_encoding("cl100k_base")
 
 
 class GeminiCliAcpConnector(GeminiBackend):
@@ -699,7 +707,7 @@ class GeminiCliAcpConnector(GeminiBackend):
             Estimated token count
         """
         try:
-            encoding = tiktoken.get_encoding("cl100k_base")
+            encoding = _cl100k_encoding()
             return len(encoding.encode(text))
         except Exception:
             # Fallback: rough estimate


### PR DESCRIPTION
## Summary
- cache the cl100k_base tiktoken encoding used by the Gemini CLI ACP connector
- reuse the cached encoding when estimating token counts to avoid repeated lookups

## Testing
- python -m pytest -o addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68ec2f427ce08333b4c1e4ecd4777ede

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented caching for the token encoder to avoid repeated re-initialization across calls.
* **Performance**
  * Improved responsiveness during token estimation and request preparation, especially in repeated operations.
  * Reduced overhead leads to smoother, faster interactions in workflows that process multiple prompts or messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->