### PR TITLE
Optimize streaming buffer trimming

### DIFF
--- a/src/core/services/streaming/tool_call_repair_processor.py
+++ b/src/core/services/streaming/tool_call_repair_processor.py
@@ -178,22 +178,25 @@ class ToolCallRepairProcessor(IStreamProcessor):
         if not buffer:
             return ""
 
-        encoded_length = len(buffer.encode("utf-8"))
+        encoded_buffer = buffer.encode("utf-8")
+        encoded_length = len(encoded_buffer)
         if encoded_length <= self._max_buffer_bytes:
             return ""
 
         overflow = encoded_length - self._max_buffer_bytes
-        flushed_chars = []
-        consumed = 0
+        cutoff = overflow
 
-        for ch in buffer:
-            char_bytes = len(ch.encode("utf-8"))
-            flushed_chars.append(ch)
-            consumed += char_bytes
-            if consumed >= overflow:
+        # Adjust cutoff to avoid splitting multibyte UTF-8 characters.
+        # decode() with strict errors will raise if the slice ends mid-character.
+        while cutoff <= encoded_length:
+            try:
+                flush_text = encoded_buffer[:cutoff].decode("utf-8")
                 break
-
-        flush_text = "".join(flushed_chars)
+            except UnicodeDecodeError:
+                cutoff += 1
+        else:
+            # If decoding still fails (extremely unlikely), fall back to flushing all
+            flush_text = buffer
 
         logger.warning(
             "ToolCallRepairProcessor buffer exceeded %d bytes; flushed %d characters",

--- a/tests/unit/core/services/test_tool_call_repair.py
+++ b/tests/unit/core/services/test_tool_call_repair.py
@@ -899,6 +899,28 @@ class TestToolCallRepairProcessorBuffering:
         # End of stream flushes remaining buffer
         assert final.content == "BBBBBBBBCCCC"  # Remaining 8 B's + 4 C's
 
+    @pytest.mark.asyncio
+    async def test_trim_buffer_preserves_multibyte_characters(self) -> None:
+        service = ToolCallRepairService(max_buffer_bytes=12)
+        processor = ToolCallRepairProcessor(service, max_buffer_bytes=8)
+
+        stream_metadata = {"stream_id": "unicode_stream"}
+
+        first = await processor.process(
+            StreamingContent(content="😀😀A", metadata=stream_metadata)
+        )
+
+        # Overflow is a single byte, but the processor must flush the entire
+        # multi-byte emoji to keep the buffer boundary aligned.
+        assert first.content == "😀"
+
+        final = await processor.process(
+            StreamingContent(content="", is_done=True, metadata=stream_metadata)
+        )
+
+        # The remaining buffer contains the second emoji and trailing text.
+        assert final.content == "😀A"
+
 
 class TestToolCallRepairProcessorReasoning:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- optimize the streaming tool-call repair buffer trimming by working on the encoded payload once and aligning the cutoff with UTF-8 boundaries
- add a regression test to ensure multi-byte characters are preserved when trimming the buffer

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc89aad308333b086334bd6fe9c4d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming tool call processing with enhanced buffer management and UTF-8 safety.
  * Better handling of incomplete tool call repairs in streaming scenarios.

* **Tests**
  * Re-enabled comprehensive test suite for tool call repair and streaming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->