### PR TITLE
Allow injecting structured output middleware in backend request manager

### DIFF
--- a/src/core/services/backend_request_manager_service.py
+++ b/src/core/services/backend_request_manager_service.py
@@ -20,6 +20,7 @@ from src.core.interfaces.backend_processor_interface import IBackendProcessor
 from src.core.interfaces.backend_request_manager_interface import IBackendRequestManager
 from src.core.interfaces.loop_detector_interface import ILoopDetector
 from src.core.interfaces.response_processor_interface import (
+    IResponseMiddleware,
     IResponseProcessor,
     ProcessedResponse,
 )
@@ -40,12 +41,22 @@ class BackendRequestManager(IBackendRequestManager):
         backend_processor: IBackendProcessor,
         response_processor: IResponseProcessor,
         wire_capture: Any | None = None,
+        *,
+        structured_output_middleware: IResponseMiddleware | None = None,
     ) -> None:
         """Initialize the backend request manager."""
         self._backend_processor = backend_processor
         self._response_processor = response_processor
         # wire_capture is currently applied at BackendService level to avoid
         # duplicating backend resolution logic; accepted here for future use.
+        self._structured_output_middleware = structured_output_middleware
+
+    def set_structured_output_middleware(
+        self, middleware: IResponseMiddleware | None
+    ) -> None:
+        """Replace the structured output middleware dependency."""
+
+        self._structured_output_middleware = middleware
 
     async def prepare_backend_request(
         self, request_data: ChatRequest, command_result: ProcessedResult
@@ -251,21 +262,19 @@ class BackendRequestManager(IBackendRequestManager):
                             f"request_id={request_id}, schema_name={schema_name}"
                         )
 
-                        # Import here to avoid circular imports
-                        from src.core.di.services import get_service_provider
-                        from src.core.services.structured_output_middleware import (
-                            StructuredOutputMiddleware,
-                        )
+                        structured_output_middleware = self._structured_output_middleware
 
-                        # Get services from DI container
-                        service_provider = get_service_provider()
-                        structured_output_middleware = (
-                            service_provider.get_required_service(
+                        if structured_output_middleware is None:
+                            from src.core.di.services import get_service_provider
+                            from src.core.services.structured_output_middleware import (
+                                StructuredOutputMiddleware,
+                            )
+
+                            service_provider = get_service_provider()
+                            structured_output_middleware = service_provider.get_required_service(
                                 StructuredOutputMiddleware
                             )
-                        )
 
-                        # Apply the middleware
                         try:
                             processed_response = (
                                 await structured_output_middleware.process(

--- a/tests/unit/core/services/test_backend_tool_preservation.py
+++ b/tests/unit/core/services/test_backend_tool_preservation.py
@@ -13,6 +13,11 @@ from src.core.domain.processed_result import ProcessedResult
 from src.core.domain.responses import ResponseEnvelope
 from src.core.services.backend_processor import BackendProcessor
 from src.core.services.backend_request_manager_service import BackendRequestManager
+from src.core.interfaces.response_processor_interface import (
+    IResponseMiddleware,
+    IResponseProcessor,
+    ProcessedResponse,
+)
 
 
 @pytest.mark.asyncio
@@ -228,3 +233,85 @@ async def test_prepare_backend_request_appends_results_without_modified_messages
     assert backend_request.messages[2].role == "tool"
     assert backend_request.messages[2].tool_call_id == "call-456"
     assert backend_request.messages[2].content == "file.txt"
+
+
+class _StubBackendProcessor:
+    async def process_backend_request(self, *args: Any, **kwargs: Any) -> ResponseEnvelope:
+        return ResponseEnvelope(content="raw", metadata={})
+
+
+class _StubResponseProcessor(IResponseProcessor):
+    async def process_response(
+        self,
+        response: Any,
+        session_id: str,
+        context: dict[str, Any] | None = None,
+    ) -> ProcessedResponse:
+        return ProcessedResponse(content="processed", metadata={"source": "processor"})
+
+    def process_streaming_response(self, response_iterator, session_id: str):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def register_middleware(self, middleware: IResponseMiddleware, priority: int = 0) -> None:
+        return None
+
+
+class _StubStructuredMiddleware(IResponseMiddleware):
+    def __init__(self) -> None:
+        super().__init__(priority=5)
+        self.calls = 0
+
+    async def process(
+        self,
+        response: Any,
+        session_id: str,
+        context: dict[str, Any],
+        is_streaming: bool = False,
+        stop_event: Any = None,
+    ) -> Any:
+        self.calls += 1
+        return ProcessedResponse(
+            content="structured",
+            metadata={"structured_output_validated": True, "schema_validation_attempted": True},
+        )
+
+
+@pytest.mark.asyncio
+async def test_backend_request_manager_uses_injected_structured_output_middleware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail_get_service_provider() -> None:
+        raise RuntimeError("global service provider should not be used")
+
+    monkeypatch.setattr(
+        "src.core.di.services.get_service_provider",
+        _fail_get_service_provider,
+    )
+
+    structured_middleware = _StubStructuredMiddleware()
+    manager = BackendRequestManager(
+        _StubBackendProcessor(),
+        _StubResponseProcessor(),
+        structured_output_middleware=structured_middleware,
+    )
+
+    request = ChatRequest(
+        model="test-model",
+        messages=[ChatMessage(role="user", content="hi")],
+        stream=False,
+    )
+    context = SimpleNamespace(
+        processing_context={
+            "response_schema": {"type": "object"},
+            "schema_name": "schema",
+            "request_id": "req-1",
+        }
+    )
+
+    response = await manager.process_backend_request(request, "session-1", context)
+
+    assert structured_middleware.calls == 1
+    assert response.content == "structured"
+    assert response.metadata is not None
+    assert response.metadata.get("structured_output_validated") is True
+    assert response.metadata.get("schema_validation_attempted") is True


### PR DESCRIPTION
## Summary
- allow `BackendRequestManager` to accept a preconfigured structured output middleware so tests and alternative setups do not have to rely on the global service provider
- add a focused unit test verifying the manager uses the injected middleware instead of resolving it globally

## Testing
- `python -m pytest tests/unit/core/services/test_backend_tool_preservation.py::test_backend_request_manager_uses_injected_structured_output_middleware -q -o addopts=""`
- `python -m pytest -o addopts=""`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc8c65ca88333a597c868358b4121)