### PR TITLE
Refine loop detector dependency injection

### DIFF
--- a/src/core/di/container.py
+++ b/src/core/di/container.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 import os
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from src.core.common.exceptions import ServiceResolutionError
 from src.core.interfaces.app_settings_interface import IAppSettings
@@ -18,7 +18,9 @@ from src.core.interfaces.di_interface import (
     ServiceLifetime,
 )
 from src.core.interfaces.request_processor_interface import IRequestProcessor
+from src.core.interfaces.response_processor_interface import IResponseProcessor
 from src.core.interfaces.session_service_interface import ISessionService
+from src.core.interfaces.wire_capture_interface import IWireCapture
 
 T = TypeVar("T")
 
@@ -425,7 +427,36 @@ class ServiceCollection(IServiceCollection):
         )
 
         self.add_scoped(IBackendProcessor, BackendProcessor)
-        self.add_scoped(IBackendRequestManager, BackendRequestManager)
+
+        def _backend_request_manager_factory(
+            provider: IServiceProvider,
+        ) -> BackendRequestManager:
+            from src.core.interfaces.loop_detector_interface import ILoopDetector
+
+            backend_processor = provider.get_required_service(IBackendProcessor)
+            response_processor = provider.get_required_service(IResponseProcessor)
+            wire_capture = provider.get_required_service(IWireCapture)
+
+            def _loop_detector_factory() -> ILoopDetector:
+                return provider.get_required_service(cast(type, ILoopDetector))
+
+            return BackendRequestManager(
+                backend_processor,
+                response_processor,
+                wire_capture,
+                loop_detector_factory=_loop_detector_factory,
+            )
+
+        self.add_scoped(
+            BackendRequestManager,
+            implementation_factory=_backend_request_manager_factory,
+        )
+        self.add_scoped(
+            IBackendRequestManager,
+            implementation_factory=lambda provider: provider.get_required_service(
+                BackendRequestManager
+            ),
+        )
         self.add_scoped(IRequestProcessor, RequestProcessor)
 
         # Register additional core services including ToolCallReactor

