### PR TITLE
Fix anonymous session aliasing in tool call reactor

### DIFF
--- a/src/core/services/tool_call_reactor_service.py
+++ b/src/core/services/tool_call_reactor_service.py
@@ -153,13 +153,15 @@ class ToolCallReactorService(IToolCallReactor):
             The reaction result from the first handler that swallows the call,
             or None if no handler swallows it.
         """
-        raw_session_id = context.session_id
-        alias_key = raw_session_id if raw_session_id else "__empty__"
-        if alias_key not in self._session_aliases:
-            self._session_aliases[alias_key] = (
-                str(raw_session_id) if raw_session_id else uuid4().hex
-            )
-        resolved_session_id = self._session_aliases[alias_key]
+        raw_session_id = (context.session_id or "").strip()
+
+        if raw_session_id:
+            alias_key = raw_session_id
+            if alias_key not in self._session_aliases:
+                self._session_aliases[alias_key] = raw_session_id
+            resolved_session_id = self._session_aliases[alias_key]
+        else:
+            resolved_session_id = uuid4().hex
 
         # Record the tool call in history if tracker is available
         if self._history_tracker:

--- a/tests/unit/core/services/test_tool_call_reactor_service.py
+++ b/tests/unit/core/services/test_tool_call_reactor_service.py
@@ -58,13 +58,13 @@ class _PassthroughHandler(IToolCallHandler):
 
 
 @pytest.mark.asyncio
-async def test_tool_call_reactor_aliases_empty_session_ids() -> None:
+async def test_tool_call_reactor_isolates_anonymous_sessions() -> None:
     tracker = _RecordingHistoryTracker()
     service = ToolCallReactorService(history_tracker=tracker)
     handler = _PassthroughHandler()
     await service.register_handler(handler)
 
-    context_without_session = ToolCallContext(
+    first_context = ToolCallContext(
         session_id="",
         backend_name="test-backend",
         model_name="model",
@@ -73,13 +73,24 @@ async def test_tool_call_reactor_aliases_empty_session_ids() -> None:
         tool_arguments={},
     )
 
-    await service.process_tool_call(context_without_session)
-    assert tracker.records
-    alias_session_id = tracker.records[0][0]
-    assert alias_session_id != ""
+    second_context = ToolCallContext(
+        session_id="",
+        backend_name="test-backend",
+        model_name="model",
+        full_response={},
+        tool_name="other",
+        tool_arguments={},
+    )
 
-    await service.process_tool_call(context_without_session)
-    assert tracker.records[1][0] == alias_session_id
+    await service.process_tool_call(first_context)
+    await service.process_tool_call(second_context)
+
+    assert tracker.records
+    first_alias = tracker.records[0][0]
+    second_alias = tracker.records[1][0]
+    assert first_alias != ""
+    assert second_alias != ""
+    assert first_alias != second_alias
 
     explicit_context = ToolCallContext(
         session_id="explicit-session",


### PR DESCRIPTION
## Summary
- ensure ToolCallReactorService generates unique aliases for requests without session IDs to avoid leaking history across sessions
- update reactor unit test to verify anonymous sessions are isolated

## Testing
- python -m pytest -n0 *(fails: ModuleNotFoundError: No module named 'pytest_mock')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc7fe10288333967c4ca943b4c966)