### PR TITLE
Add TTL cleanup to loop detection processor to prevent memory leaks

### DIFF
--- a/src/core/config/app_config.py
+++ b/src/core/config/app_config.py
@@ -450,6 +450,8 @@ class SessionConfig(DomainModel):
     json_repair_buffer_cap_bytes: int = 64 * 1024
     json_repair_strict_mode: bool = False
     json_repair_schema: dict[str, Any] | None = None  # Added
+    # TTL for cleaning up idle loop detection sessions to avoid memory leaks (seconds)
+    loop_detection_session_ttl_seconds: int = 600
     tool_call_reactor: ToolCallReactorConfig = Field(
         default_factory=ToolCallReactorConfig
     )

--- a/src/core/di/services.py
+++ b/src/core/di/services.py
@@ -1020,7 +1020,15 @@ def register_core_services(
         def create_detector() -> ILoopDetector:
             return provider.get_required_service(cast(type, ILoopDetector))
 
-        return LoopDetectionProcessor(loop_detector_factory=create_detector)
+        app_config = provider.get_required_service(AppConfig)
+        session_ttl = getattr(
+            app_config.session, "loop_detection_session_ttl_seconds", 300
+        )
+
+        return LoopDetectionProcessor(
+            loop_detector_factory=create_detector,
+            session_ttl_seconds=session_ttl,
+        )
 
     _add_singleton(
         LoopDetectionProcessor, implementation_factory=_loop_detection_processor_factory

--- a/src/core/domain/streaming_response_processor.py
+++ b/src/core/domain/streaming_response_processor.py
@@ -1,5 +1,5 @@
 """
-Streaming response processor interfaces and utilities.
+"""Streaming response processor interfaces and utilities.
 
 This module provides interfaces and utilities for processing streaming
 responses in a consistent way, regardless of the source or format.
@@ -8,6 +8,7 @@ responses in a consistent way, regardless of the source or format.
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Awaitable, Callable
 
 from src.core.app.constants.logging_constants import TRACE_LEVEL
@@ -35,19 +36,53 @@ class LoopDetectionProcessor(IStreamProcessor):
         self,
         loop_detector_factory: Callable[[], ILoopDetector],
         cancel_callback: Callable[[], Awaitable[None]] | None = None,
+        *,
+        session_ttl_seconds: int = 300,
+        time_provider: Callable[[], float] | None = None,
     ) -> None:
         """Initialize loop detection processor.
 
         Args:
             loop_detector_factory: Factory function to create new loop detector instances per session.
             cancel_callback: Optional callback to trigger API cancellation when loop is detected.
+            session_ttl_seconds: Maximum idle time (in seconds) before a detector is
+                automatically discarded. Defaults to 300 seconds. Set to 0 to disable TTL cleanup.
+            time_provider: Optional callable returning the current time in seconds. Primarily
+                intended for tests so they can control time progression deterministically.
         """
         self.loop_detector_factory = loop_detector_factory
         self.cancel_callback = cancel_callback
         # Per-session detector instances to ensure isolation
         self._session_detectors: dict[str, ILoopDetector] = {}
+        self._session_last_activity: dict[str, float] = {}
+        self._session_ttl_seconds = max(0, session_ttl_seconds)
+        self._time_provider = time_provider or time.time
 
-    def _get_detector_for_session(self, session_id: str) -> ILoopDetector:
+    def _cleanup_stale_sessions(self, current_time: float) -> None:
+        """Prune detector instances that have been inactive beyond the TTL."""
+
+        if self._session_ttl_seconds <= 0:
+            return
+
+        stale_sessions = [
+            session_id
+            for session_id, last_seen in self._session_last_activity.items()
+            if current_time - last_seen >= self._session_ttl_seconds
+        ]
+
+        for session_id in stale_sessions:
+            if session_id in self._session_detectors:
+                logger.debug(
+                    "Pruning stale loop detector for session %s after %ss of inactivity",
+                    session_id,
+                    self._session_ttl_seconds,
+                )
+                self._session_detectors.pop(session_id, None)
+            self._session_last_activity.pop(session_id, None)
+
+    def _get_detector_for_session(
+        self, session_id: str, current_time: float
+    ) -> ILoopDetector:
         """Get or create a loop detector for the given session.
 
         Args:
@@ -56,10 +91,13 @@ class LoopDetectionProcessor(IStreamProcessor):
         Returns:
             A loop detector instance dedicated to this session
         """
+        self._cleanup_stale_sessions(current_time)
+
         if session_id not in self._session_detectors:
             detector = self.loop_detector_factory()
             self._session_detectors[session_id] = detector
             logger.debug(f"Created new loop detector for session {session_id}")
+        self._session_last_activity[session_id] = current_time
         return self._session_detectors[session_id]
 
     def cleanup_session(self, session_id: str) -> None:
@@ -71,6 +109,7 @@ class LoopDetectionProcessor(IStreamProcessor):
         if session_id in self._session_detectors:
             del self._session_detectors[session_id]
             logger.debug(f"Cleaned up loop detector for session {session_id}")
+        self._session_last_activity.pop(session_id, None)
 
     async def process(self, content: StreamingContent) -> StreamingContent:
         """Process a streaming content chunk and check for loops.
@@ -91,8 +130,10 @@ class LoopDetectionProcessor(IStreamProcessor):
         raw_session = content.metadata.get("session_id") or content.metadata.get("id")
         session_id = str(raw_session) if raw_session else str(stream_id)
 
+        current_time = self._time_provider()
+
         # Get the detector instance for this specific session
-        loop_detector = self._get_detector_for_session(session_id)
+        loop_detector = self._get_detector_for_session(session_id, current_time)
 
         # Process the content for loop detection
         # Ensure content is a string for loop detector

--- a/tests/unit/loop_detection/test_session_isolation.py
+++ b/tests/unit/loop_detection/test_session_isolation.py
@@ -5,10 +5,56 @@ These tests ensure that loop detector state is never shared between different se
 preventing state contamination and ensuring each session has independent loop detection.
 """
 
+from typing import Any
+
 import pytest
 from src.core.domain.streaming_response_processor import LoopDetectionProcessor
+from src.core.interfaces.loop_detector_interface import (
+    ILoopDetector,
+    LoopDetectionResult,
+)
 from src.core.ports.streaming import StreamingContent
+from src.loop_detection.event import LoopDetectionEvent
 from src.loop_detection.hybrid_detector import HybridLoopDetector
+
+
+class _FakeTime:
+    """Deterministic time provider for TTL tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._current = start
+
+    def advance(self, seconds: float) -> None:
+        self._current += seconds
+
+    def now(self) -> float:
+        return self._current
+
+
+class _NoopLoopDetector(ILoopDetector):
+    """Simple loop detector stub for exercising processor lifecycle logic."""
+
+    def __init__(self) -> None:
+        self._seen_chunks: list[str] = []
+
+    def is_enabled(self) -> bool:
+        return True
+
+    def process_chunk(self, chunk: str) -> LoopDetectionEvent | None:
+        self._seen_chunks.append(chunk)
+        return None
+
+    def reset(self) -> None:
+        self._seen_chunks.clear()
+
+    def get_loop_history(self) -> list[Any]:
+        return []
+
+    def get_current_state(self) -> dict[str, Any]:
+        return {"chunks": list(self._seen_chunks)}
+
+    async def check_for_loops(self, content: str) -> LoopDetectionResult:
+        return LoopDetectionResult(has_loop=False)
 
 
 class TestLoopDetectionSessionIsolation:
@@ -366,3 +412,58 @@ class TestLoopDetectionRegressionPrevention:
             "REGRESSION: Session A's detector contains Session B's content! "
             "Detector state is being shared globally instead of per-session."
         )
+
+
+class TestLoopDetectionProcessorMemoryManagement:
+    """Tests covering memory-leak prevention mechanics in the processor."""
+
+    @pytest.mark.asyncio
+    async def test_stale_sessions_are_pruned_after_ttl(self) -> None:
+        fake_time = _FakeTime()
+        processor = LoopDetectionProcessor(
+            loop_detector_factory=_NoopLoopDetector,
+            session_ttl_seconds=5,
+            time_provider=fake_time.now,
+        )
+
+        async def send(session_id: str) -> None:
+            content = StreamingContent(
+                content="chunk", metadata={"session_id": session_id}
+            )
+            await processor.process(content)
+
+        await send("session-a")
+        fake_time.advance(1)
+        await send("session-b")
+
+        assert set(processor._session_detectors) == {"session-a", "session-b"}
+
+        # Advance time past the TTL without touching session-a
+        fake_time.advance(6)
+        await send("session-b")
+
+        assert "session-a" not in processor._session_detectors
+        assert "session-a" not in processor._session_last_activity
+        assert "session-b" in processor._session_detectors
+
+    @pytest.mark.asyncio
+    async def test_zero_ttl_disables_cleanup(self) -> None:
+        fake_time = _FakeTime()
+        processor = LoopDetectionProcessor(
+            loop_detector_factory=_NoopLoopDetector,
+            session_ttl_seconds=0,
+            time_provider=fake_time.now,
+        )
+
+        content = StreamingContent(
+            content="chunk", metadata={"session_id": "session-x"}
+        )
+        await processor.process(content)
+
+        # Even after a large time jump, the session should still be present
+        fake_time.advance(10_000)
+        await processor.process(
+            StreamingContent(content="chunk", metadata={"session_id": "session-x"})
+        )
+
+        assert set(processor._session_detectors) == {"session-x"}


### PR DESCRIPTION
## Summary
- track last activity for each loop detector instance and prune stale sessions using a configurable TTL to prevent unbounded growth
- surface the loop-detection TTL through `SessionConfig` and pass it through the DI factory so deployments can tune cleanup behaviour
- extend the loop detection session isolation tests with deterministic time control and coverage for TTL pruning and disabled cleanup scenarios

## Testing
- python -m pytest *(fails: environment is missing optional tooling such as snapshot fixtures, vulture, bandit, mypy, ruff, etc.)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc7a044c48333a8bce47209dc9bd8)