### PR TITLE
Fix failover validator coroutine leak when event loop is active

### DIFF
--- a/src/core/persistence.py
+++ b/src/core/persistence.py
@@ -255,8 +255,6 @@ class ServiceProviderFailoverRouteValidator(FailoverRouteValidatorProtocol):
                 ),
             )
 
-        coroutine = backend_service.validate_backend_and_model(backend_name, model_name)
-
         try:
             asyncio.get_running_loop()
             loop_running = True
@@ -273,6 +271,8 @@ class ServiceProviderFailoverRouteValidator(FailoverRouteValidatorProtocol):
                     "Cannot validate failover routes while the event loop is running."
                 )
             return FailoverValidationResult(is_valid=True, warning=warning)
+
+        coroutine = backend_service.validate_backend_and_model(backend_name, model_name)
 
         try:
             is_valid, message = asyncio.run(coroutine)

--- a/tests/unit/core/test_persistence_failover_validator.py
+++ b/tests/unit/core/test_persistence_failover_validator.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import gc
+import warnings
+from typing import Any, TypeVar
+from unittest.mock import AsyncMock
+
+import pytest
+from src.core.persistence import ServiceProviderFailoverRouteValidator
+
+_T = TypeVar("_T")
+
+
+class _DummyProvider:
+    def __init__(self, service: Any):
+        self._service = service
+
+    def get_required_service(self, _service_type: type[_T]) -> _T:
+        return self._service
+
+
+def _strict_supplier() -> bool:
+    return False
+
+
+def test_validator_runs_backend_validation_when_loop_not_running() -> None:
+    backend_service = type("BackendService", (), {})()
+    backend_service.validate_backend_and_model = AsyncMock(return_value=(True, None))
+
+    validator = ServiceProviderFailoverRouteValidator(
+        _DummyProvider(backend_service), _strict_supplier
+    )
+
+    result = validator.validate("backend", "model")
+
+    backend_service.validate_backend_and_model.assert_awaited_once()
+    assert result.is_valid is True
+    assert result.warning is None
+
+
+@pytest.mark.asyncio
+async def test_validator_does_not_leak_coroutines_when_loop_running() -> None:
+    backend_service = type("BackendService", (), {})()
+    backend_service.validate_backend_and_model = AsyncMock(return_value=(True, None))
+
+    validator = ServiceProviderFailoverRouteValidator(
+        _DummyProvider(backend_service), _strict_supplier
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+        result = validator.validate("backend", "model")
+        gc.collect()
+
+    assert result.is_valid is True
+    assert result.warning is not None
+    backend_service.validate_backend_and_model.assert_not_called()
+    assert not any("was never awaited" in str(w.message) for w in caught)


### PR DESCRIPTION
## Summary
- avoid instantiating the backend validation coroutine when the event loop is already running to prevent un-awaited coroutine warnings
- add tests covering both synchronous validation and the event-loop-running skip path

## Testing
- python -m pytest *(fails: environment is missing optional tooling such as `vulture`, `bandit`, and fixtures required by snapshot-based tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc836bcd4833395c505c79c726e71)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend validation logic to properly handle asynchronous operations across different system states, preventing execution conflicts and enhancing reliability.

* **Tests**
  * Added comprehensive test suite for failover route validation covering various scenarios and system state conditions to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->