### PR TITLE
Handle optional test dependency availability

### DIFF
--- a/tests/integration/test_zai_coding_plan.py
+++ b/tests/integration/test_zai_coding_plan.py
@@ -1,5 +1,7 @@
 import pytest
 from httpx import Response
+
+pytest.importorskip("respx")
 from respx import MockRouter
 from starlette.testclient import TestClient
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-import respx
 from src.core.domain.session import Session, SessionState
 
 
@@ -267,7 +266,7 @@ class MockSessionService:
 
 
 def mock_backend_api(
-    respx_mock: respx.Router, base_url: str = "https://api.openai.com/v1"
+    respx_mock: Any, base_url: str = "https://api.openai.com/v1"
 ) -> None:
     """Mock backend API calls for testing.
 

--- a/tests/unit/connectors/test_streaming_utils.py
+++ b/tests/unit/connectors/test_streaming_utils.py
@@ -4,6 +4,8 @@ Tests for the streaming utilities module using Hypothesis for property-based tes
 
 import pytest
 
+pytest.importorskip("hypothesis")
+
 # Suppress Windows ProactorEventLoop ResourceWarnings for this module
 pytestmark = pytest.mark.filterwarnings(
     "ignore:unclosed event loop <ProactorEventLoop.*:ResourceWarning"

--- a/tests/unit/core/services/test_backend_service_hypothesis.py
+++ b/tests/unit/core/services/test_backend_service_hypothesis.py
@@ -7,6 +7,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+
+pytest.importorskip("hypothesis")
+
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from src.connectors.base import LLMBackend


### PR DESCRIPTION
## Summary
- skip respx-dependent integration test when the optional dependency is missing
- make hypothesis-based test modules self-skipping when Hypothesis is absent
- avoid importing respx in shared helpers so other tests do not fail when it is unavailable

## Testing
- `pytest tests/integration/test_zai_coding_plan.py -k nothing --maxfail=1`
- `pytest tests/unit/connectors/test_streaming_utils.py -k nothing --maxfail=1`
- `pytest tests/unit/core/services/test_backend_service_hypothesis.py -k nothing --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68ef79847e088333ad4ca9f40f216108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Conditionally skip relevant test suites when optional dependencies (HTTP mocking and property-based testing libraries) are not installed, preventing spurious failures in lean environments.
  * Relaxed a test helper’s parameter type to accept generic mocks, improving flexibility and compatibility across setups.
  * No impact on runtime behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->