### PR TITLE
Add support for repetition penalty and min_p parameters

### DIFF
--- a/src/connectors/anthropic.py
+++ b/src/connectors/anthropic.py
@@ -327,6 +327,16 @@ class AnthropicBackend(LLMBackend):
             logger.warning(
                 "AnthropicBackend does not support the 'logit_bias' parameter."
             )
+        if request_data.repetition_penalty is not None and logger.isEnabledFor(
+            logging.WARNING
+        ):
+            logger.warning(
+                "AnthropicBackend does not support the 'repetition_penalty' parameter."
+            )
+        if request_data.min_p is not None and logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                "AnthropicBackend does not support the 'min_p' parameter."
+            )
 
         # Include tools and tool_choice when provided (tests set these fields)
         if request_data.tools is not None:

--- a/src/connectors/gemini.py
+++ b/src/connectors/gemini.py
@@ -712,6 +712,14 @@ class GeminiBackend(LLMBackend):
             logger.warning("GeminiBackend does not support the 'logit_bias' parameter.")
         if request_data.user is not None and logger.isEnabledFor(logging.WARNING):
             logger.warning("GeminiBackend does not support the 'user' parameter.")
+        if request_data.repetition_penalty is not None and logger.isEnabledFor(
+            logging.WARNING
+        ):
+            logger.warning(
+                "GeminiBackend does not support the 'repetition_penalty' parameter."
+            )
+        if request_data.min_p is not None and logger.isEnabledFor(logging.WARNING):
+            logger.warning("GeminiBackend does not support the 'min_p' parameter.")
 
     def _normalize_model_name(self, effective_model: str) -> str:
         model_name = effective_model

--- a/src/connectors/gemini_cloud_project.py
+++ b/src/connectors/gemini_cloud_project.py
@@ -1420,6 +1420,18 @@ class GeminiCloudProjectConnector(GeminiBackend, GeminiCodeAssistMixin):
         if top_k is not None:
             with contextlib.suppress(Exception):
                 cfg["topK"] = int(top_k)
+        if getattr(request_data, "repetition_penalty", None) is not None and logger.isEnabledFor(
+            logging.WARNING
+        ):
+            logger.warning(
+                "GeminiCloudProjectConnector does not support the 'repetition_penalty' parameter."
+            )
+        if getattr(request_data, "min_p", None) is not None and logger.isEnabledFor(
+            logging.WARNING
+        ):
+            logger.warning(
+                "GeminiCloudProjectConnector does not support the 'min_p' parameter."
+            )
         return cfg
 
     async def _ensure_project_onboarded(self, auth_session) -> str:

--- a/src/connectors/gemini_oauth_base.py
+++ b/src/connectors/gemini_oauth_base.py
@@ -2740,6 +2740,17 @@ class GeminiOAuthBaseConnector(GeminiBackend, GeminiCodeAssistMixin, abc.ABC):
         if "top_k" in cfg:
             cfg["topK"] = cfg.pop("top_k")
 
