### PR TITLE
Cap session repository size to prevent DoS

### DIFF
--- a/src/core/repositories/in_memory_session_repository.py
+++ b/src/core/repositories/in_memory_session_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from datetime import datetime, timezone
@@ -13,6 +14,9 @@ from src.core.services.conversation_fingerprint_service import (
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_MAX_SESSIONS = 1024
+
+
 class InMemorySessionRepository(ISessionRepository):
     """In-memory implementation of session repository.
 
@@ -20,8 +24,13 @@ class InMemorySessionRepository(ISessionRepository):
     It is suitable for development and testing.
     """
 
-    def __init__(self) -> None:
-        """Initialize the in-memory session repository."""
+    def __init__(self, max_sessions: int | None = DEFAULT_MAX_SESSIONS) -> None:
+        """Initialize the in-memory session repository.
+
+        Args:
+            max_sessions: Maximum number of sessions to retain in memory. ``None``
+                falls back to :data:`DEFAULT_MAX_SESSIONS`.
+        """
         self._sessions: dict[str, Session] = {}
         self._user_sessions: dict[str, list[str]] = {}
         self._last_accessed: dict[str, float] = {}
@@ -29,6 +38,10 @@ class InMemorySessionRepository(ISessionRepository):
         self._fingerprints: dict[str, str] = {}  # session_id -> fingerprint
         self._client_sessions: dict[str, list[str]] = {}  # client_key -> session_ids
         self._fingerprint_bundles: dict[str, ConversationFingerprintBundle] = {}
+        resolved_limit = (
+            DEFAULT_MAX_SESSIONS if max_sessions is None else max(int(max_sessions), 1)
+        )
+        self._max_sessions: int = resolved_limit
 
     async def get_by_id(self, id: str) -> Session | None:
         """Get a session by its ID."""
@@ -51,6 +64,8 @@ class InMemorySessionRepository(ISessionRepository):
             if entity.user_id not in self._user_sessions:
                 self._user_sessions[entity.user_id] = []
             self._user_sessions[entity.user_id].append(entity.id)
+
+        self._evict_if_necessary()
 
         return entity
 
@@ -89,45 +104,64 @@ class InMemorySessionRepository(ISessionRepository):
 
     async def delete(self, id: str) -> bool:
         """Delete a session by its ID."""
-        if id in self._sessions:
-            # Remove from user tracking
-            for user_id, session_ids in list(self._user_sessions.items()):
-                if id in session_ids:
-                    try:
-                        session_ids.remove(id)
-                    except ValueError:
-                        pass  # Already removed, consistent state is the goal
-                    if not session_ids:
-                        del self._user_sessions[user_id]
-
-            # Remove from fingerprint tracking
-            if id in self._fingerprints:
-                del self._fingerprints[id]
-            if id in self._fingerprint_bundles:
-                del self._fingerprint_bundles[id]
-
-            # Remove from client session tracking
-            for client_key, session_ids in list(self._client_sessions.items()):
-                if id in session_ids:
-                    try:
-                        session_ids.remove(id)
-                    except ValueError:
-                        pass  # Already removed
-                    if not session_ids:
-                        del self._client_sessions[client_key]
-
-            # Remove from main collections
-            del self._sessions[id]
-            if id in self._last_accessed:
-                del self._last_accessed[id]
-
-            return True
-        return False
+        return self._remove_session_internal(id)
 
     async def get_by_user_id(self, user_id: str) -> list[Session]:
         """Get all sessions for a specific user."""
         session_ids = self._user_sessions.get(user_id, [])
         return [self._sessions[id] for id in session_ids if id in self._sessions]
+
+    def _remove_session_internal(self, session_id: str) -> bool:
+        """Remove a session from all tracking structures."""
+        if session_id not in self._sessions:
+            return False
+
+        # Remove from user tracking
+        for user_id, session_ids in list(self._user_sessions.items()):
+            if session_id in session_ids:
+                with contextlib.suppress(ValueError):
+                    session_ids.remove(session_id)
+                if not session_ids:
+                    del self._user_sessions[user_id]
+
+        # Remove from fingerprint tracking
+        self._fingerprints.pop(session_id, None)
+        self._fingerprint_bundles.pop(session_id, None)
+
+        # Remove from client session tracking
+        for client_key, session_ids in list(self._client_sessions.items()):
+            if session_id in session_ids:
+                with contextlib.suppress(ValueError):
+                    session_ids.remove(session_id)
+                if not session_ids:
+                    del self._client_sessions[client_key]
+
+        # Remove from main collections
+        self._sessions.pop(session_id, None)
+        self._last_accessed.pop(session_id, None)
+
+        return True
+
+    def _evict_if_necessary(self) -> None:
+        """Ensure the repository does not exceed the configured session cap."""
+        overflow = len(self._sessions) - self._max_sessions
+        if overflow <= 0:
+            return
+
+        # Evict the least recently accessed sessions first
+        sorted_sessions = sorted(self._last_accessed.items(), key=lambda item: item[1])
+
+        for session_id, _ in sorted_sessions:
+            if overflow <= 0:
+                break
+            if self._remove_session_internal(session_id):
+                overflow -= 1
+                if logger.isEnabledFor(logging.INFO):
+                    logger.info(
+                        "Evicted session %s due to repository size limit (%s)",
+                        session_id,
+                        self._max_sessions,
+                    )
 
     async def cleanup_expired(self, max_age_seconds: int) -> int:
         """Clean up expired sessions.

--- a/src/core/repositories/session_repository.py
+++ b/src/core/repositories/session_repository.py
@@ -22,13 +22,20 @@ class PersistentSessionRepository(ISessionRepository):
     It would use file-based storage, a database, or another persistence mechanism.
     """
 
-    def __init__(self, storage_path: str | None = None):
+    def __init__(
+        self,
+        storage_path: str | None = None,
+        *,
+        max_sessions: int | None = None,
+    ):
         """Initialize the persistent session repository.
 
         Args:
             storage_path: Optional path to store sessions
         """
-        self._memory_repo = InMemorySessionRepository()  # Use in-memory as cache
+        self._memory_repo = InMemorySessionRepository(
+            max_sessions=max_sessions
+        )  # Use in-memory as cache
         self._storage_path = storage_path
         # Future: Initialize storage adapter based on storage_path
 

--- a/tests/unit/core/repositories/test_in_memory_session_repository.py
+++ b/tests/unit/core/repositories/test_in_memory_session_repository.py
@@ -391,3 +391,21 @@ class TestInMemorySessionRepository:
         assert await repository.delete("any") is False
         assert await repository.get_by_user_id("any") == []
         assert await repository.cleanup_expired(0) == 0
+
+    @pytest.mark.asyncio
+    async def test_max_sessions_eviction(self) -> None:
+        """Repository should evict least-recently-used sessions when full."""
+        repo = InMemorySessionRepository(max_sessions=3)
+
+        # Insert more sessions than the cap.
+        sessions = [Session(session_id=f"session-{i}") for i in range(5)]
+        for session in sessions:
+            await repo.add(session)
+
+        # Only the three most recent sessions should remain.
+        remaining_ids = set(repo._sessions.keys())
+        assert remaining_ids == {
+            sessions[2].session_id,
+            sessions[3].session_id,
+            sessions[4].session_id,
+        }

--- a/tests/unit/core/repositories/test_persistent_session_repository.py
+++ b/tests/unit/core/repositories/test_persistent_session_repository.py
@@ -198,6 +198,21 @@ class TestPersistentSessionRepository:
         assert persistent_result is sample_session
 
     @pytest.mark.asyncio
+    async def test_max_sessions_limit(self) -> None:
+        """Persistent repository should respect max session limits."""
+        repository = PersistentSessionRepository(max_sessions=2)
+
+        sessions = [Session(session_id=f"persist-{i}") for i in range(4)]
+        for session in sessions:
+            await repository.add(session)
+
+        remaining_ids = set(repository._memory_repo._sessions.keys())
+        assert remaining_ids == {
+            sessions[2].session_id,
+            sessions[3].session_id,
+        }
+
+    @pytest.mark.asyncio
     async def test_multiple_operations_work_consistently(
         self, repository: PersistentSessionRepository, sample_session: Session
     ) -> None:


### PR DESCRIPTION
## Summary
- add a configurable maximum capacity to the in-memory session repository and evict least-recently-used sessions when it is exceeded
- expose the `max_sessions` option on the persistent repository wrapper so alternate entry points can enforce the same limit
- cover the new behaviour with focused unit tests for both repositories

## Testing
- python -m pytest *(fails: missing optional lint/security tooling and snapshot plugin in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd689007c8333a6e85aafe0c93465)