### PR TITLE
Fix connector identity scoping

### DIFF
--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -61,7 +61,6 @@ class OpenAIConnector(LLMBackend):
         self.available_models: list[str] = []
         self.api_key: str | None = None
         self.api_base_url: str = "https://api.openai.com/v1"
-        self.identity: Any | None = None
 
         # Health check attributes
         self._health_checked: bool = False
@@ -95,7 +94,9 @@ class OpenAIConnector(LLMBackend):
             )
         return service
 
-    def get_headers(self) -> dict[str, str]:
+    def get_headers(
+        self, identity: IAppIdentityConfig | None = None
+    ) -> dict[str, str]:
         """Return request headers including API key and per-request identity."""
 
         headers: dict[str, str] = {}
@@ -103,9 +104,9 @@ class OpenAIConnector(LLMBackend):
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
-        if self.identity:
+        if identity:
             try:
-                identity_headers = self.identity.get_resolved_headers(None)
+                identity_headers = identity.get_resolved_headers(None)
             except Exception:
                 identity_headers = {}
             if identity_headers:
@@ -246,9 +247,6 @@ class OpenAIConnector(LLMBackend):
         # Cast to CanonicalChatRequest for mypy compatibility with _prepare_payload signature
         domain_request: CanonicalChatRequest = cast(CanonicalChatRequest, request_data)
 
-        # Ensure identity headers are scoped to the current request only.
-        self.identity = identity
-
         # Prepare the payload using a helper so subclasses and tests can
         # override or patch payload construction logic easily.
         payload = await self._prepare_payload(
@@ -263,7 +261,7 @@ class OpenAIConnector(LLMBackend):
             headers = dict(headers_override)
 
             try:
-                base_headers = self.get_headers()
+                base_headers = self.get_headers(identity)
             except Exception:
                 base_headers = None
 
@@ -273,12 +271,7 @@ class OpenAIConnector(LLMBackend):
                 headers = merged_headers
         else:
             try:
-                # Always update the cached identity so that per-request
-                # identity headers do not leak between calls. Downstream
-                # callers rely on identity-specific headers being scoped to
-                # a single request.
-                self.identity = identity
-                headers = self.get_headers()
+                headers = self.get_headers(identity)
             except Exception:
                 headers = None
 
@@ -569,9 +562,6 @@ class OpenAIConnector(LLMBackend):
         if effective_model:
             payload["model"] = effective_model
 
-        # Ensure identity headers are scoped per request before computing headers.
-        self.identity = identity
-
         # Update messages with processed_messages if available
         if processed_messages:
             try:
@@ -612,12 +602,9 @@ class OpenAIConnector(LLMBackend):
         if headers_override is not None:
             resolved_headers = dict(headers_override)
 
-        if identity:
-            self.identity = identity
-
         base_headers: dict[str, str] | None
         try:
-            base_headers = self.get_headers()
+            base_headers = self.get_headers(identity)
         except Exception:
             base_headers = None
 

--- a/src/connectors/openrouter.py
+++ b/src/connectors/openrouter.py
@@ -90,15 +90,17 @@ class OpenRouterBackend(OpenAIConnector):
                 code="missing_credentials",
             ) from exc
 
-    def get_headers(self) -> dict[str, str]:
+    def get_headers(
+        self, identity: IAppIdentityConfig | None = None
+    ) -> dict[str, str]:
         if not self.headers_provider or not self.api_key:
             raise AuthenticationError(
                 message="OpenRouter headers provider or API key not set.",
                 code="missing_credentials",
             )
         headers = self._resolve_headers_from_provider()
-        if self.identity:
-            headers.update(self.identity.get_resolved_headers(None))
+        if identity:
+            headers.update(identity.get_resolved_headers(None))
         logger.info(
             f"OpenRouter headers: Authorization: Bearer {self.api_key[:20]}..., HTTP-Referer: {headers.get('HTTP-Referer', 'NOT_SET')}, X-Title: {headers.get('X-Title', 'NOT_SET')}"
         )
@@ -154,8 +156,6 @@ class OpenRouterBackend(OpenAIConnector):
         project: str | None = None,
         **kwargs: Any,
     ) -> ResponseEnvelope | StreamingResponseEnvelope:
-        self.identity = identity
-
         # request_data is expected to be a domain ChatRequest (or subclass like CanonicalChatRequest)
         # (the frontend controller converts from frontend-specific format to domain format)
         # Backends should ONLY convert FROM domain TO backend-specific format

--- a/src/connectors/qwen_oauth.py
+++ b/src/connectors/qwen_oauth.py
@@ -31,7 +31,6 @@ from src.core.config.app_config import AppConfig
 from src.core.domain.responses import ResponseEnvelope, StreamingResponseEnvelope
 from src.core.interfaces.configuration_interface import IAppIdentityConfig
 from src.core.interfaces.model_bases import DomainModel, InternalDTO
