### PR TITLE
Await async scoped service disposal

### DIFF
--- a/src/core/di/container.py
+++ b/src/core/di/container.py
@@ -92,7 +92,9 @@ class ServiceScope(IServiceScope):
             if hasattr(instance, "__aenter__") and hasattr(instance, "__aexit__"):
                 await instance.__aexit__(None, None, None)
             elif hasattr(instance, "dispose") and callable(instance.dispose):
-                instance.dispose()
+                result = instance.dispose()
+                if inspect.isawaitable(result):
+                    await result
 
         self._instances.clear()
 

--- a/tests/unit/core/di/test_service_scope_dispose.py
+++ b/tests/unit/core/di/test_service_scope_dispose.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+from src.core.di.container import ServiceCollection
+
+
+class _AsyncDisposable:
+    def __init__(self) -> None:
+        self.disposed = False
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+@pytest.mark.asyncio
+async def test_scope_dispose_awaits_async_dispose() -> None:
+    services = ServiceCollection()
+    services.add_scoped(
+        _AsyncDisposable,
+        implementation_factory=lambda _provider: _AsyncDisposable(),
+    )
+
+    provider = services.build_service_provider()
+    scope = provider.create_scope()
+
+    service = scope.service_provider.get_required_service(_AsyncDisposable)
+    assert service.disposed is False
+
+    await scope.dispose()
+
+    assert service.disposed is True


### PR DESCRIPTION
## Summary
- ensure `ServiceScope.dispose` awaits asynchronous `dispose()` methods to prevent leaked coroutines
- add a regression test covering scoped async disposables

## Testing
- python -m pytest tests/unit/core/di/test_service_scope_dispose.py -q
- python -m pytest -q *(fails: missing optional tooling like `bandit`, `vulture`, `mypy`, and snapshot fixtures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc836bcd4833395c505c79c726e71)