+        if getattr(request_data, "repetition_penalty", None) is not None and logger.isEnabledFor(
+            logging.WARNING
+        ):
+            logger.warning(
+                "GeminiOAuthBase does not support the 'repetition_penalty' parameter."
+            )
+        if getattr(request_data, "min_p", None) is not None and logger.isEnabledFor(
+            logging.WARNING
+        ):
+            logger.warning("GeminiOAuthBase does not support the 'min_p' parameter.")
+
         return cfg
 
     def _convert_from_code_assist_format(

--- a/src/connectors/openai.py
+++ b/src/connectors/openai.py
@@ -54,6 +54,7 @@ class OpenAIConnector(LLMBackend):
     """
 
     backend_type: str = "openai"
+    SUPPORTED_CUSTOM_PARAMETERS: frozenset[str] = frozenset()
 
     def __init__(
         self,
@@ -527,7 +528,29 @@ class OpenAIConnector(LLMBackend):
         if isinstance(extra, dict):
             payload.update(extra)
 
+        self._filter_unsupported_parameters(payload)
+
         return payload  # type: ignore[no-any-return]
+
+    def _filter_unsupported_parameters(self, payload: dict[str, Any]) -> None:
+        unsupported_parameters = []
+        for param_name in ("repetition_penalty", "min_p"):
+            if param_name in payload and param_name not in self.SUPPORTED_CUSTOM_PARAMETERS:
+                unsupported_parameters.append(param_name)
+
+        if not unsupported_parameters:
+            return
+
+        backend_name = self.backend_type or self.__class__.__name__
+        for param_name in unsupported_parameters:
+            value = payload.pop(param_name, None)
+            if value is not None and logger.isEnabledFor(logging.WARNING):
+                logger.warning(
+                    "%s backend does not support the '%s' parameter; ignoring value %r",
+                    backend_name,
+                    param_name,
+                    value,
+                )
 
     async def _handle_non_streaming_response(
         self,

--- a/src/connectors/openrouter.py
+++ b/src/connectors/openrouter.py
@@ -28,6 +28,9 @@ class OpenRouterBackend(OpenAIConnector):
     """LLMBackend implementation for OpenRouter.ai."""
 
     backend_type: str = "openrouter"
+    SUPPORTED_CUSTOM_PARAMETERS: frozenset[str] = frozenset(
+        {"repetition_penalty", "min_p"}
+    )
 
     def __init__(
         self,

--- a/src/core/domain/chat.py
+++ b/src/core/domain/chat.py
@@ -150,6 +150,8 @@ class ChatRequest(ValueObject):
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
+    repetition_penalty: float | None = None
+    min_p: float | None = None
     n: int | None = None
     stream: bool | None = None
     stop: list[str] | str | None = None

--- a/src/core/domain/gemini_translation.py
+++ b/src/core/domain/gemini_translation.py
@@ -222,6 +222,8 @@ def gemini_request_to_canonical_request(
     temperature = generation_config.get("temperature")
     top_p = generation_config.get("topP")
     top_k = generation_config.get("topK")
+    repetition_penalty = generation_config.get("repetitionPenalty")
+    min_p = generation_config.get("minP")
     max_tokens = generation_config.get("maxOutputTokens")
     stop = generation_config.get("stopSequences")
 
@@ -298,6 +300,8 @@ def gemini_request_to_canonical_request(
         tools=tools,  # type: ignore
         tool_choice=tool_choice,
         reasoning_effort=reasoning_effort,
+        repetition_penalty=repetition_penalty,
+        min_p=min_p,
     )
 
 

--- a/src/core/domain/translation.py
+++ b/src/core/domain/translation.py
@@ -752,6 +752,10 @@ class Translation(BaseTranslator):
             temperature=Translation._get_request_param(request, "temperature"),
             top_p=Translation._get_request_param(request, "top_p"),
             top_k=Translation._get_request_param(request, "top_k"),
+            repetition_penalty=Translation._get_request_param(
+                request, "repetition_penalty"
+            ),
+            min_p=Translation._get_request_param(request, "min_p"),
             n=Translation._get_request_param(request, "n"),
             stream=Translation._get_request_param(request, "stream"),
             stop=normalized_stop,
@@ -993,6 +997,8 @@ class Translation(BaseTranslator):
             seed = request.get("seed")
             reasoning_effort = request.get("reasoning_effort")
             reasoning_payload = request.get("reasoning")
+            repetition_penalty = request.get("repetition_penalty")
+            min_p = request.get("min_p")
         else:
             model = getattr(request, "model", None)
             messages = getattr(request, "messages", [])
@@ -1007,6 +1013,8 @@ class Translation(BaseTranslator):
             seed = getattr(request, "seed", None)
             reasoning_effort = getattr(request, "reasoning_effort", None)
             reasoning_payload = getattr(request, "reasoning", None)
+            repetition_penalty = getattr(request, "repetition_penalty", None)
+            min_p = getattr(request, "min_p", None)
 
         if reasoning_effort in ("", None) and isinstance(reasoning_payload, dict):
             raw_effort = reasoning_payload.get("effort")
@@ -1037,6 +1045,8 @@ class Translation(BaseTranslator):
             top_k=top_k,
             top_p=top_p,
             temperature=temperature,
+            repetition_penalty=repetition_penalty,
+            min_p=min_p,
             max_tokens=max_tokens,
             stop=stop,
             stream=stream,
@@ -1880,6 +1890,8 @@ class Translation(BaseTranslator):
             stop = request.get("stop")
             seed = request.get("seed")
             reasoning_effort = request.get("reasoning_effort")
+            repetition_penalty = request.get("repetition_penalty")
+            min_p = request.get("min_p")
             extra_params = request.get("extra_params")
         else:
             model = getattr(request, "model", None)
@@ -1891,6 +1903,8 @@ class Translation(BaseTranslator):
             stop = getattr(request, "stop", None)
             seed = getattr(request, "seed", None)
             reasoning_effort = getattr(request, "reasoning_effort", None)
+            repetition_penalty = getattr(request, "repetition_penalty", None)
+            min_p = getattr(request, "min_p", None)
             extra_params = getattr(request, "extra_params", None)
 
         if not model:
@@ -1914,6 +1928,8 @@ class Translation(BaseTranslator):
             stop=stop,
             seed=seed,
             reasoning_effort=reasoning_effort,
+            repetition_penalty=repetition_penalty,
+            min_p=min_p,
             stream=(
                 request.get("stream")
                 if isinstance(request, dict)
@@ -2357,6 +2373,10 @@ class Translation(BaseTranslator):
             payload["presence_penalty"] = request.presence_penalty
         if request.frequency_penalty is not None:
             payload["frequency_penalty"] = request.frequency_penalty
+        if request.repetition_penalty is not None:
+            payload["repetition_penalty"] = request.repetition_penalty
+        if request.min_p is not None:
+            payload["min_p"] = request.min_p
         if request.user is not None:
             payload["user"] = request.user
         if request.tools is not None:

--- a/src/core/services/parameter_resolution_service.py
+++ b/src/core/services/parameter_resolution_service.py
@@ -33,6 +33,8 @@ class ResolvedParameters:
     reasoning_effort: ParameterSource | None = None
     top_p: ParameterSource | None = None
     top_k: ParameterSource | None = None
+    repetition_penalty: ParameterSource | None = None
+    min_p: ParameterSource | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -63,6 +65,12 @@ class ResolvedParameters:
 
         if self.reasoning_effort is not None:
             result["reasoning_effort"] = self.reasoning_effort.value
+
+        if self.repetition_penalty is not None:
+            result["repetition_penalty"] = self.repetition_penalty.value
+
+        if self.min_p is not None:
+            result["min_p"] = self.min_p.value
 
         return result
 
@@ -112,6 +120,18 @@ class ResolvedParameters:
                 "source": self.reasoning_effort.source,
             }
 
+        if self.repetition_penalty is not None:
+            result["repetition_penalty"] = {
+                "effective_value": self.repetition_penalty.value,
+                "source": self.repetition_penalty.source,
+            }
+
+        if self.min_p is not None:
+            result["min_p"] = {
+                "effective_value": self.min_p.value,
+                "source": self.min_p.source,
+            }
+
         return result
 
 
@@ -135,6 +155,8 @@ class ParameterResolutionService:
         "top_p",
         "top_k",
         "reasoning_effort",
+        "repetition_penalty",
+        "min_p",
     ]
 
     def resolve_parameters(

--- a/tests/unit/connectors/test_precision_payload_mapping.py
+++ b/tests/unit/connectors/test_precision_payload_mapping.py
@@ -46,6 +46,41 @@ async def test_openai_payload_contains_temperature_and_top_p(
 
 
 @pytest.mark.asyncio
+async def test_openai_warns_for_unsupported_penalties(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg = AppConfig()
+    client = httpx.AsyncClient()
+    connector = OpenAIConnector(client, cfg, translation_service=TranslationService())
+    connector.api_key = "test-api-key"
+    req = ChatRequest(
+        model="gpt-4",
+        messages=_messages(),
+        repetition_penalty=1.1,
+        min_p=0.05,
+    )
+
+    captured_payload: dict[str, Any] = {}
+
+    async def fake_post(url: str, json: dict, headers: dict) -> httpx.Response:
+        captured_payload.update(json)
+        return httpx.Response(
+            200, json={"id": "1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    monkeypatch.setattr(client, "post", fake_post)
+    caplog.set_level("WARNING")
+
+    await connector.chat_completions(req, req.messages, req.model)
+
+    assert "does not support the 'repetition_penalty'" in caplog.text
+    assert "does not support the 'min_p'" in caplog.text
+    assert "repetition_penalty" not in captured_payload
+    assert "min_p" not in captured_payload
+
+
+@pytest.mark.asyncio
 async def test_openai_payload_uses_processed_messages_with_list_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -89,7 +124,12 @@ async def test_openrouter_payload_contains_temperature_and_top_p(
     connector = OpenRouterBackend(client, cfg, translation_service=TranslationService())
     connector.api_key = "test-api-key"  # Add API key to avoid authentication error
     req = ChatRequest(
-        model="openrouter:gpt-4", messages=_messages(), temperature=0.2, top_p=0.5
+        model="openrouter:gpt-4",
+        messages=_messages(),
+        temperature=0.2,
+        top_p=0.5,
+        repetition_penalty=1.01,
+        min_p=0.15,
     )
 
     captured_payload = {}
@@ -106,11 +146,14 @@ async def test_openrouter_payload_contains_temperature_and_top_p(
 
     assert captured_payload.get("temperature") == 0.2
     assert captured_payload.get("top_p") == 0.5
+    assert captured_payload.get("repetition_penalty") == 1.01
+    assert captured_payload.get("min_p") == 0.15
 
 
 @pytest.mark.asyncio
 async def test_anthropic_payload_contains_temperature_and_top_p(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     cfg = AppConfig()
     client = httpx.AsyncClient()
@@ -143,12 +186,22 @@ async def test_anthropic_payload_contains_temperature_and_top_p(
     monkeypatch.setattr(client, "post", fake_post)
 
     req = ChatRequest(
-        model="claude-3", messages=_messages(), temperature=0.25, top_p=0.6
+        model="claude-3",
+        messages=_messages(),
+        temperature=0.25,
+        top_p=0.6,
+        repetition_penalty=1.05,
+        min_p=0.2,
     )
+    caplog.set_level("WARNING")
     await backend.chat_completions(req, req.messages, req.model, api_key="test-key")
     payload = captured.get("payload", {})
     assert payload.get("temperature") == 0.25
     assert payload.get("top_p") == 0.6
+    assert "repetition_penalty" not in payload
+    assert "min_p" not in payload
+    assert "repetition_penalty" in caplog.text
+    assert "min_p" in caplog.text
 
 
 def test_gemini_public_generation_config_clamping_and_topk() -> None:
@@ -167,7 +220,32 @@ def test_gemini_public_generation_config_clamping_and_topk() -> None:
     assert gc.get("topK") == 50
 
 
-def test_gemini_oauth_personal_builds_topk() -> None:
+def test_gemini_generation_config_warns_for_penalties(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg = AppConfig()
+    backend = GeminiBackend(
+        httpx.AsyncClient(), cfg, translation_service=TranslationService()
+    )
+    payload: dict[str, Any] = {}
+    req = ChatRequest(
+        model="gemini-pro",
+        messages=_messages(),
+        repetition_penalty=1.05,
+        min_p=0.22,
+    )
+    caplog.set_level("WARNING")
+    backend._apply_generation_config(payload, req)
+    gc = payload.get("generationConfig", {})
+    assert "repetitionPenalty" not in gc
+    assert "minP" not in gc
+    assert "repetition_penalty" in caplog.text
+    assert "min_p" in caplog.text
+
+
+def test_gemini_oauth_personal_builds_topk(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     cfg = AppConfig()
     backend = GeminiOAuthPlanConnector(
         httpx.AsyncClient(), cfg, translation_service=TranslationService()
@@ -178,14 +256,21 @@ def test_gemini_oauth_personal_builds_topk() -> None:
         top_p = 0.55
         top_k = 33
         max_tokens = 777
+        repetition_penalty = 1.02
+        min_p = 0.18
 
+    caplog.set_level("WARNING")
     gc = backend._build_generation_config(_Req())
     assert gc["temperature"] == pytest.approx(0.22)
     assert gc["topP"] == pytest.approx(0.55)
     assert gc["topK"] == 33
+    assert "repetition_penalty" in caplog.text
+    assert "min_p" in caplog.text
 
 
-def test_gemini_cloud_project_builds_topk() -> None:
+def test_gemini_cloud_project_builds_topk(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     cfg = AppConfig()
     # Minimal init (project id may be None for this isolated helper test)
     backend = GeminiCloudProjectConnector(
@@ -200,8 +285,13 @@ def test_gemini_cloud_project_builds_topk() -> None:
         top_p = 0.77
         top_k = 21
         max_tokens = 512
+        repetition_penalty = 1.04
+        min_p = 0.12
 
+    caplog.set_level("WARNING")
     gc = backend._build_generation_config(_Req())
     assert gc["temperature"] == pytest.approx(0.3)
     assert gc["topP"] == pytest.approx(0.77)
     assert gc["topK"] == 21
+    assert "repetition_penalty" in caplog.text
+    assert "min_p" in caplog.text

--- a/tests/unit/core/services/test_parameter_resolution_service.py
+++ b/tests/unit/core/services/test_parameter_resolution_service.py
@@ -41,6 +41,8 @@ class TestResolvedParameters:
         assert params.reasoning_effort is None
         assert params.top_p is None
         assert params.top_k is None
+        assert params.repetition_penalty is None
+        assert params.min_p is None
 
     def test_resolved_parameters_creation_with_values(self):
         """Test creating ResolvedParameters with values."""
@@ -49,17 +51,24 @@ class TestResolvedParameters:
         top_p_source = ParameterSource(value=0.9, source="config")
         top_k_source = ParameterSource(value=42, source="header")
 
+        repetition_source = ParameterSource(value=1.1, source="uri")
+        min_p_source = ParameterSource(value=0.05, source="session")
+
         params = ResolvedParameters(
             temperature=temp_source,
             reasoning_effort=effort_source,
             top_p=top_p_source,
             top_k=top_k_source,
+            repetition_penalty=repetition_source,
+            min_p=min_p_source,
         )
 
         assert params.temperature == temp_source
         assert params.reasoning_effort == effort_source
         assert params.top_p == top_p_source
         assert params.top_k == top_k_source
+        assert params.repetition_penalty == repetition_source
+        assert params.min_p == min_p_source
 
     def test_to_dict_empty(self):
         """Test to_dict with no parameters."""
@@ -101,6 +110,16 @@ class TestResolvedParameters:
         result = params.to_dict()
 
         assert result == {"top_p": 0.92, "top_k": 32}
+
+    def test_to_dict_with_penalty_parameters(self):
+        """Test to_dict with repetition_penalty and min_p."""
+        params = ResolvedParameters(
+            repetition_penalty=ParameterSource(1.2, "uri"),
+            min_p=ParameterSource(0.07, "session"),
+        )
+        result = params.to_dict()
+
+        assert result == {"repetition_penalty": 1.2, "min_p": 0.07}
 
     def test_get_debug_info_empty(self):
         """Test get_debug_info with no parameters."""
@@ -155,6 +174,21 @@ class TestResolvedParameters:
         assert "top_k" in debug_info
         assert debug_info["top_k"]["effective_value"] == 16
         assert debug_info["top_k"]["source"] == "session"
+
+    def test_get_debug_info_with_penalty_parameters(self):
+        """Test get_debug_info includes penalty parameters."""
+        params = ResolvedParameters(
+            repetition_penalty=ParameterSource(1.25, "config"),
+            min_p=ParameterSource(0.09, "header"),
+        )
+        debug_info = params.get_debug_info()
+
+        assert "repetition_penalty" in debug_info
+        assert debug_info["repetition_penalty"]["effective_value"] == 1.25
+        assert debug_info["repetition_penalty"]["source"] == "config"
+        assert "min_p" in debug_info
+        assert debug_info["min_p"]["effective_value"] == 0.09
+        assert debug_info["min_p"]["source"] == "header"
 
 
 class TestParameterResolutionService:
@@ -255,6 +289,28 @@ class TestParameterResolutionService:
         assert result.reasoning_effort is not None
         assert result.reasoning_effort.value == "low"
         assert result.reasoning_effort.source == "session"
+
+    def test_precedence_repetition_penalty_uri(self, service):
+        """Test repetition_penalty resolution from URI."""
+        result = service.resolve_parameters(
+            config_params={"repetition_penalty": 1.05},
+            uri_params={"repetition_penalty": 1.2},
+        )
+
+        assert result.repetition_penalty is not None
+        assert result.repetition_penalty.value == 1.2
+        assert result.repetition_penalty.source == "uri"
+
+    def test_precedence_min_p_session(self, service):
+        """Test min_p resolution with session override."""
+        result = service.resolve_parameters(
+            config_params={"min_p": 0.1},
+            session_params={"min_p": 0.2},
+        )
+
+        assert result.min_p is not None
+        assert result.min_p.value == 0.2
+        assert result.min_p.source == "session"
 
     def test_precedence_mixed_parameters_different_sources(self, service):
         """Test precedence with different parameters from different sources."""
@@ -633,7 +689,9 @@ class TestParameterResolutionService:
         assert "reasoning_effort" in service.SUPPORTED_PARAMETERS
         assert "top_p" in service.SUPPORTED_PARAMETERS
         assert "top_k" in service.SUPPORTED_PARAMETERS
-        assert len(service.SUPPORTED_PARAMETERS) == 4
+        assert "repetition_penalty" in service.SUPPORTED_PARAMETERS
+        assert "min_p" in service.SUPPORTED_PARAMETERS
+        assert len(service.SUPPORTED_PARAMETERS) == 6
 
     # ========================================================================
     # Integration-like Tests


### PR DESCRIPTION
## Summary
- extend the chat domain model and translation pipeline to carry `repetition_penalty` and `min_p`
- allow OpenRouter to forward the new sampling parameters and warn on unsupported backends
- update parameter resolution plus connector tests to cover the additional knobs and warning paths

## Testing
- python -m pytest tests/unit/connectors/test_precision_payload_mapping.py tests/unit/core/services/test_parameter_resolution_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d32a693908333938030d130de2cf6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new generation parameters (`repetition_penalty` and `min_p`) to fine-tune response generation across supported LLM backends.
  * Integrated warning notifications when unsupported parameters are specified, improving configuration transparency.

* **Chores**
  * Enhanced internal parameter resolution infrastructure to track new generation parameters.
  * Expanded test coverage for parameter handling across backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->