### PR TITLE
Handle missing session ids in pytest steering

### DIFF
--- a/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
+++ b/src/core/services/tool_call_handlers/pytest_full_suite_handler.py
@@ -198,7 +198,14 @@ class PytestFullSuiteHandler(IToolCallHandler):
         if not _looks_like_full_suite(normalized):
             return False
 
-        state = self._session_state.get(context.session_id)
+        session_key = context.session_id.strip() if context.session_id else None
+        if not session_key:
+            # Without a stable session identifier we cannot track per-session
+            # steering state. Treat the command as new so that we do not leak
+            # steering behaviour across unrelated requests.
+            return True
+
+        state = self._session_state.get(session_key)
         return not (state and state.last_command == normalized)
 
     async def handle(self, context: ToolCallContext) -> ToolCallReactionResult:
@@ -213,7 +220,28 @@ class PytestFullSuiteHandler(IToolCallHandler):
         if not _looks_like_full_suite(normalized):
             return ToolCallReactionResult(should_swallow=False)
 
-        state = self._session_state.setdefault(context.session_id, _SessionState())
+        session_key = context.session_id.strip() if context.session_id else None
+
+        if session_key is None:
+            # Without a reliable session identifier we cannot remember previous
+            # steering decisions. Swallow this invocation but avoid mutating the
+            # global state dictionary so that other requests are unaffected.
+            logger.info(
+                "Steering full-suite pytest command without session id: %s",
+                normalized,
+            )
+            return ToolCallReactionResult(
+                should_swallow=True,
+                replacement_response=self._message,
+                metadata={
+                    "handler": self.name,
+                    "tool_name": context.tool_name,
+                    "command": normalized,
+                    "source": "pytest_full_suite_steering",
+                },
+            )
+
+        state = self._session_state.setdefault(session_key, _SessionState())
         if state.last_command == normalized:
             return ToolCallReactionResult(should_swallow=False)
 
@@ -221,7 +249,7 @@ class PytestFullSuiteHandler(IToolCallHandler):
 
         logger.info(
             "Steering full-suite pytest command in session %s: %s",
-            context.session_id,
+            session_key,
             normalized,
         )
 

--- a/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
+++ b/tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
@@ -105,6 +105,21 @@ async def test_handler_allows_second_session_immediately() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handler_handles_missing_session_id_without_state_leak() -> None:
+    handler = PytestFullSuiteHandler(enabled=True)
+    first = _build_context("pytest", session_id="")
+    second = _build_context("pytest", session_id="")
+
+    assert await handler.can_handle(first) is True
+    first_result = await handler.handle(first)
+    assert first_result.should_swallow is True
+
+    assert await handler.can_handle(second) is True
+    second_result = await handler.handle(second)
+    assert second_result.should_swallow is True
+
+
+@pytest.mark.asyncio
 async def test_handler_passes_through_targeted_pytest() -> None:
     handler = PytestFullSuiteHandler(enabled=True)
     context = _build_context("pytest tests/unit/test_example.py")


### PR DESCRIPTION
## Summary
- guard the pytest full-suite steering handler against empty session identifiers so one request cannot leak state to others
- add a regression test ensuring missing session ids still trigger the steering response for each request

## Testing
- python -m pytest -o addopts='' tests/unit/core/services/tool_call_handlers/test_pytest_full_suite_handler.py
- python -m pytest -o addopts=''

------
https://chatgpt.com/codex/tasks/task_e_68ec25089a4c8333a7c641442c526119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when session information is missing to prevent unintended actions and cross-session state leakage.
  * Ensures repeated commands are handled correctly within a session and improves log clarity with consistent identifiers.

* **Tests**
  * Added test coverage for scenarios with missing session information to validate safe, consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->