-from src.core.security.loop_prevention import ensure_loop_guard_header
 from src.core.services.backend_registry import backend_registry
 
 from .openai import OpenAIConnector
@@ -630,7 +629,9 @@ class QwenOAuthConnector(OpenAIConnector):
                 logger.error(f"Error loading Qwen OAuth credentials: {e}")
             return False
 
-    def get_headers(self) -> dict[str, str]:
+    def get_headers(
+        self, identity: IAppIdentityConfig | None = None
+    ) -> dict[str, str]:
         """Override to use access_token from loaded credentials."""
         if not self._oauth_credentials or not self._oauth_credentials.get(
             "access_token"
@@ -639,13 +640,15 @@ class QwenOAuthConnector(OpenAIConnector):
                 status_code=401,
                 detail="No valid Qwen OAuth access token available. Please authenticate.",
             )
-        return ensure_loop_guard_header(
+        headers = super().get_headers(identity)
+        headers.update(
             {
                 "Authorization": f"Bearer {self._oauth_credentials['access_token']}",
                 "Content-Type": "application/json",
                 "Accept": "application/json",
             }
         )
+        return headers
 
     async def _perform_health_check(self) -> bool:
         """Override parent health check to use Qwen-specific API endpoint."""

--- a/src/connectors/zai.py
+++ b/src/connectors/zai.py
@@ -103,18 +103,19 @@ class ZAIConnector(OpenAIConnector):
         if not self.available_models:
             self.available_models = self._default_models.copy()
 
-    def get_headers(self) -> dict[str, str]:
+    def get_headers(
+        self, identity: IAppIdentityConfig | None = None
+    ) -> dict[str, str]:
         """Get headers with ZAI API key."""
         if not self.api_key:
             raise AuthenticationError(
                 message="ZAI API key is not set.", code="missing_api_key"
             )
-        return ensure_loop_guard_header(
-            {
-                "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "application/json",
-            }
-        )
+
+        headers = super().get_headers(identity)
+        headers["Authorization"] = f"Bearer {self.api_key}"
+        headers["Content-Type"] = "application/json"
+        return headers
 
     def get_available_models(self) -> list[str]:
         """

--- a/tests/unit/openai_connector_tests/test_identity_scoping.py
+++ b/tests/unit/openai_connector_tests/test_identity_scoping.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -159,3 +160,55 @@ async def test_responses_clears_identity_between_calls(
     assert observed_headers[1] is not None
     assert observed_headers[0].get("X-Test") == "one"
     assert "X-Test" not in observed_headers[1]
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_identity_is_isolated_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = AsyncMock()
+    connector = OpenAIConnector(client=client, config=AppConfig())
+    connector.api_key = "token"
+    connector.disable_health_check()
+
+    proceed = asyncio.Event()
+    observed_headers: dict[str, dict[str, str]] = {}
+
+    async def fake_handle(
+        self: OpenAIConnector,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None,
+        session_id: str,
+    ) -> ResponseEnvelope:
+        observed_headers[session_id] = dict(headers or {})
+        if session_id == "session-a":
+            await proceed.wait()
+        else:
+            proceed.set()
+        return ResponseEnvelope(content={}, headers={}, status_code=200)
+
+    monkeypatch.setattr(
+        OpenAIConnector,
+        "_handle_non_streaming_response",
+        fake_handle,
+    )
+
+    base_request = _build_request()
+    request_one = base_request.model_copy(update={"session_id": "session-a"})
+    request_two = base_request.model_copy(update={"session_id": "session-b"})
+
+    identity_one = DummyIdentity({"X-Test": "one"})
+    identity_two = DummyIdentity({"X-Test": "two"})
+
+    await asyncio.gather(
+        connector.chat_completions(
+            request_one, [], "gpt-4", identity=identity_one
+        ),
+        connector.chat_completions(
+            request_two, [], "gpt-4", identity=identity_two
+        ),
+    )
+
+    assert observed_headers["session-a"].get("X-Test") == "one"
+    assert observed_headers["session-b"].get("X-Test") == "two"


### PR DESCRIPTION
## Summary
- scope per-request identity headers in the OpenAI and OpenRouter connectors so concurrent calls cannot leak headers across sessions
- add a regression test that issues concurrent chat completions to ensure identity headers remain isolated

## Testing
- python -m pytest -o addopts="" tests/unit/openai_connector_tests/test_identity_scoping.py
- python -m pytest -o addopts=""
  - fails: missing optional test dependencies (pytest-asyncio, pytest_httpx, respx, hypothesis)


------
https://chatgpt.com/codex/tasks/task_e_68ec25089a4c8333a7c641442c526119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Switched to per-request identity handling for API headers, removing shared connector state so identity headers are scoped to individual requests.

- Tests
  - Added a concurrency test that verifies identity header isolation across simultaneous requests.

- Bug Fixes
  - Fixed unintended carryover of identity headers between requests to improve reliability in concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->