--- a/src/core/di/services.py
+++ b/src/core/di/services.py
@@ -899,11 +899,23 @@ def register_core_services(
     def _backend_request_manager_factory(
         provider: IServiceProvider,
     ) -> BackendRequestManager:
+        from typing import cast
+
+        from src.core.interfaces.loop_detector_interface import ILoopDetector
+
         backend_processor = provider.get_required_service(IBackendProcessor)  # type: ignore[type-abstract]
         response_processor = provider.get_required_service(IResponseProcessor)  # type: ignore[type-abstract]
         wire_capture = provider.get_required_service(IWireCapture)  # type: ignore[type-abstract]
+
+        def _loop_detector_factory() -> ILoopDetector:
+            detector = provider.get_required_service(cast(type, ILoopDetector))
+            return detector
+
         return BackendRequestManager(
-            backend_processor, response_processor, wire_capture
+            backend_processor,
+            response_processor,
+            wire_capture,
+            loop_detector_factory=_loop_detector_factory,
         )
 
     _add_singleton(

--- a/src/core/services/backend_request_manager_service.py
+++ b/src/core/services/backend_request_manager_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Callable, Iterable
 from typing import Any, cast
 
 from src.core.common.exceptions import BackendError
@@ -40,12 +40,14 @@ class BackendRequestManager(IBackendRequestManager):
         backend_processor: IBackendProcessor,
         response_processor: IResponseProcessor,
         wire_capture: Any | None = None,
+        loop_detector_factory: Callable[[], ILoopDetector] | None = None,
     ) -> None:
         """Initialize the backend request manager."""
         self._backend_processor = backend_processor
         self._response_processor = response_processor
         # wire_capture is currently applied at BackendService level to avoid
         # duplicating backend resolution logic; accepted here for future use.
+        self._loop_detector_factory = loop_detector_factory
 
     async def prepare_backend_request(
         self, request_data: ChatRequest, command_result: ProcessedResult
@@ -697,6 +699,32 @@ class BackendRequestManager(IBackendRequestManager):
 
     def _create_loop_detector(self) -> ILoopDetector:
         """Create or resolve a loop detector instance for streaming inspection."""
+        detector = None
+        if self._loop_detector_factory is not None:
+            try:
+                detector = self._loop_detector_factory()
+            except Exception:  # pragma: no cover - defensive guard
+                logger.debug(
+                    "Loop detector factory failed; using DI fallback", exc_info=True
+                )
+                detector = None
+            else:
+                if detector is None:
+                    logger.debug(
+                        "Loop detector factory returned None; using DI fallback"
+                    )
+                else:
+                    try:
+                        detector.reset()
+                    except Exception:  # pragma: no cover - defensive guard
+                        logger.debug(
+                            "Loop detector factory produced detector without reset; using fallback",
+                            exc_info=True,
+                        )
+                        detector = None
+                    else:
+                        return detector
+
         try:
             from src.core.di.services import get_or_build_service_provider
 

--- a/tests/unit/core/services/test_backend_request_manager_di.py
+++ b/tests/unit/core/services/test_backend_request_manager_di.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from src.core.di.container import ServiceCollection
+from src.core.interfaces.backend_processor_interface import IBackendProcessor
+from src.core.interfaces.loop_detector_interface import (
+    ILoopDetector,
+    LoopDetectionResult,
+)
+from src.core.interfaces.response_processor_interface import IResponseProcessor
+from src.core.interfaces.wire_capture_interface import IWireCapture
+from src.core.services.backend_request_manager_service import BackendRequestManager
+
+
+class RecordingLoopDetector(ILoopDetector):
+    """Simple loop detector implementation that records reset calls."""
+
+    def __init__(self) -> None:
+        self.reset_count = 0
+
+    def is_enabled(self) -> bool:
+        return True
+
+    def process_chunk(self, chunk: str):  # type: ignore[override]
+        return None
+
+    def reset(self) -> None:
+        self.reset_count += 1
+
+    def get_loop_history(self):  # type: ignore[override]
+        return []
+
+    def get_current_state(self):  # type: ignore[override]
+        return {}
+
+    async def check_for_loops(self, content: str) -> LoopDetectionResult:
+        return LoopDetectionResult(has_loop=False)
+
+
+def _make_manager_with_factory(
+    factory: Callable[[], ILoopDetector],
+) -> BackendRequestManager:
+    backend_processor = MagicMock(spec=IBackendProcessor)
+    response_processor = MagicMock(spec=IResponseProcessor)
+    return BackendRequestManager(
+        backend_processor=backend_processor,
+        response_processor=response_processor,
+        loop_detector_factory=factory,
+    )
+
+
+def test_backend_request_manager_uses_injected_loop_detector_factory() -> None:
+    """A supplied loop detector factory should be preferred over DI fallback."""
+
+    detector = RecordingLoopDetector()
+
+    manager = _make_manager_with_factory(lambda: detector)
+
+    created = manager._create_loop_detector()
+
+    assert created is detector
+    assert detector.reset_count == 1
+
+
+def test_backend_request_manager_respects_provider_loop_detector() -> None:
+    """Factory provided by a scoped provider should create detectors per scope."""
+
+    services = ServiceCollection()
+
+    backend_processor = MagicMock(spec=IBackendProcessor)
+    response_processor = MagicMock(spec=IResponseProcessor)
+    wire_capture = MagicMock(spec=IWireCapture)
+
+    services.add_instance(cast(type, IBackendProcessor), backend_processor)
+    services.add_instance(cast(type, IResponseProcessor), response_processor)
+    services.add_instance(cast(type, IWireCapture), wire_capture)
+
+    services.add_transient(
+        cast(type, ILoopDetector),
+        implementation_factory=lambda _provider: RecordingLoopDetector(),
+    )
+
+    def backend_request_manager_factory(provider: Any) -> BackendRequestManager:
+        def loop_detector_factory() -> ILoopDetector:
+            return provider.get_required_service(cast(type, ILoopDetector))
+
+        return BackendRequestManager(
+            backend_processor=provider.get_required_service(
+                cast(type, IBackendProcessor)
+            ),
+            response_processor=provider.get_required_service(
+                cast(type, IResponseProcessor)
+            ),
+            wire_capture=provider.get_required_service(cast(type, IWireCapture)),
+            loop_detector_factory=loop_detector_factory,
+        )
+
+    services.add_singleton(
+        BackendRequestManager, implementation_factory=backend_request_manager_factory
+    )
+
+    provider = services.build_service_provider()
+    manager = provider.get_required_service(BackendRequestManager)
+
+    detector = manager._create_loop_detector()
+    assert isinstance(detector, RecordingLoopDetector)
+    assert detector.reset_count == 1
+
+    # Ensure repeated calls create independent detectors
+    another = manager._create_loop_detector()
+    assert isinstance(another, RecordingLoopDetector)
+    assert another is not detector


### PR DESCRIPTION
## Summary
- allow `BackendRequestManager` to accept an injected loop-detector factory before falling back to the global service locator
- wire the DI container registrations so scoped providers create detectors via the factory instead of constructing them manually
- add unit coverage that verifies factory injection both directly and through a scoped `ServiceCollection`

## Testing
- `python -m pytest` *(fails: environment lacks optional snapshot/bandit tooling and dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc8c65ca88333a597c868358b4121)