### PR TITLE
Fix tool call session alias isolation

### DIFF
--- a/src/core/services/tool_call_reactor_service.py
+++ b/src/core/services/tool_call_reactor_service.py
@@ -51,7 +51,11 @@ class ToolCallReactorService(IToolCallReactor):
         self._history_tracker = history_tracker
         self._lock = asyncio.Lock()
         self._sorted_handlers: tuple[IToolCallHandler, ...] | None = None
-        self._session_aliases: dict[str, str] = {}
+        # Map normalized alias keys to resolved session identifiers. Alias keys
+        # encode the source of the identifier (e.g., explicit session id,
+        # response id, object identity) so we never reuse aliases across
+        # unrelated requests when upstream callers omit a true session id.
+        self._session_aliases: dict[tuple[str, str], str] = {}
 
         # Telemetry counters for tool access control
         self._tool_definitions_filtered_count: int = 0
@@ -153,13 +157,7 @@ class ToolCallReactorService(IToolCallReactor):
             The reaction result from the first handler that swallows the call,
             or None if no handler swallows it.
         """
-        raw_session_id = context.session_id
-        alias_key = raw_session_id if raw_session_id else "__empty__"
-        if alias_key not in self._session_aliases:
-            self._session_aliases[alias_key] = (
-                str(raw_session_id) if raw_session_id else uuid4().hex
-            )
-        resolved_session_id = self._session_aliases[alias_key]
+        resolved_session_id = self._resolve_session_identifier(context)
 
         # Record the tool call in history if tracker is available
         if self._history_tracker:
@@ -220,6 +218,92 @@ class ToolCallReactorService(IToolCallReactor):
             f"No handler swallowed tool call '{context.tool_name}' in session {resolved_session_id}"
         )
         return None
+
+    @staticmethod
+    def _normalize_session_identifier(session_id: str | None) -> str | None:
+        """Normalize a raw session identifier value."""
+
+        if session_id is None:
+            return None
+
+        normalized = str(session_id).strip()
+        return normalized or None
+
+    @staticmethod
+    def _extract_response_identifier(full_response: Any) -> str | None:
+        """Extract a stable identifier from a full response payload."""
+
+        try:
+            if isinstance(full_response, dict):
+                candidate = full_response.get("id") or full_response.get("response_id")
+                if candidate:
+                    return str(candidate)
+
+            candidate = getattr(full_response, "id", None)
+            if candidate:
+                return str(candidate)
+        except Exception:
+            logger.debug("Failed to extract response identifier", exc_info=True)
+
+        return None
+
+    @staticmethod
+    def _extract_object_identity(full_response: Any) -> str | None:
+        """Fallback to an object identity when no identifier is provided."""
+
+        if full_response is None:
+            return None
+
+        return hex(id(full_response))
+
+    def _build_alias_key(
+        self, context: ToolCallContext
+    ) -> tuple[tuple[str, str], str | None] | None:
+        """Determine the alias key and preset value for a tool call context."""
+
+        normalized_session = self._normalize_session_identifier(context.session_id)
+        if normalized_session is not None:
+            return ("session", normalized_session), normalized_session
+
+        response_identifier = self._extract_response_identifier(context.full_response)
+        if response_identifier is not None:
+            return ("response", response_identifier), None
+
+        object_identity = self._extract_object_identity(context.full_response)
+        if object_identity is not None:
+            return ("object", object_identity), None
+
+        return None
+
+    def _resolve_session_identifier(self, context: ToolCallContext) -> str:
+        """Resolve a stable session identifier for the given tool call context."""
+
+        alias_info = self._build_alias_key(context)
+        if alias_info is None:
+            return uuid4().hex
+
+        alias_key, preset_value = alias_info
+        if alias_key not in self._session_aliases:
+            resolved_value = preset_value if preset_value is not None else uuid4().hex
+            self._session_aliases[alias_key] = resolved_value
+
+        return self._session_aliases[alias_key]
+
+    async def clear_history(self, session_id: str | None = None) -> None:
+        """Clear tracked history and alias mappings for a session."""
+
+        if self._history_tracker is not None:
+            await self._history_tracker.clear_history(session_id)
+
+        if session_id is None:
+            self._session_aliases.clear()
+            return
+
+        keys_to_remove = [
+            key for key, value in self._session_aliases.items() if value == session_id
+        ]
+        for key in keys_to_remove:
+            self._session_aliases.pop(key, None)
 
     def get_registered_handlers(self) -> list[str]:
         """Get the names of all registered handlers.

