### PR TITLE
Fix stale JSON repair stream state leak

### DIFF
--- a/src/core/services/streaming/json_repair_processor.py
+++ b/src/core/services/streaming/json_repair_processor.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
 import src.core.services.metrics_service as metrics
@@ -23,6 +24,7 @@ class _JsonStreamState:
     brace_level: int = 0
     in_string: bool = False
     json_started: bool = False
+    last_accessed: float = field(default_factory=time.time)
 
 
 class JsonRepairProcessor(IStreamProcessor):
@@ -35,6 +37,7 @@ class JsonRepairProcessor(IStreamProcessor):
         strict_mode: bool,
         schema: dict[str, Any] | None = None,
         enabled: bool = True,
+        state_ttl_seconds: int = 300,
     ) -> None:
         self._service = repair_service
         self._buffer_cap_bytes = int(buffer_cap_bytes)
@@ -42,6 +45,8 @@ class JsonRepairProcessor(IStreamProcessor):
         self._schema = schema
         self._enabled = bool(enabled)
         self._states: dict[str, _JsonStreamState] = {}
+        ttl = int(state_ttl_seconds)
+        self._state_ttl_seconds = ttl if ttl > 0 else None
 
     def reset(self) -> None:
         """Clear any buffered state across streams (called per new streaming session)."""
@@ -51,11 +56,14 @@ class JsonRepairProcessor(IStreamProcessor):
         if not self._enabled:
             return content
 
+        self._cleanup_stale_states()
+
         if content.is_empty and not content.is_done:
             return content
 
         stream_id = get_stream_id(content)
         state = self._states.setdefault(stream_id, _JsonStreamState())
+        state.last_accessed = time.time()
 
         out_parts: list[str] = []
         text = content.content or ""
@@ -105,6 +113,28 @@ class JsonRepairProcessor(IStreamProcessor):
             usage=content.usage,
             raw_data=content.raw_data,
         )
+
+    def _cleanup_stale_states(self) -> None:
+        if not self._states or self._state_ttl_seconds is None:
+            return
+
+        current_time = time.time()
+        expired_streams = [
+            stream_id
+            for stream_id, state in list(self._states.items())
+            if current_time - state.last_accessed > self._state_ttl_seconds
+        ]
+
+        if not expired_streams:
+            return
+
+        for stream_id in expired_streams:
+            self._states.pop(stream_id, None)
+            logger.debug(
+                "Cleaned up stale JSON repair state for stream_id=%s after %s seconds",
+                stream_id,
+                self._state_ttl_seconds,
+            )
 
     # ---------------------------------------------------------------------
     # Internal helpers

--- a/tests/unit/core/services/test_json_repair_processor.py
+++ b/tests/unit/core/services/test_json_repair_processor.py
@@ -6,6 +6,9 @@ import pytest
 from src.core.domain.streaming_response_processor import StreamingContent
 from src.core.services.json_repair_service import JsonRepairService
 from src.core.services.streaming.json_repair_processor import JsonRepairProcessor
+from src.core.services.streaming import (
+    json_repair_processor as json_repair_processor_module,
+)
 
 
 @pytest.fixture()
@@ -143,6 +146,44 @@ async def test_stream_with_multiple_reparable_json_objects(
         processor, "Text1 {'a': 1,} Text2 {'b': 2,} Text3"
     )
     assert result == 'Text1 {"a": 1} Text2 {"b": 2} Text3'
+
+
+class _FakeTime:
+    def __init__(self, start: float) -> None:
+        self._value = start
+
+    def advance(self, delta: float) -> None:
+        self._value += delta
+
+    def time(self) -> float:
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_stale_stream_state_is_cleaned_up(monkeypatch) -> None:
+    processor = JsonRepairProcessor(
+        repair_service=JsonRepairService(),
+        buffer_cap_bytes=1024,
+        strict_mode=False,
+        state_ttl_seconds=5,
+    )
+
+    fake_time = _FakeTime(start=1000.0)
+    monkeypatch.setattr(json_repair_processor_module.time, "time", fake_time.time)
+
+    await processor.process(
+        StreamingContent(content='{"partial": ', metadata={"stream_id": "stale"})
+    )
+    assert "stale" in processor._states
+
+    fake_time.advance(10.0)
+
+    await processor.process(
+        StreamingContent(content='{"new": ', metadata={"stream_id": "fresh"})
+    )
+
+    assert "stale" not in processor._states
+    assert "fresh" in processor._states
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add TTL-based cleanup to the JSON repair stream processor so incomplete streams do not accumulate state indefinitely
- track last access times for each stream buffer and expose a configurable cleanup TTL
- add a regression test that verifies stale stream state is evicted once the TTL expires

## Testing
- python -m pytest tests/unit/core/services/test_json_repair_processor.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc7a044c48333a8bce47209dc9bd8)