### PR TITLE
Fix metrics timer stats deadlock

### DIFF
--- a/src/core/services/metrics_service.py
+++ b/src/core/services/metrics_service.py
@@ -14,6 +14,28 @@ _lock = threading.Lock()
 _counters: dict[str, int] = defaultdict(int)
 _timers: dict[str, list[float]] = defaultdict(list)
 
+def _calculate_timer_stats(durations: list[float]) -> dict[str, Any]:
+    """Calculate statistics for the provided list of durations."""
+    if not durations:
+        return {
+            "count": 0,
+            "total": 0.0,
+            "average": 0.0,
+            "min": 0.0,
+            "max": 0.0,
+        }
+
+    total_duration = sum(durations)
+    count = len(durations)
+    return {
+        "count": count,
+        "total": total_duration,
+        "average": total_duration / count,
+        "min": min(durations),
+        "max": max(durations),
+    }
+
+
 
 def inc(name: str, by: int = 1) -> None:
     """Increment a counter metric by the specified amount.
@@ -90,23 +112,9 @@ def get_timer_stats(name: str) -> dict[str, Any]:
         A dictionary containing count, total, average, min, and max durations
     """
     with _lock:
-        durations = _timers.get(name, [])
-        if not durations:
-            return {
-                "count": 0,
-                "total": 0.0,
-                "average": 0.0,
-                "min": 0.0,
-                "max": 0.0,
-            }
+        durations = list(_timers.get(name, []))
 
-        return {
-            "count": len(durations),
-            "total": sum(durations),
-            "average": sum(durations) / len(durations),
-            "min": min(durations),
-            "max": max(durations),
-        }
+    return _calculate_timer_stats(durations)
 
 
 def get_all_timer_stats() -> dict[str, dict[str, Any]]:
@@ -116,7 +124,9 @@ def get_all_timer_stats() -> dict[str, dict[str, Any]]:
         A dictionary mapping timer names to their statistics
     """
     with _lock:
-        return {name: get_timer_stats(name) for name in _timers}
+        timers_snapshot = {name: list(durations) for name, durations in _timers.items()}
+
+    return {name: _calculate_timer_stats(durations) for name, durations in timers_snapshot.items()}
 
 
 def log_performance_stats() -> None:

--- a/tests/unit/core/services/aaa_test_metrics_service.py
+++ b/tests/unit/core/services/aaa_test_metrics_service.py
@@ -4,6 +4,7 @@ Unit tests for the metrics service.
 
 from __future__ import annotations
 
+import threading
 import time
 
 from src.core.services import metrics_service
@@ -84,6 +85,23 @@ class TestMetricsService:
         assert "timer2" in all_stats
         assert all_stats["timer1"]["count"] == 1
         assert all_stats["timer2"]["count"] == 1
+
+    def test_get_all_timer_stats_thread_safe(self):
+        """Ensure get_all_timer_stats does not deadlock when called from another thread."""
+        metrics_service.record_duration("timer1", 0.1)
+        metrics_service.record_duration("timer2", 0.2)
+
+        result: dict[str, dict[str, float]] = {}
+
+        def target() -> None:
+            result.update(metrics_service.get_all_timer_stats())
+
+        worker = threading.Thread(target=target)
+        worker.start()
+        worker.join(timeout=1)
+
+        assert not worker.is_alive(), "get_all_timer_stats deadlocked when called from another thread"
+        assert result, "Expected timer stats to be populated after thread execution"
 
     def test_tool_call_processing_metrics(self):
         """Test metrics specific to tool call processing."""


### PR DESCRIPTION
## Summary
- ensure metrics timer statistics reuse a new helper so locks are not reacquired
- add a regression test that verifies `get_all_timer_stats` returns when invoked from another thread

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc8e2ad088333b9044bd6931b4c6f)