--- a/tests/unit/core/services/test_tool_call_reactor_service.py
+++ b/tests/unit/core/services/test_tool_call_reactor_service.py
@@ -93,6 +93,67 @@ async def test_tool_call_reactor_aliases_empty_session_ids() -> None:
     assert tracker.records[2][0] == "explicit-session"
 
 
+@pytest.mark.asyncio
+async def test_tool_call_reactor_isolates_missing_session_ids_across_requests() -> None:
+    tracker = _RecordingHistoryTracker()
+    service = ToolCallReactorService(history_tracker=tracker)
+    handler = _PassthroughHandler()
+    await service.register_handler(handler)
+
+    first_context = ToolCallContext(
+        session_id="",
+        backend_name="test-backend",
+        model_name="model",
+        full_response={"id": "resp-1"},
+        tool_name="dummy",
+        tool_arguments={},
+    )
+
+    second_context = ToolCallContext(
+        session_id="",
+        backend_name="test-backend",
+        model_name="model",
+        full_response={"id": "resp-2"},
+        tool_name="dummy",
+        tool_arguments={},
+    )
+
+    await service.process_tool_call(first_context)
+    await service.process_tool_call(second_context)
+
+    assert len(tracker.records) == 2
+    first_alias, second_alias = tracker.records[0][0], tracker.records[1][0]
+    assert first_alias != second_alias
+
+
+@pytest.mark.asyncio
+async def test_clear_history_removes_alias_mapping() -> None:
+    tracker = _RecordingHistoryTracker()
+    service = ToolCallReactorService(history_tracker=tracker)
+    handler = _PassthroughHandler()
+    await service.register_handler(handler)
+
+    context = ToolCallContext(
+        session_id="",
+        backend_name="backend",
+        model_name="model",
+        full_response={"id": "resp-123"},
+        tool_name="dummy",
+        tool_arguments={},
+    )
+
+    await service.process_tool_call(context)
+    assert tracker.records
+    alias = tracker.records[0][0]
+    assert any(value == alias for value in service._session_aliases.values())
+
+    await service.clear_history(alias)
+    assert all(value != alias for value in service._session_aliases.values())
+
+    await service.clear_history(None)
+    assert not service._session_aliases
+
+
 class MockToolCallHandler(IToolCallHandler):
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- ensure ToolCallReactorService resolves session identifiers per request using response metadata or generated aliases to avoid cross-request leakage
- add a clear_history helper so alias caches can be flushed alongside recorded history
- extend tool call reactor unit tests to cover missing-session isolation and alias cleanup behaviour

## Testing
- python -m pytest tests/unit/core/services/test_tool_call_reactor_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dda42d38483338f509b2080f04935)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve session IDs per request using response/identity-based aliases and add clear_history; expand tests to cover alias isolation and cleanup.
> 
> - **Core Service (`src/core/services/tool_call_reactor_service.py`)**:
>   - **Session aliasing**: Replace flat alias map with keyed aliases (`("session"|"response"|"object", value) -> session_id`).
>   - **Identifier resolution**: Add `_normalize_session_identifier`, `_extract_response_identifier`, `_extract_object_identity`, and `_build_alias_key`; use `_resolve_session_identifier` in `process_tool_call`.
>   - **History management**: Add `clear_history(session_id)` to flush tracker data and remove corresponding alias mappings.
> - **Tests (`tests/unit/core/services/test_tool_call_reactor_service.py`)**:
>   - Add tests for isolating missing-session IDs across requests via response IDs.
>   - Add tests verifying `clear_history` removes alias mappings.
>   - Keep existing handler ordering/cache invalidation tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e67255560d45e406ebb92362789407b34ab66763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded tool call processing engine to production-ready implementation with handler prioritization and registration/unregistration support
  * Added session aliasing and stable identifier resolution for consistent session management
  * Introduced tool call history tracking with configurable per-session retention limits
  * Implemented comprehensive telemetry and monitoring counters for tool interactions
  * Enhanced safety with bounded argument snapshotting and depth protection mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->