### PR TITLE
Optimize streaming rewrite buffer handling

### DIFF
--- a/src/core/app/middleware/content_rewriting_middleware.py
+++ b/src/core/app/middleware/content_rewriting_middleware.py
@@ -395,10 +395,15 @@ class ContentRewritingMiddleware(BaseHTTPMiddleware):
         if isinstance(response, StreamingResponse):
 
             async def new_iterator():
-                response_body = b""
+                # StreamingResponse.body_iterator yields immutable bytes objects.
+                # Using += on bytes forces Python to allocate a brand-new object for
+                # every chunk, resulting in quadratic time/memory behaviour for
+                # long streams. Collect the chunks in a mutable buffer instead and
+                # only coerce to bytes once before rewriting.
+                buffer = bytearray()
                 async for chunk in response.body_iterator:
-                    response_body += chunk
-                rewritten_body = self.rewriter.rewrite_reply(response_body.decode())
+                    buffer.extend(chunk)
+                rewritten_body = self.rewriter.rewrite_reply(buffer.decode())
                 yield rewritten_body.encode("utf-8")
 
             background = response.background


### PR DESCRIPTION
## Summary
- replace repeated byte concatenation in the content rewriting middleware's streaming path with a bytearray buffer to avoid quadratic copying
- document the reason for using a mutable buffer when rewriting streaming responses

## Testing
- python -m pytest --override-ini addopts="" tests/integration/test_content_rewriting_middleware.py
- python -m pytest --override-ini addopts="" *(fails: missing local dev dependencies such as pytest-asyncio, pytest-httpx, respx)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2f427ce08333b4c1e4ecd4777ede

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized how streaming responses are assembled to significantly improve performance and memory efficiency, especially for long messages.
  * Users should notice smoother streaming, reduced lag, and fewer memory spikes during lengthy replies.
  * Enhances reliability and stability under heavy load without changing visible behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->