### PR TITLE
Use context-local override for tool text renderer

### DIFF
--- a/src/core/services/tool_text_renderer.py
+++ b/src/core/services/tool_text_renderer.py
@@ -5,6 +5,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from contextvars import ContextVar, Token
 from typing import Any
 
 from src.core.domain.chat import ToolCall
@@ -279,31 +280,35 @@ def reset_renderer_registry() -> None:
 
 
 # Context manager to temporarily override the renderer for a block of code
-_override: str | None = None
+_renderer_override: ContextVar[str | None] = ContextVar(
+    "tool_text_renderer_override",
+    default=None,
+)
 
 
 class OverrideRenderer:
     def __init__(self, renderer_name: str):
         self.renderer_name = renderer_name
-        self.original_override = _override
+        self._token: Token[str | None] | None = None
 
     def __enter__(self) -> None:
-        global _override
-        _override = self.renderer_name
+        self._token = _renderer_override.set(self.renderer_name)
 
     def __exit__(self, exc_type: Any, _: Any, traceback: Any) -> None:
-        global _override
-        _override = self.original_override
+        if self._token is not None:
+            _renderer_override.reset(self._token)
+            self._token = None
 
 
 def render_tool_call(tool_call: ToolCall) -> str | None:
     """Render a tool call using the currently active renderer."""
-    renderer_name = _override or _renderer_registry.default_renderer
+    override_name = _renderer_override.get()
+    renderer_name = override_name or _renderer_registry.default_renderer
     renderer = get_renderer(renderer_name)
     text = renderer.render(tool_call)
     if text:
         return text
-    if (_override or "").strip().lower() in {"", "none"}:
+    if (override_name or "").strip().lower() in {"", "none"}:
         return None
     fallback_name = _renderer_registry.fallback_renderer
     if fallback_name and fallback_name != renderer_name:


### PR DESCRIPTION
## Summary
- replace the global override flag in the tool text renderer with a ContextVar so overrides are scoped to the current context
- keep the override context manager semantics while avoiding cross-request pollution when multiple requests render tools concurrently

## Testing
- python -m pytest tests/unit/core/services/test_translation_service_responses_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd9a49da083338f40709e7f89a1b2)