### PR TITLE
Optimize session repository user tracking

### DIFF
--- a/src/core/repositories/in_memory_session_repository.py
+++ b/src/core/repositories/in_memory_session_repository.py
@@ -22,6 +22,8 @@ class InMemorySessionRepository(ISessionRepository):
         self._sessions: dict[str, Session] = {}
         self._user_sessions: dict[str, list[str]] = {}
         self._last_accessed: dict[str, float] = {}
+        # Track owning user for each session to avoid costly scans during updates
+        self._session_to_user: dict[str, str] = {}
 
     async def get_by_id(self, id: str) -> Session | None:
         """Get a session by its ID."""
@@ -41,9 +43,13 @@ class InMemorySessionRepository(ISessionRepository):
 
         # Track by user if available
         if hasattr(entity, "user_id") and entity.user_id:
-            if entity.user_id not in self._user_sessions:
-                self._user_sessions[entity.user_id] = []
-            self._user_sessions[entity.user_id].append(entity.id)
+            user_id = entity.user_id
+            self._session_to_user[entity.id] = user_id
+            if user_id not in self._user_sessions:
+                self._user_sessions[user_id] = []
+            self._user_sessions[user_id].append(entity.id)
+        else:
+            self._session_to_user.pop(entity.id, None)
 
         return entity
 
@@ -53,15 +59,8 @@ class InMemorySessionRepository(ISessionRepository):
         if existing_session is None:
             return await self.add(entity)
 
-        previous_user_id = next(
-            (
-                user_id
-                for user_id, session_ids in self._user_sessions.items()
-                if entity.id in session_ids
-            ),
-            None,
-        )
-        new_user_id = getattr(entity, "user_id", None)
+        previous_user_id = self._session_to_user.get(entity.id)
+        new_user_id = getattr(entity, "user_id", None) or None
 
         self._sessions[entity.id] = entity
         self._last_accessed[entity.id] = time.time()
@@ -72,11 +71,15 @@ class InMemorySessionRepository(ISessionRepository):
                 tracked_sessions.remove(entity.id)
                 if not tracked_sessions:
                     del self._user_sessions[previous_user_id]
+            self._session_to_user.pop(entity.id, None)
 
         if new_user_id:
             tracked_sessions = self._user_sessions.setdefault(new_user_id, [])
             if entity.id not in tracked_sessions:
                 tracked_sessions.append(entity.id)
+            self._session_to_user[entity.id] = new_user_id
+        else:
+            self._session_to_user.pop(entity.id, None)
 
         return entity
 
@@ -93,11 +96,14 @@ class InMemorySessionRepository(ISessionRepository):
                     and id in self._user_sessions[user_id]
                 ):
                     self._user_sessions[user_id].remove(id)
+                if not self._user_sessions.get(user_id):
+                    self._user_sessions.pop(user_id, None)
 
             # Remove from main collections
             del self._sessions[id]
             if id in self._last_accessed:
                 del self._last_accessed[id]
+            self._session_to_user.pop(id, None)
 
             return True
         return False

--- a/tests/unit/core/repositories/test_in_memory_session_repository.py
+++ b/tests/unit/core/repositories/test_in_memory_session_repository.py
@@ -80,6 +80,7 @@ class TestInMemorySessionRepository:
         """Test repository initialization."""
         assert repository._sessions == {}
         assert repository._user_sessions == {}
+        assert repository._session_to_user == {}
 
     @pytest.mark.asyncio
     async def test_get_by_id_empty_repository(
@@ -111,6 +112,9 @@ class TestInMemorySessionRepository:
         # Check user tracking
         assert "user-456" in repository._user_sessions
         assert sample_session.session_id in repository._user_sessions["user-456"]
+        assert (
+            repository._session_to_user[sample_session.session_id] == "user-456"
+        )
 
     @pytest.mark.asyncio
     async def test_add_session_without_user_id(
@@ -124,6 +128,7 @@ class TestInMemorySessionRepository:
 
         # Should not create user tracking for sessions without user_id
         assert repository._user_sessions == {}
+        assert repository._session_to_user == {}
 
     @pytest.mark.asyncio
     async def test_get_by_id_existing_session(
@@ -179,6 +184,7 @@ class TestInMemorySessionRepository:
             "user-456", []
         )
         assert repository._user_sessions.get("user-789") == [sample_session.session_id]
+        assert repository._session_to_user[sample_session.session_id] == "user-789"
 
     @pytest.mark.asyncio
     async def test_update_session_removes_user_tracking_when_user_cleared(
@@ -197,6 +203,7 @@ class TestInMemorySessionRepository:
             sample_session.session_id not in sessions
             for sessions in repository._user_sessions.values()
         )
+        assert sample_session.session_id not in repository._session_to_user
 
     @pytest.mark.asyncio
     async def test_update_nonexistent_session(
@@ -220,7 +227,9 @@ class TestInMemorySessionRepository:
         assert sample_session.session_id not in repository._sessions
 
         # Check user tracking cleanup
-        assert sample_session.session_id not in repository._user_sessions["user-456"]
+        user_sessions = repository._user_sessions.get("user-456")
+        assert not user_sessions or sample_session.session_id not in user_sessions
+        assert sample_session.session_id not in repository._session_to_user
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_session(
@@ -357,7 +366,9 @@ class TestInMemorySessionRepository:
         await repository.delete(sample_session.session_id)
 
         # Verify user tracking is cleaned up
-        assert sample_session.session_id not in repository._user_sessions["user-456"]
+        user_sessions = repository._user_sessions.get("user-456")
+        assert not user_sessions or sample_session.session_id not in user_sessions
+        assert sample_session.session_id not in repository._session_to_user
 
     @pytest.mark.asyncio
     async def test_get_all_returns_copy(


### PR DESCRIPTION
## Summary
- cache the owning user for each session in the in-memory repository to avoid repeatedly scanning every tracked user during updates and deletes
- extend the repository unit tests to cover the new session-to-user mapping and cleanup behaviour

## Testing
- `python -m pytest -o addopts="" tests/unit/core/repositories/test_in_memory_session_repository.py`
- `python -m pytest -o addopts=""` *(fails: missing optional test dependencies such as pytest_asyncio, pytest_httpx, respx)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2f427ce08333b4c1e4ecd4777ede

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized session ownership tracking to avoid costly scans, improving performance and consistency across add, update, and delete operations. No public API changes.
- Tests
  - Expanded unit tests to validate initialization, updates, and cleanup of session-to-user associations throughout the session lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->